### PR TITLE
fix(presences): #MA-848 remove hidden absence reasons from selects

### DIFF
--- a/presences/src/main/resources/public/template/behaviours/sniplet-collective-absence-form/sniplet-collective-absence-form.html
+++ b/presences/src/main/resources/public/template/behaviours/sniplet-collective-absence-form/sniplet-collective-absence-form.html
@@ -119,8 +119,7 @@
                         <label>
                             <select data-ng-model="vm.form.reasonId"
                                     data-ng-change="vm.selectReason()"
-                                    ng-options="reason.id as reason.label for reason in vm.reasons"
-                                    options-disabled="reason.hidden for reason in vm.reasons">
+                                    ng-options="reason.id as reason.label disable when reason.hidden for reason in vm.reasons">
                                 <option value="">[[lang.translate('presences.absence.select.empty')]]</option>
                             </select>
                         </label>

--- a/presences/src/main/resources/public/template/behaviours/sniplet-event-form/sniplet-events-absence-form.html
+++ b/presences/src/main/resources/public/template/behaviours/sniplet-event-form/sniplet-events-absence-form.html
@@ -69,8 +69,7 @@
             <label>
                 <select data-ng-model="vm.form.reason_id"
                         data-ng-change="vm.selectReason()"
-                        ng-options="reason.id as reason.label for reason in vm.reasons"
-                        options-disabled="reason.hidden for reason in vm.reasons">
+                        ng-options="reason.id as reason.label disable when reason.hidden for reason in vm.reasons">
                     <option value="">[[lang.translate('presences.absence.select.empty')]]</option>
                 </select>
             </label>

--- a/presences/src/main/resources/public/template/events/table.html
+++ b/presences/src/main/resources/public/template/events/table.html
@@ -73,8 +73,7 @@
                 <select data-ng-model="event.reason.id"
                         data-ng-click="vm.reasonSelect($event)"
                         data-ng-change="vm.changeAllReason(event, event.student.id)"
-                        ng-options="reason.id as reason.label for reason in vm.filterSelect(vm.eventReasonsType, event)"
-                        options-disabled="reason.hidden for reason in vm.eventReasonsType">
+                        ng-options="reason.id as reason.label disable when reason.hidden for reason in vm.filterSelect(vm.eventReasonsType, event)">
                     <option value="">[[lang.translate('presences.absence.select.empty')]]</option>
                 </select>
             </label>
@@ -141,8 +140,7 @@
                  <label ng-if="history.type_id == 1">
                     <select data-ng-model="history.reason_id"
                             data-ng-change="vm.changeReason(history, event, event.student.id)"
-                            ng-options="reason.id as reason.label for reason in vm.eventReasonsTypeDescription"
-                            options-disabled="reason.hidden for reason in vm.eventReasonsType">
+                            ng-options="reason.id as reason.label disable when reason.hidden for reason in vm.eventReasonsTypeDescription">
                         <option value="">[[lang.translate('presences.absence.select.empty')]]</option>
                     </select>
                 </label>

--- a/presences/src/main/resources/public/template/register/panel.html
+++ b/presences/src/main/resources/public/template/register/panel.html
@@ -35,8 +35,7 @@
             <div class="select-reason-absences right-magnet margin-bottom-md">
                 <label>
                     <select ng-model="vm.filter.student.absence.reason_id"
-                            ng-options="reason.id as reason.label for reason in vm.reasons"
-                            options-disabled="reason.hidden for reason in vm.reasons"
+                            ng-options="reason.id as reason.label disable when reason.hidden for reason in vm.reasons"
                             ng-change="vm.manageAbsence(vm.filter.student.absence, vm.filter.student)">
                         <option value="">
                             [[lang.translate('presences.absence.select.empty')]]

--- a/presences/src/main/resources/public/template/widgets/absences.html
+++ b/presences/src/main/resources/public/template/widgets/absences.html
@@ -55,8 +55,7 @@
                 <div>
                     <select data-ng-model="absence.reason_id"
                             data-ng-change="vm.updateReasonAbsenceEvent(absence); vm.setAbsenceRegularisation(absence)"
-                            ng-options="reason.id as reason.label for reason in vm.reasons"
-                            options-disabled="reason.hidden for reason in vm.reasons">
+                            ng-options="reason.id as reason.label disable when reason.hidden for reason in vm.reasons">
                         <option value="" label="[[lang.translate('presences.absence.select.empty')]]">
                             [[lang.translate('presences.absence.select.empty')]]
                         </option>


### PR DESCRIPTION
- `options-disabled` n'est plus fonctionnel : remplacement par un `disable when` dans les ng-options pour les selects des motifs d'absences, afin de pouvoir cacher les motifs marqués `hidden`

https://entsupport.gdapublic.fr/browse/MA-848