### PR TITLE
feat(presences): #MA-839 lateness form : remove end slot + change time on slot change

### DIFF
--- a/presences/src/main/resources/public/template/behaviours/sniplet-event-form/sniplet-events-lateness-form.html
+++ b/presences/src/main/resources/public/template/behaviours/sniplet-event-form/sniplet-events-lateness-form.html
@@ -3,56 +3,38 @@
     <!-- Info -->
     <div class="eventFormLightBox-body-info row spacing">
 
-        <!-- date -->
-        <div class="twelve eventFormLightBox-body-timeslot-margin-bottom">
-            <i18n class="margin-right-sm">presences.from</i18n>
+        <div class="twelve flex-row">
+            <!-- date -->
+            <div class="eventFormLightBox-body-timeslot-margin-bottom">
+                <i18n class="margin-right-sm">presences.the</i18n>
 
-            <span class="card date-picker margin-right-sm">
+                <span class="card date-picker margin-right-sm">
                 <date-picker required ng-model="vm.form.startDate"
                              data-ng-change="vm.selectTimeSlot(vm.timeSlotHourPeriod.START_HOUR)"
                              ng-disabled="vm.form.id"></date-picker>
             </span>
 
-            <label class="eventFormLightBox-body-timeslot">
-                <label class="timeslot-select">
-                    <i class="time-picker"></i>
-                    <select data-ng-model="vm.timeSlotTimePeriod.start"
-                            data-ng-change="vm.selectTimeSlot(vm.timeSlotHourPeriod.START_HOUR)"
-                            ng-disabled="vm.form.id"
-                            ng-options="item.name + ' : ' + item.startHour for item in vm.structureTimeSlot.slots
+                <i18n class="margin-right-sm">presences.at</i18n>
+                <label class="eventFormLightBox-body-timeslot">
+                    <label class="timeslot-select">
+                        <i class="time-picker"></i>
+                        <select data-ng-model="vm.timeSlotTimePeriod.start"
+                                data-ng-change="vm.selectTimeSlot(vm.timeSlotHourPeriod.START_HOUR)"
+                                ng-disabled="vm.form.id"
+                                ng-options="item.name + ' : ' + item.startHour for item in vm.structureTimeSlot.slots
                                     | orderBy:vm.timeSlotHourPeriod.START_HOUR">
-                        <option value="">[[lang.translate('presences.pick.timeslot')]]</option>
-                    </select>
+                            <option value="">[[lang.translate('presences.pick.timeslot')]]</option>
+                        </select>
+                    </label>
                 </label>
-            </label>
-
-            <i18n class="margin-right-sm">presences.to</i18n>
-            <span class="card date-picker margin-right-sm">
-                <date-picker required ng-model="vm.form.endDate"
-                             data-ng-change="vm.selectTimeSlot(vm.timeSlotHourPeriod.END_HOUR)"
-                             ng-disabled="vm.form.id"></date-picker>
-            </span>
-
-            <label class="eventFormLightBox-body-timeslot">
-                <label class="timeslot-select">
-                    <i class="time-picker"></i>
-                    <select data-ng-model="vm.timeSlotTimePeriod.end"
-                            data-ng-change="vm.selectTimeSlot(vm.timeSlotHourPeriod.END_HOUR)"
-                            ng-disabled="vm.form.id"
-                            ng-options="item.name + ' : ' + item.endHour for item in vm.structureTimeSlot.slots
-                                | orderBy:vm.timeSlotHourPeriod.END_HOUR">
-                        <option value="">[[lang.translate('presences.pick.timeslot')]]</option>
-                    </select>
-                </label>
-            </label>
-        </div>
-
-        <!-- time picker -->
-        <div class="presenceLightbox-body-info-choice margin-top-md">
-            <i18n>presences.registry.csv.lateness.time</i18n>&#58;
-            <span class="card eventFormLightBox-body-timepicker margin-left-md">
-                <time-picker required ng-model="vm.form.endDateTime"></time-picker>
-            </span>
+            </div>
+            <!-- time picker -->
+            <div class="presenceLightbox-body-info-choice">
+                <i18n>presences.registry.csv.lateness.time</i18n>&#58;
+                <span class="card eventFormLightBox-body-timepicker margin-left-md">
+                    <time-picker required ng-model="vm.form.endDateTime"></time-picker>
+                </span>
+            </div>
         </div>
 
         <!--description-->

--- a/presences/src/main/resources/public/ts/sniplets/events-form.ts
+++ b/presences/src/main/resources/public/ts/sniplets/events-form.ts
@@ -1,4 +1,4 @@
-import {IStructureSlot, ITimeSlot, SNIPLET_FORM_EMIT_EVENTS, SNIPLET_FORM_EVENTS} from '@common/model';
+import {EVENT_TYPES, IStructureSlot, ITimeSlot, SNIPLET_FORM_EMIT_EVENTS, SNIPLET_FORM_EVENTS} from '@common/model';
 import {
     Absence,
     AbsenceEventResponse,
@@ -698,9 +698,16 @@ const vm: ViewModel = {
     },
 
     selectTimeSlot: (hourPeriod: TimeSlotHourPeriod): void => {
+        switch (vm.selectedEventType) {
+            case EVENT_TYPES.LATENESS:
+                vm.form.endDateTime =  moment(DateUtils.getDateFormat(vm.form.startDate,
+                    DateUtils.getTimeFormatDate(vm.timeSlotTimePeriod.start.startHour))).toDate();
+                break;
+        }
+
         PeriodFormUtils.setHourSelectorsFromTimeSlotsOrFree(hourPeriod, vm.display.isFreeSchedule, vm.form,
             "startDateTime", "endDateTime", "startDate", "endDate",
-            vm.timeSlotTimePeriod, vm.form, "startSlot", "endSlot")
+            vm.timeSlotTimePeriod, vm.form, "startSlot", "endSlot");
     },
 
     hourInput: (hourPeriod: TimeSlotHourPeriod): void => {


### PR DESCRIPTION
- Suppression de l'horaire de fin de créneau dans le formulaire de création/modification de retards (la valeur `vm.timeSlotTimePeriod.start` n'étant pas utilisée)

- Mise à jour de l'heure de retard si le créneau est changé, permettant d'éviter de déclarer un retard avant l'heure du début de créneau

https://entsupport.gdapublic.fr/browse/MA-839