### PR TITLE
fix(multiple-slots): #MA-850 apply admin and user multipleSlot setting properly for registers/courses

### DIFF
--- a/common/src/main/java/fr/openent/presences/core/constants/Field.java
+++ b/common/src/main/java/fr/openent/presences/core/constants/Field.java
@@ -40,6 +40,11 @@ public class Field {
     public static final String MULTIPLE_SLOT = "multiple_slot";
     public static final String ALLOW_MULTIPLE_SLOTS = "allow_multiple_slots";
 
+    // Register
+    public static final String COURSE_ID = "course_id";
+    public static final String STATE_ID = "state_id";
+    public static final String NOTIFIED = "notified";
+
 
     public static final String FORGOTTEN_REGISTERS = "forgotten_registers";
 

--- a/presences/src/main/java/fr/openent/presences/controller/CourseController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/CourseController.java
@@ -6,7 +6,7 @@ import fr.openent.presences.constants.Actions;
 import fr.openent.presences.core.constants.*;
 import fr.openent.presences.export.RegisterCSVExport;
 import fr.openent.presences.helper.CourseHelper;
-import fr.openent.presences.model.Course;
+import fr.openent.presences.model.*;
 import fr.openent.presences.service.*;
 import fr.openent.presences.service.impl.*;
 import fr.wseduc.rs.ApiDoc;
@@ -72,13 +72,13 @@ public class CourseController extends ControllerHelper {
                         renderError(request);
                 })
                 .onSuccess(res -> {
-                    boolean multipleSlot;
+                    MultipleSlotSettings multipleSlot = new MultipleSlotSettings();
 
                     if (params.contains(Field.MULTIPLE_SLOT)) {
-                        multipleSlot = Boolean.parseBoolean(request.getParam(Field.MULTIPLE_SLOT));
-                    } else {
-                        multipleSlot = res.getBoolean(Field.ALLOW_MULTIPLE_SLOTS, true);
+                        multipleSlot.setUserValue(Boolean.parseBoolean(request.getParam(Field.MULTIPLE_SLOT)));
                     }
+                    multipleSlot.setStructureValue(res.getBoolean(Field.ALLOW_MULTIPLE_SLOTS, true));
+
 
                     courseService.listCourses(params.get(Field.STRUCTURE), params.getAll(Field.TEACHER),
                             params.getAll(Field.GROUP), params.get(Field.START), params.get(Field.END),
@@ -117,13 +117,15 @@ public class CourseController extends ControllerHelper {
                     renderError(request);
                 })
                 .onSuccess(res -> {
-                    boolean multipleSlot;
+
+                    MultipleSlotSettings multipleSlot = new MultipleSlotSettings();
 
                     if (params.contains(Field.MULTIPLE_SLOT)) {
-                        multipleSlot =  Boolean.parseBoolean(request.getParam(Field.MULTIPLE_SLOT));
-                    } else {
-                        multipleSlot = res.getBoolean(Field.ALLOW_MULTIPLE_SLOTS, true);
+                        multipleSlot.setUserValue(Boolean.parseBoolean(request.getParam(Field.MULTIPLE_SLOT)));
                     }
+
+                    multipleSlot.setStructureValue(res.getBoolean(Field.ALLOW_MULTIPLE_SLOTS, true));
+
 
                     courseService.listCourses(params.get(Field.STRUCTURE), params.getAll(Field.TEACHER),
                             params.getAll(Field.GROUP), params.get(Field.START), params.get(Field.END), null,

--- a/presences/src/main/java/fr/openent/presences/model/MultipleSlotSettings.java
+++ b/presences/src/main/java/fr/openent/presences/model/MultipleSlotSettings.java
@@ -1,0 +1,39 @@
+package fr.openent.presences.model;
+
+public class MultipleSlotSettings {
+
+    private Boolean userValue;
+    private Boolean structureValue;
+
+
+    public MultipleSlotSettings() {
+        this.structureValue = true;
+    }
+
+    public MultipleSlotSettings(boolean value) {
+        this.structureValue = value;
+        this.userValue = value;
+    }
+
+
+    public void setUserValue(boolean value) {
+        this.userValue = value;
+    }
+
+    public void setStructureValue(boolean value) {
+        this.structureValue = value;
+    }
+
+    public boolean getUserValue() {
+        return this.userValue;
+    }
+
+    public boolean getStructureValue() {
+        return this.structureValue;
+    }
+
+    public boolean getDefaultValue() {
+        return (this.userValue != null) ? this.userValue : this.structureValue;
+    }
+
+}

--- a/presences/src/main/java/fr/openent/presences/service/CourseService.java
+++ b/presences/src/main/java/fr/openent/presences/service/CourseService.java
@@ -1,5 +1,6 @@
 package fr.openent.presences.service;
 
+import fr.openent.presences.model.*;
 import fr.wseduc.webutils.Either;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
@@ -30,15 +31,16 @@ public interface CourseService {
      * @param handler         Function handler returning data
      */
     void listCourses(String structureId, List<String> teachersList, List<String> groupsList,
-                     String start, String end, String startTime, String endTime, boolean forgottenFilter, boolean multipleSlot,
+                     String start, String end, String startTime, String endTime, boolean forgottenFilter,
+                     MultipleSlotSettings multipleSlot, Handler<Either<String, JsonArray>> handler);
+
+    void listCourses(String structureId, List<String> teachersList, List<String> groupsList,
+                     String start, String end, String startTime, String endTime, boolean forgottenFilter,
+                     MultipleSlotSettings multipleSlot, String limit, String offset, String descendingDate,
                      Handler<Either<String, JsonArray>> handler);
 
     void listCourses(String structureId, List<String> teachersList, List<String> groupsList,
-                     String start, String end, String startTime, String endTime, boolean forgottenFilter, boolean multipleSlot,
-                     String limit, String offset, String descendingDate, Handler<Either<String, JsonArray>> handler);
-
-    void listCourses(String structureId, List<String> teachersList, List<String> groupsList,
-                     String start, String end, String startTime, String endTime, boolean forgottenFilter, boolean multipleSlot,
-                     String limit, String offset, String descendingDate, String isWithTeacherFilter,
-                     Handler<Either<String, JsonArray>> handler);
+                     String start, String end, String startTime, String endTime, boolean forgottenFilter,
+                     MultipleSlotSettings multipleSlot, String limit, String offset, String descendingDate,
+                     String isWithTeacherFilter, Handler<Either<String, JsonArray>> handler);
 }

--- a/presences/src/main/java/fr/openent/presences/service/RegisterService.java
+++ b/presences/src/main/java/fr/openent/presences/service/RegisterService.java
@@ -73,8 +73,9 @@ public interface RegisterService {
      * @param groupNames        Group names
      * @param startDate         Start date
      * @param endDate           End date
+     * @param multipleSlot      Multiple slot admin setting value
      * @param handler           Function handler returning data
      */
     void getLastForgottenRegistersCourses(String structureId, List<String> teacherIds, List<String> groupNames,
-                                          String startDate, String endDate, Handler<AsyncResult<JsonArray>> handler);
+                                          String startDate, String endDate, boolean multipleSlot, Handler<AsyncResult<JsonArray>> handler);
 }

--- a/presences/src/main/java/fr/openent/presences/service/impl/DefaultCourseService.java
+++ b/presences/src/main/java/fr/openent/presences/service/impl/DefaultCourseService.java
@@ -7,15 +7,12 @@ import fr.openent.presences.helper.CourseHelper;
 import fr.openent.presences.helper.MapHelper;
 import fr.openent.presences.helper.SlotHelper;
 import fr.openent.presences.helper.SquashHelper;
-import fr.openent.presences.model.Course;
-import fr.openent.presences.model.Slot;
+import fr.openent.presences.model.*;
 import fr.openent.presences.service.CourseService;
 import fr.openent.presences.service.RegisterService;
 import fr.wseduc.mongodb.MongoDb;
 import fr.wseduc.webutils.Either;
-import io.vertx.core.CompositeFuture;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
+import io.vertx.core.*;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -84,7 +81,7 @@ public class DefaultCourseService implements CourseService {
     @Override
     public void listCourses(String structureId, List<String> teachersList, List<String> groupsList,
                             String start, String end, String startTime, String endTime,
-                            boolean forgottenFilter, boolean multipleSlot,
+                            boolean forgottenFilter, MultipleSlotSettings multipleSlot,
                             Handler<Either<String, JsonArray>> handler) {
         this.listCourses(structureId, teachersList, groupsList, start, end, startTime, endTime,
                 forgottenFilter, multipleSlot, null, null, null, handler);
@@ -93,7 +90,7 @@ public class DefaultCourseService implements CourseService {
     @Override
     public void listCourses(String structureId, List<String> teachersList, List<String> groupsList,
                             String start, String end, String startTime, String endTime,
-                            boolean forgottenFilter, boolean multipleSlot,
+                            boolean forgottenFilter, MultipleSlotSettings multipleSlot,
                             String limit, String offset, String descendingDate, Handler<Either<String, JsonArray>> handler) {
         this.listCourses(structureId, teachersList, groupsList, start, end, startTime, endTime,
                 forgottenFilter, multipleSlot, null, null, null, null, handler);
@@ -102,7 +99,7 @@ public class DefaultCourseService implements CourseService {
     @Override
     public void listCourses(String structureId, List<String> teachersList, List<String> groupsList,
                             String start, String end, String startTime, String endTime,
-                            boolean forgottenFilter, boolean multipleSlot,
+                            boolean forgottenFilter, MultipleSlotSettings multipleSlot,
                             String limit, String offset, String descendingDate, String searchTeacher, Handler<Either<String, JsonArray>> handler) {
         courseHelper.getCourses(structureId, teachersList, groupsList, start, end, startTime, endTime, limit, offset, descendingDate,
                 searchTeacher, event -> {
@@ -118,33 +115,34 @@ public class DefaultCourseService implements CourseService {
                             .stream()
                             .map(course -> course.getString("_id")).collect(Collectors.toList());
 
-                    Future<JsonArray> teachersFuture = Future.future();
-                    Future<JsonArray> slotsFuture = Future.future();
-                    Future<JsonArray> registerEventFuture = Future.future();
+                    Promise<JsonArray> teachersFuture = Promise.promise();
+                    Promise<JsonArray> slotsFuture = Promise.promise();
+                    Promise<JsonArray> registerEventFuture = Promise.promise();
 
-                    CompositeFuture.all(teachersFuture, slotsFuture, registerEventFuture).setHandler(asyncHandler -> {
-                        if (asyncHandler.failed()) {
-                            handler.handle(new Either.Left<>(asyncHandler.cause().toString()));
-                            return;
-                        }
+                    CompositeFuture.all(teachersFuture.future(), slotsFuture.future(), registerEventFuture.future())
+                            .onFailure(fail ->  handler.handle(new Either.Left<>(fail.getCause().getMessage())))
+                            .onSuccess(ar -> {
+                                JsonArray teachers = teachersFuture.future().result();
+                                JsonObject teacherMap = MapHelper.transformToMap(teachers, "id");
 
-                        JsonArray teachers = teachersFuture.result();
-                        JsonObject teacherMap = MapHelper.transformToMap(teachers, "id");
+                                CourseHelper.formatCourse(courses, teacherMap);
 
-                        CourseHelper.formatCourse(courses, teacherMap);
+                                List<Slot> slots = SlotHelper.getSlotListFromJsonArray(slotsFuture.future().result(),
+                                        Slot.MANDATORY_ATTRIBUTE);
+                                List<Course> coursesEvent = CourseHelper.getCourseListFromJsonArray(courses,
+                                        Course.MANDATORY_ATTRIBUTE);
+                                List<Course> splitCoursesEvent = CourseHelper.splitCoursesFromSlot(coursesEvent, slots);
 
-                        List<Slot> slots = SlotHelper.getSlotListFromJsonArray(slotsFuture.result(), Slot.MANDATORY_ATTRIBUTE);
-                        List<Course> coursesEvent = CourseHelper.getCourseListFromJsonArray(courses, Course.MANDATORY_ATTRIBUTE);
-                        List<Course> splitCoursesEvent = CourseHelper.splitCoursesFromSlot(coursesEvent, slots);
+                                List<Course> squashCourses = SquashHelper.squash(coursesEvent, splitCoursesEvent,
+                                        registerEventFuture.future().result(), multipleSlot);
 
-                        SquashHelper squashHelper = new SquashHelper();
-                        List<Course> squashCourses = squashHelper.squash(coursesEvent, splitCoursesEvent, registerEventFuture.result(), multipleSlot);
-
-                        handler.handle(new Either.Right<>(forgottenFilter ?
-                                new JsonArray(filterForgottenCourses(CourseHelper.formatCourses(squashCourses, multipleSlot, slots, BooleanUtils.toBooleanObject(searchTeacher)))) :
-                                new JsonArray(CourseHelper.formatCourses(squashCourses, multipleSlot, slots, BooleanUtils.toBooleanObject(searchTeacher)))
-                        ));
-                    });
+                                handler.handle(new Either.Right<>(forgottenFilter ?
+                                        new JsonArray(filterForgottenCourses(CourseHelper.formatCourses(squashCourses,
+                                                multipleSlot, slots, BooleanUtils.toBooleanObject(searchTeacher)))) :
+                                        new JsonArray(CourseHelper.formatCourses(squashCourses, multipleSlot,
+                                                slots, BooleanUtils.toBooleanObject(searchTeacher)))
+                                ));
+                            });
                     courseHelper.getCourseTeachers(teachersIds, FutureHelper.handlerJsonArray(teachersFuture));
                     Viescolaire.getInstance().getSlotsFromProfile(structureId, FutureHelper.handlerJsonArray(slotsFuture));
                     registerService.list(structureId, coursesIds, FutureHelper.handlerJsonArray(registerEventFuture));

--- a/presences/src/main/java/fr/openent/presences/worker/CreateDailyPresenceWorker.java
+++ b/presences/src/main/java/fr/openent/presences/worker/CreateDailyPresenceWorker.java
@@ -5,7 +5,7 @@ import fr.openent.presences.common.helper.DateHelper;
 import fr.openent.presences.common.helper.FutureHelper;
 import fr.openent.presences.core.constants.*;
 import fr.openent.presences.helper.MapHelper;
-import fr.openent.presences.model.Course;
+import fr.openent.presences.model.*;
 import fr.openent.presences.service.*;
 import fr.openent.presences.service.impl.*;
 import fr.wseduc.webutils.*;
@@ -196,7 +196,8 @@ public class CreateDailyPresenceWorker extends BusModBase implements Handler<Mes
         settingsService.retrieveMultipleSlots(structureId)
                 .onFailure(fail -> handler.handle(new Either.Left<>(fail.getMessage())))
                 .onSuccess(res -> {
-                    boolean multipleSlot = res.getBoolean(Field.ALLOW_MULTIPLE_SLOTS, true);
+                    MultipleSlotSettings multipleSlot = new MultipleSlotSettings();
+                    multipleSlot.setUserValue(res.getBoolean(Field.ALLOW_MULTIPLE_SLOTS, true));
                     courseService.listCourses(structureId, new ArrayList<>(), new ArrayList<>(), date, date,
                             startTime, endTime, true, multipleSlot, handler);
                 });


### PR DESCRIPTION
Modification des API GET `/courses` (1) et GET `/structures/:id/registers/forgotten` (2) afin de prendre correctement en compte le paramétrage des appels multiples. 

(1) : route utilisée avec un paramètre `multipleSlot `pour récupérer la liste des cours avec les paramètres des appels qui sont liés :

- Si le CPE a activé les appels multiples, alors un enseignant aura le choix de séparer les appels multiples ou pas _uniquement si l'appel n'a pas été ouvert, sinon il est multiple par défaut_.
- Si le CPE a désactivé l'option, l'utilisateur n'a pas le choix et les appels ne sont jamais séparés.

(2): route utilisée côté CPE pour récupérer les derniers appels oubliés
- Les appels suivront le réglage CPE




https://entsupport.gdapublic.fr/browse/MA-850