### PR TITLE
fix(forgotten-registers): #MA-854 filter forgotten courses from multipleSlot setting

### DIFF
--- a/presences/src/main/java/fr/openent/presences/service/impl/DefaultRegisterService.java
+++ b/presences/src/main/java/fr/openent/presences/service/impl/DefaultRegisterService.java
@@ -901,7 +901,8 @@ public class DefaultRegisterService extends DBService implements RegisterService
                             List<Course> squashCourses = SquashHelper.squash(coursesEvent, splitCoursesEvent,
                                     registers, new MultipleSlotSettings(multipleSlot));
 
-                            promise.complete(filterLastForgottenRegisterCourses(squashCourses, teacherIds, groupNames));
+                            promise.complete(filterLastForgottenRegisterCourses(squashCourses, teacherIds, groupNames,
+                                    multipleSlot));
                         });
 
                 formatCourseTeachersAndSubjects(courses, FutureHelper.handlerJsonArray(teachersFuture));
@@ -931,11 +932,14 @@ public class DefaultRegisterService extends DBService implements RegisterService
         });
     }
 
-    private JsonArray filterLastForgottenRegisterCourses(List<Course> courses, List<String> teacherIds, List<String> groupNames) {
+    private JsonArray filterLastForgottenRegisterCourses(List<Course> courses, List<String> teacherIds,
+                                                         List<String> groupNames, boolean multipleSlot) {
         final int numberRegisters = 16;
         courses = courses.stream().filter(course -> (teacherIds.isEmpty() || courseHasTeacherOfId(course.toJSON(), teacherIds))
                         && (groupNames.isEmpty() || courseHasClassOrGroupName(course.toJSON(), groupNames))
-                        && !course.getTeachers().isEmpty() && course.getRegisterId() != null)
+                        && !course.getTeachers().isEmpty()
+                        && course.getRegisterId() != null
+                        && course.isSplitSlot() == multipleSlot)
                 .sorted((o1, o2) -> o2.getStartDate().compareToIgnoreCase(o1.getStartDate()))
                 .limit(numberRegisters)
                 .sorted((o1, o2) -> o1.getStartDate().compareToIgnoreCase(o2.getStartDate()))


### PR DESCRIPTION
- Ajout d'une verif du champ `splitSlot` sur les appels oubliés, car il est possible qu'un cours apparaisse deux fois et donc sera dupliqué (l'un marqué à `true `l'autre à `false`)


https://entsupport.gdapublic.fr/browse/MA-854