### PR TITLE
fix(absence-widget): #MA-853 filter absences without a student name

### DIFF
--- a/common/src/main/java/fr/openent/presences/core/constants/Field.java
+++ b/common/src/main/java/fr/openent/presences/core/constants/Field.java
@@ -6,6 +6,8 @@ public class Field {
     public static final String NAME = "name";
     public static final String STRUCTURE = "structure";
     public static final String TEACHER = "teacher";
+    public static final String STUDENT_ID = "student_id";
+    public static final String STUDENT = "student";
     public static final String SEARCH_TEACHER = "searchTeacher";
     public static final String GROUP = "group";
     public static final String LIMIT = "limit";

--- a/presences/src/main/resources/public/ts/models/CounsellorAbsence.ts
+++ b/presences/src/main/resources/public/ts/models/CounsellorAbsence.ts
@@ -13,7 +13,8 @@ export class CounsellorAbsence {
     student: {
         id: string,
         displayName: string,
-        className: string
+        className: string,
+        name?: string
     };
 
     async updateReason() {

--- a/presences/src/main/resources/public/ts/services/AbsenceService.ts
+++ b/presences/src/main/resources/public/ts/services/AbsenceService.ts
@@ -29,8 +29,11 @@ export const absenceService: AbsenceService = {
         return Mix.castArrayAs(Absence, await retrieve(structure, students, [], start, end, justified, regularized, reasons));
     },
 
-    async getCounsellorAbsence(structure: string, students: string[], groups: string[], start: string, end: string, justified: boolean, regularized: boolean, reasons: number[]): Promise<CounsellorAbsence[]> {
-        return Mix.castArrayAs(CounsellorAbsence, await retrieve(structure, students, groups, start, end, justified, regularized, reasons));
+    async getCounsellorAbsence(structure: string, students: string[], groups: string[],
+                               start: string, end: string, justified: boolean, regularized: boolean,
+                               reasons: number[]): Promise<CounsellorAbsence[]> {
+        return Mix.castArrayAs(CounsellorAbsence, await retrieve(structure, students, groups, start, end,
+            justified, regularized, reasons)).filter((absence: CounsellorAbsence) => absence.student.name != null);
     },
 
     async updateFollowed(ids: number[], followed: boolean): Promise<AxiosResponse> {


### PR DESCRIPTION
- API GET /absences : (front/back) filtrage des absences qui n'ont pas de `student.name`

https://entsupport.gdapublic.fr/browse/MA-853