### PR TITLE
fix(alert): #MA-852 suppress event synchronously to check necessity t…

### DIFF
--- a/presences/src/main/java/fr/openent/presences/service/impl/DefaultAbsenceService.java
+++ b/presences/src/main/java/fr/openent/presences/service/impl/DefaultAbsenceService.java
@@ -840,15 +840,13 @@ public class DefaultAbsenceService extends DBService implements AbsenceService {
     }
 
     private void deleteEventsOnDelete(JsonObject absenceResult, Handler<Either<String, JsonObject>> handler) {
-        String query = "DELETE FROM " + Presences.dbSchema + ".event" +
-                " WHERE student_id = ? AND start_date >= ? AND end_date <= ? AND counsellor_input = true AND type_id = "
-                + EventType.ABSENCE.getType();
+        String query = "SELECT " + Presences.dbSchema + ".function_delete_events_synchronously(?,?,?)";
 
         JsonArray params = new JsonArray()
                 .add(absenceResult.getString("student_id"))
                 .add(absenceResult.getString("start_date"))
                 .add(absenceResult.getString("end_date"));
-        Sql.getInstance().prepared(query, params, SqlResult.validUniqueResultHandler(handler));
+        sql.prepared(query, params, SqlResult.validUniqueResultHandler(handler));
     }
 
     private void resetEventsOnDelete(JsonObject absenceResult, Handler<Either<String, JsonObject>> handler) {

--- a/presences/src/main/java/fr/openent/presences/service/impl/DefaultCollectiveAbsenceService.java
+++ b/presences/src/main/java/fr/openent/presences/service/impl/DefaultCollectiveAbsenceService.java
@@ -868,14 +868,12 @@ public class DefaultCollectiveAbsenceService extends DBService implements Collec
     }
 
     private JsonObject getDeleteEventsOnDeleteStatement(Absence absence) {
-        String query = "DELETE FROM " + Presences.dbSchema + ".event" +
-                " WHERE student_id = ? AND start_date < ? AND end_date > ? AND counsellor_input = true AND type_id = "
-                + EventType.ABSENCE.getType();
+        String query = "SELECT " + Presences.dbSchema + ".function_delete_events_synchronously(?,?,?)";
 
         JsonArray params = new JsonArray()
                 .add(absence.getStudentId())
-                .add(absence.getEndDate())
-                .add(absence.getStartDate());
+                .add(absence.getStartDate())
+                .add(absence.getEndDate());
 
         return new JsonObject()
                 .put("action", "prepared")

--- a/presences/src/main/resources/sql/041-MA-852-delete-events-synchronously-function.sql
+++ b/presences/src/main/resources/sql/041-MA-852-delete-events-synchronously-function.sql
@@ -1,0 +1,22 @@
+CREATE OR REPLACE FUNCTION presences.function_delete_events_synchronously(studentId varchar,
+                                                                          startdate timestamp without time zone,
+                                                                          enddate timestamp without time zone) RETURNS VOID AS
+$BODY$
+DECLARE
+    e presences.event%rowtype;
+BEGIN
+    FOR e IN SELECT *
+             FROM presences.event
+             WHERE student_id = studentId
+               AND start_date < endDate
+               AND end_date > startDate
+               AND counsellor_input = true
+               AND type_id = 1
+        LOOP
+            DELETE FROM presences.event WHERE id = e.id;
+        END LOOP;
+
+    RETURN;
+END
+$BODY$
+    LANGUAGE plpgsql;


### PR DESCRIPTION
[Jira - MA-852](https://entsupport.gdapublic.fr/secure/RapidBoard.jspa?rapidView=25&projectKey=MA&view=planning&selectedIssue=MA-852&issueLimit=100)

Le problème mesuré était que la suppressions pluriel des évènements déclenchait pour chacun d'eux un trigger en parallèle. Dans le cas par exemple où les absences sont comptés par demis journée, chaque trigger vérifiait que leur évènement en question était le dernier de sa demis journée. Comme ils arrivent tous à ce même constat, ils décrémentent individuellement le nombre d'alerts correspondant, au lieu de tenir compte du faite que cette action a déjà été faite 1 fois (-1 pour une demis journée en moins).

La solution choisit à donc été d'exécuté une méthode PostgreSQL plutôt que de supprimer directement toutes les rows des évènements souhaités, afin de faire cette suppression un par un, dans une loop et non plus en parallèle, permettant ainsi que chaque triggers déclenchés tiennent compte de l'action du dernier.    