### PR TITLE
fix(punishments): #MA-859 reappearance of punishments in parents dash…

### DIFF
--- a/incidents/src/main/java/fr/openent/incidents/service/impl/DefaultEventStudentService.java
+++ b/incidents/src/main/java/fr/openent/incidents/service/impl/DefaultEventStudentService.java
@@ -41,6 +41,7 @@ public class DefaultEventStudentService implements EventStudentService {
         String start = body.get("start_at");
         String end = body.get("end_at");
         List<String> types = body.getAll("type");
+        body.set("id", (String) null);
 
         if (!validTypes(types)) {
             String message = "[Presences@DefaultEventStudentService::get] Types are not valid.";


### PR DESCRIPTION
Dans le dashboard parents, on ne récupérais plus les punitions / sanction.
Après recherche, il a été remarqué qu'un champ "id" est présent dans l'URI de récupération des punitions / sanctions:
![image](https://user-images.githubusercontent.com/55873580/136001996-530020ad-b6e4-4105-b339-06de516ab111.png)
Cette Id ici représente l'identifiant de l'étudiant. Nous faisons par la suite appel à un Service pour faire la récupération des punishments. La méthode en question prend en paramètre le bodyParams contenant les paramètres de recherches. Or ici, dans ce bodyParams, l'Id est traiter comme un filtre sur l'identifiant du punishment (et non l'identifiant du student).

Pour résoudre ce problème, l'hypothèse du changement de nom de paramètre a été mis de coté, car il impacte un ResourceProvider faisant appliquer un droit, qui lui même est présent sur plusieurs endpoints (ce qui impacterais de devoir tous les tester).
La résolution adopté a donc été de supprimer l'identifiant du bodyParams avant de faire appel au service de de récupération des punishments.