### PR TITLE
fix(memento): #MA-866 custom punishments date by type.

### DIFF
--- a/incidents/src/main/resources/public/template/behaviours/sniplet-memento/incidents.html
+++ b/incidents/src/main/resources/public/template/behaviours/sniplet-memento/incidents.html
@@ -64,7 +64,7 @@
                         <div class="flex-row row__15">
                             <!-- date -->
                             <div class="flex-col col__3 min-height-45">
-                                <span>[[vm.formatIncident(mementoIncident.item.date)]]</span>
+                                <span>[[vm.formatDate(mementoIncident)]]</span>
                             </div>
                             <!-- category -->
                             <div class="flex-col col__3 min-height-45">

--- a/incidents/src/main/resources/public/ts/controllers/punishments.ts
+++ b/incidents/src/main/resources/public/ts/controllers/punishments.ts
@@ -261,37 +261,7 @@ export const punishmentController = ng.controller('PunishmentController',
 
             };
 
-            vm.getPunishmentDate = (punishment: IPunishment): string => {
-                let createdDate: string = DateUtils.format(punishment.created_at, DateUtils.FORMAT['DAY-MONTH-YEAR']);
-
-                if (punishment.type) {
-                    switch (punishment.type.punishment_category_id) {
-                        case 1: // DUTY
-                            let dutyDate: string = createdDate;
-                            if ((<IPDutyField> punishment.fields).delay_at) {
-                                dutyDate = DateUtils.format((<IPDutyField> punishment.fields).delay_at, DateUtils.FORMAT['DAY-MONTH-YEAR']);
-                            }
-                            return lang.translate('incidents.punishments.date.for.the') + dutyDate;
-                        case 2: // DETENTION
-                            let startDetentionDate: string = createdDate;
-                            if ((<IPDetentionField> punishment.fields).start_at) {
-                                startDetentionDate = DateUtils.format((<IPDetentionField> punishment.fields).start_at, DateUtils.FORMAT['DAY-MONTH-YEAR']);
-                            }
-                            return lang.translate('incidents.punishments.date.for.the') + startDetentionDate;
-                        case 3: // BLAME
-                            return lang.translate('incidents.punishments.date.created.on') + createdDate;
-                        case 4: // EXCLUSION
-                            if ((<IPDetentionField> punishment.fields).start_at && (<IPDetentionField> punishment.fields).end_at) {
-                                let startExcludeDate: string = DateUtils.format((<IPExcludeField> punishment.fields).start_at, DateUtils.FORMAT['DAY-MONTH-YEAR']);
-                                let endExcludeDate: string = DateUtils.format((<IPExcludeField> punishment.fields).end_at, DateUtils.FORMAT['DAY-MONTH-YEAR']);
-                                if (startExcludeDate && endExcludeDate) {
-                                    return lang.translate('incidents.punishments.date.from') + startExcludeDate + lang.translate('incidents.punishments.date.to') + endExcludeDate;
-                                }
-                            }
-                    }
-                }
-                return lang.translate('incidents.punishments.date.created.on') + createdDate;
-            };
+            vm.getPunishmentDate = (punishment: IPunishment): string => PunishmentsUtils.getPunishmentDate(punishment);
 
             vm.getPunishmentTime = (punishment: IPunishment): string => {
                 if (punishment.type && punishment.type.punishment_category_id === 2) { // DETENTION

--- a/incidents/src/main/resources/public/ts/sniplets/memento/incidents.ts
+++ b/incidents/src/main/resources/public/ts/sniplets/memento/incidents.ts
@@ -7,6 +7,7 @@ import {incidentService, punishmentService, punishmentsTypeService} from "@incid
 import {IPunishmentType} from "@incidents/models/PunishmentType";
 import {EVENT_TYPES} from "@common/model";
 import {User} from "@common/model/User";
+import {PunishmentsUtils} from "@incidents/utilities/punishments";
 
 console.log("memento incidents/punishment");
 
@@ -35,7 +36,7 @@ interface IViewModel {
 
     loadStudentYearIncidents(): Promise<void>;
 
-    formatIncident(date: string): void;
+    formatDate(mementoItem: IMementoIncident): string;
 
     setIPunishmentRequest(): void;
 
@@ -135,9 +136,9 @@ const vm: IViewModel = {
         })
     },
 
-    formatIncident(date: string): string {
-        return moment(date).format(DateUtils.FORMAT["DAY-MONTH-YEAR"]);
-    },
+    formatDate: (mementoItem: IMementoIncident): string => mementoItem.type === EVENT_TYPES.INCIDENT ?
+        moment((<Incident>mementoItem.item).date).format(DateUtils.FORMAT["DAY-MONTH-YEAR"]) :
+        PunishmentsUtils.getPunishmentDate(<IPunishment>mementoItem.item),
 
     redirectTo(mementoIncident: IMementoIncident): void {
         if (mementoIncident.type === EVENT_TYPES.INCIDENT) {

--- a/incidents/src/main/resources/public/ts/utilities/punishments.ts
+++ b/incidents/src/main/resources/public/ts/utilities/punishments.ts
@@ -1,5 +1,5 @@
 import {
-    IPDetentionField, IPDutyField, IPExcludeField,
+    IPDetentionField, IPDutyField, IPExcludeField, IPunishment,
     IPunishmentBody,
     MassmailingsPunishments,
     PunishmentsProcessStates,
@@ -8,6 +8,7 @@ import {
 import {model} from "entcore";
 import incidentsRights from "@incidents/rights";
 import {DateUtils} from "@common/utils";
+import {idiom as lang} from 'entcore';
 
 export class PunishmentsUtils {
 
@@ -119,4 +120,36 @@ export class PunishmentsUtils {
             return false;
         }
     }
+
+    static getPunishmentDate = (punishment: IPunishment): string => {
+        let createdDate: string = DateUtils.format(punishment.created_at, DateUtils.FORMAT['DAY-MONTH-YEAR']);
+
+        if (punishment.type) {
+            switch (punishment.type.punishment_category_id) {
+                case 1: // DUTY
+                    let dutyDate: string = createdDate;
+                    if ((<IPDutyField> punishment.fields).delay_at) {
+                        dutyDate = DateUtils.format((<IPDutyField> punishment.fields).delay_at, DateUtils.FORMAT['DAY-MONTH-YEAR']);
+                    }
+                    return lang.translate('incidents.punishments.date.for.the') + dutyDate;
+                case 2: // DETENTION
+                    let startDetentionDate: string = createdDate;
+                    if ((<IPDetentionField> punishment.fields).start_at) {
+                        startDetentionDate = DateUtils.format((<IPDetentionField> punishment.fields).start_at, DateUtils.FORMAT['DAY-MONTH-YEAR']);
+                    }
+                    return lang.translate('incidents.punishments.date.for.the') + startDetentionDate;
+                case 3: // BLAME
+                    return lang.translate('incidents.punishments.date.created.on') + createdDate;
+                case 4: // EXCLUSION
+                    if ((<IPDetentionField> punishment.fields).start_at && (<IPDetentionField> punishment.fields).end_at) {
+                        let startExcludeDate: string = DateUtils.format((<IPExcludeField> punishment.fields).start_at, DateUtils.FORMAT['DAY-MONTH-YEAR']);
+                        let endExcludeDate: string = DateUtils.format((<IPExcludeField> punishment.fields).end_at, DateUtils.FORMAT['DAY-MONTH-YEAR']);
+                        if (startExcludeDate && endExcludeDate) {
+                            return lang.translate('incidents.punishments.date.from') + startExcludeDate + lang.translate('incidents.punishments.date.to') + endExcludeDate;
+                        }
+                    }
+            }
+        }
+        return lang.translate('incidents.punishments.date.created.on') + createdDate;
+    };
 }


### PR DESCRIPTION
[Jira - MA-866](https://entsupport.gdapublic.fr/secure/RapidBoard.jspa?rapidView=25&projectKey=MA&view=detail&selectedIssue=MA-866)

Sur memento, la date affichée pour les punishments était systématiquement la date de création.

Il a donc été choisi de réutiliser la fonction le permettant sur la liste des punishments.

