### PR TITLE
fix(registers-cron): #MA-862 add a personnel id on registers created by CRON

### DIFF
--- a/presences/src/main/java/fr/openent/presences/worker/CreateDailyPresenceWorker.java
+++ b/presences/src/main/java/fr/openent/presences/worker/CreateDailyPresenceWorker.java
@@ -150,7 +150,9 @@ public class CreateDailyPresenceWorker extends BusModBase implements Handler<Mes
                     log.error(message);
                 }
             } else {
-                personnelId = personnelFuture.future().result();
+                if (!personnelFuture.future().result().isEmpty()){
+                    personnelId = personnelFuture.future().result();
+                }
             }
 
             JsonObject result = new JsonObject()
@@ -180,8 +182,7 @@ public class CreateDailyPresenceWorker extends BusModBase implements Handler<Mes
 
                 Promise<JsonObject> promise = Promise.promise();
                 futures.add(promise.future());
-                String userId = teachers.isEmpty() ? personnelId : teachers.getJsonObject(0).getString(Field.ID);
-                createRegisterFuture(result, course, register, promise.future(), userId);
+                createRegisterFuture(result, course, register, promise.future(), personnelId);
             }
             CompositeFuture.join(futures)
                     .onSuccess(resultFutures -> handler.handle(Future.succeededFuture(result)))

--- a/presences/src/main/resources/i18n/en.json
+++ b/presences/src/main/resources/i18n/en.json
@@ -394,7 +394,7 @@
   "presences.widgets.day.forgotten.registers": "Derniers appels oubliés du jour",
   "presences.widgets.day.forgotten.registers.empty": "Pas d'appel oublié aujourd'hui",
   "presences.widgets.day.set.multiple.slot": "Appels multiples pour mes cours dépassant 1h",
-  "presences.widgets.day.set.multiple.slot.toolip.activate": "Activez cette option pour générer plusieurs appels pour les cours dépassant 1h. Valable à partir du prochain cours.",
+  "presences.widgets.day.set.multiple.slot.toolip.activate": "Activez cette option pour générer plusieurs appels pour les cours dépassant 1h. Valable à partir du prochain cours si l'appel n'a pas déjà été ouvert.",
   "presences.widgets.day.set.multiple.slot.toolip.disable": "Désactivez cette option pour générer un appel unique pour les cours dépassant 1h. Valable à partir du prochain cours.",
   "presences.widgets.day_presences": "Présences du jour",
   "presences.widgets.day.presences.empty": "Pas de présences déclarées aujourd'hui",

--- a/presences/src/main/resources/i18n/fr.json
+++ b/presences/src/main/resources/i18n/fr.json
@@ -458,7 +458,7 @@
   "presences.widgets.day.forgotten.registers": "Derniers appels oubliés du jour",
   "presences.widgets.day.forgotten.registers.empty": "Pas d'appel oublié aujourd'hui",
   "presences.widgets.day.set.multiple.slot": "Appels multiples pour mes cours dépassant 1h",
-  "presences.widgets.day.set.multiple.slot.toolip.activate": "Activez cette option pour générer plusieurs appels pour les cours dépassant 1h. Valable à partir du prochain cours.",
+  "presences.widgets.day.set.multiple.slot.toolip.activate": "Activez cette option pour générer plusieurs appels pour les cours dépassant 1h. Valable à partir du prochain cours si l'appel n'a pas déjà été ouvert.",
   "presences.widgets.day.set.multiple.slot.toolip.disable": "Désactivez cette option pour générer un appel unique pour les cours dépassant 1h. Valable à partir du prochain cours.",
   "presences.widgets.day_presences": "Présences du jour",
   "presences.widgets.day.presences.empty": "Pas de présences déclarées aujourd'hui",


### PR DESCRIPTION
- Lors de la création d'un appel par le CRON, mettre un profil CPE en tant que `owner`
- Ajout d'information au survol de l'icône `?` pour les appels multiples côté enseignant