### PR TITLE
feat(forgotten-notebook): #MA-856 add button to reset forgotten notebooks

### DIFF
--- a/common/src/main/java/fr/openent/presences/core/constants/Field.java
+++ b/common/src/main/java/fr/openent/presences/core/constants/Field.java
@@ -94,6 +94,9 @@ public class Field {
     public static final String TIMESTAMP = "timestamp";
     public static final String UPDATED = "updated";
 
+    // Alert
+    public static final String TYPE = "type";
+
     // Presence
     public static final String COMMENT = "comment";
     public static final String MARKEDSTUDENTS = "markedStudents";

--- a/presences/src/main/java/fr/openent/presences/Presences.java
+++ b/presences/src/main/java/fr/openent/presences/Presences.java
@@ -52,7 +52,6 @@ public class Presences extends BaseServer {
     public static final String ABSENCE_STATEMENTS_CREATE = "presences.absence.statements.create";
     public static final String MANAGE_FORGOTTEN_NOTEBOOK = "presences.manage.forgotten.notebook";
     public static final String MANAGE_COLLECTIVE_ABSENCES = "presences.manage.collective.absences";
-
     public static final String ALERTS_STUDENT_NUMBER = "presences.alerts.students.number";
 
     public static final String READ_OWN_INFO = "presences.read.own.info";

--- a/presences/src/main/java/fr/openent/presences/controller/AlertController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/AlertController.java
@@ -5,15 +5,14 @@ import fr.openent.presences.common.service.GroupService;
 import fr.openent.presences.common.service.impl.DefaultGroupService;
 import fr.openent.presences.constants.Actions;
 import fr.openent.presences.constants.Alerts;
+import fr.openent.presences.core.constants.*;
 import fr.openent.presences.export.AlertsCSVExport;
 import fr.openent.presences.security.Alert.AlertStudentNumber;
 import fr.openent.presences.security.AlertFilter;
 import fr.openent.presences.security.DeleteAlertFilter;
 import fr.openent.presences.service.AlertService;
 import fr.openent.presences.service.impl.DefaultAlertService;
-import fr.wseduc.rs.ApiDoc;
-import fr.wseduc.rs.Delete;
-import fr.wseduc.rs.Get;
+import fr.wseduc.rs.*;
 import fr.wseduc.security.ActionType;
 import fr.wseduc.security.SecuredAction;
 import fr.wseduc.webutils.Either;
@@ -118,19 +117,34 @@ public class AlertController extends ControllerHelper {
     @ResourceFilter(AlertStudentNumber.class)
     @ApiDoc("Get student alert number by given type with the corresponding threshold")
     public void getStudentAlertNumberWithThreshold(HttpServerRequest request) {
-        String type = request.params().get("type");
+        String type = request.params().get(Field.TYPE);
         if (type == null || !Alerts.ALERT_LIST.contains(type)) {
             badRequest(request);
             return;
         }
 
-        alertService.getStudentAlertNumberWithThreshold(
-                request.getParam("id"),
-                request.getParam("studentId"),
-                type,
-                defaultResponseHandler(request)
+        alertService.getStudentAlertNumberWithThreshold(request.getParam(Field.ID), request.getParam(Field.STUDENTID),
+                type, defaultResponseHandler(request)
         );
     }
+
+    @Delete("/structures/:id/students/:studentId/alerts/reset")
+    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(AlertFilter.class)
+    @Trace(Actions.ALERT_DELETION)
+    @ApiDoc("Reset student alert count")
+    public void resetStudentAlertsCount(HttpServerRequest request) {
+        String type = request.params().get(Field.TYPE);
+        if (type == null || !Alerts.ALERT_LIST.contains(type)) {
+            badRequest(request);
+            return;
+        }
+
+        alertService.resetStudentAlertsCount(request.getParam(Field.ID), request.getParam(Field.STUDENTID), type)
+                .onSuccess(res -> renderJson(request, res))
+                .onFailure(unused -> renderError(request));
+    }
+
 
     @Get("/structures/:id/alerts/export")
     @ApiDoc("Export alerts")

--- a/presences/src/main/java/fr/openent/presences/service/AlertService.java
+++ b/presences/src/main/java/fr/openent/presences/service/AlertService.java
@@ -1,7 +1,7 @@
 package fr.openent.presences.service;
 
 import fr.wseduc.webutils.Either;
-import io.vertx.core.Handler;
+import io.vertx.core.*;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -43,4 +43,13 @@ public interface AlertService {
      * @param handler     function handler returning data
      */
     void getStudentAlertNumberWithThreshold(String structureId, String studentId, String type, Handler<Either<String, JsonObject>> handler);
+
+    /**
+     * Delete alerts of given type for a student
+     * @param structureId   structure identifier
+     * @param studentId     student identifier
+     * @param type          alert type
+     * @return  {@link Future} of {@link JsonObject}
+     */
+    Future<JsonObject> resetStudentAlertsCount(String structureId, String studentId, String type);
 }

--- a/presences/src/main/resources/i18n/en.json
+++ b/presences/src/main/resources/i18n/en.json
@@ -166,6 +166,8 @@
   "presences.filters": "Filtres",
   "presences.forgotten.form.create.succeed": "Carnet oublié créé avec succès",
   "presences.forgotten.form.delete.succeed": "Carnet oublié supprimé avec succès",
+  "presences.forgotten.form.delete.error": "Erreur lors de la réinitialisation",
+  "presences.forgotten.form.reset.succeed": "Réinitalisation effectuée avec succès",
   "presences.forgotten.form.edit.succeed": "Carnet oublié modifié avec succès",
   "presences.forgotten.notebook": "Carnet oublié",
   "presences.forgotten.notebook.2": "Oublis de carnet",

--- a/presences/src/main/resources/i18n/fr.json
+++ b/presences/src/main/resources/i18n/fr.json
@@ -224,6 +224,8 @@
   "presences.filters": "Filtres",
   "presences.forgotten.form.create.succeed": "Carnet oublié créé avec succès",
   "presences.forgotten.form.delete.succeed": "Carnet oublié supprimé avec succès",
+  "presences.forgotten.form.delete.error": "Erreur lors de la réinitialisation",
+  "presences.forgotten.form.reset.succeed": "Réinitalisation effectuée avec succès",
   "presences.forgotten.form.edit.succeed": "Carnet oublié modifié avec succès",
   "presences.forgotten.notebook": "Carnet oublié",
   "presences.forgotten.notebook.2": "Oublis de carnet",

--- a/presences/src/main/resources/public/template/behaviours/sniplet-forgotten-notebook-form.html
+++ b/presences/src/main/resources/public/template/behaviours/sniplet-forgotten-notebook-form.html
@@ -46,7 +46,7 @@
     <!-- footer/buttons -->
     <div class="forgotten-notebook-form-footer row">
         <!-- reset mode  -->
-        <button disabled class="forbidden">
+        <button data-ng-disabled="vm.count_forgotten_notebook === 0" data-ng-click="vm.resetForbiddenNotebookCount(vm.form.studentId)">
             <i18n>presences.reset</i18n>
         </button>
 

--- a/presences/src/main/resources/public/ts/services/AlertService.ts
+++ b/presences/src/main/resources/public/ts/services/AlertService.ts
@@ -1,5 +1,5 @@
 import {ng} from 'entcore';
-import http from 'axios';
+import http, {AxiosResponse} from 'axios';
 import {Alert} from "@presences/models/Alert";
 
 export interface AlertService {
@@ -10,6 +10,8 @@ export interface AlertService {
     getStudentAlerts(structureId: string, studentId: string, type: string): Promise<{ count: number, threshold: number }>;
 
     reset(alerts: Array<number>): Promise<void>;
+
+    resetStudentAlertsCount(structureId: string, studentId: string, type: string): Promise<AxiosResponse>;
 
     exportCSV(structureId: string, type: string[]): void;
 }
@@ -70,6 +72,10 @@ export const alertService: AlertService = {
         } catch (e) {
             throw e;
         }
+    },
+
+    resetStudentAlertsCount(structureId: string, studentId: string, type: string): Promise<AxiosResponse> {
+        return http.delete(`/presences/structures/${structureId}/students/${studentId}/alerts/reset?type=${type}`);
     },
 
     exportCSV(structureId: string, types: string[]): void {

--- a/presences/src/main/resources/public/ts/sniplets/forgotten-notebook-form.ts
+++ b/presences/src/main/resources/public/ts/sniplets/forgotten-notebook-form.ts
@@ -3,6 +3,7 @@ import {alertService, forgottenNotebookService, NotebookRequest} from "../servic
 import {idiom as lang, moment, toasts} from "entcore";
 import {DateUtils} from "@common/utils";
 import {AlertType} from "../models";
+import {AxiosResponse} from "axios";
 
 console.log("forgottenNotebookFormSniplets");
 
@@ -34,6 +35,8 @@ interface ViewModel {
     updateForbiddenNotebook(): Promise<void>;
 
     deleteForbiddenNotebook(): Promise<void>;
+
+    resetForbiddenNotebookCount(studentId: string): Promise<void>;
 
     getStudentForgottenNoteBookNumberWithThreshold(id?: string): void;
 
@@ -125,6 +128,24 @@ const vm: ViewModel = {
         forgottenNotebookForm.that.$emit(SNIPLET_FORM_EMIT_EVENTS.DELETE);
         vm.safeApply();
     },
+
+    resetForbiddenNotebookCount: async (studentId: string): Promise<void> => {
+        try {
+            let response: AxiosResponse = await alertService.resetStudentAlertsCount(window.structure.id, studentId,
+                AlertType[AlertType.FORGOTTEN_NOTEBOOK]);
+
+            if (response.status === 200 || response.status === 201) {
+                vm.getStudentForgottenNoteBookNumberWithThreshold(studentId);
+                toasts.confirm(lang.translate('presences.forgotten.form.reset.succeed'));
+            } else {
+                toasts.warning(lang.translate('presences.forgotten.form.delete.error'));
+            }
+            vm.safeApply();
+        } catch (e) {
+            throw e;
+        }
+    },
+
 
     getStudentForgottenNoteBookNumberWithThreshold: async (id?: string) => {
         // assigning id from parameter as student id, case we did not find it,

--- a/presences/src/test/java/fr/openent/presences/service/impl/AlertServiceTest.java
+++ b/presences/src/test/java/fr/openent/presences/service/impl/AlertServiceTest.java
@@ -1,0 +1,48 @@
+package fr.openent.presences.service.impl;
+
+import fr.openent.presences.core.constants.*;
+import fr.openent.presences.db.*;
+import fr.openent.presences.db.DB;
+import fr.openent.presences.service.*;
+import io.vertx.core.*;
+import io.vertx.core.json.*;
+import io.vertx.ext.unit.*;
+import io.vertx.ext.unit.junit.*;
+import org.entcore.common.sql.*;
+import org.junit.*;
+import org.junit.runner.*;
+import org.mockito.*;
+import org.mockito.stubbing.*;
+import org.powermock.reflect.*;
+
+@RunWith(VertxUnitRunner.class)
+public class AlertServiceTest extends DBService {
+
+    Sql sql = Mockito.mock(Sql.class);
+
+    private AlertService alertService;
+
+    @Before
+    public void setUp() {
+        DB.getInstance().init(null, sql, null);
+        this.alertService = new DefaultAlertService();
+    }
+
+    @Test
+    public void testResetStudentAlertsCount(TestContext ctx) throws Exception {
+        Mockito.doAnswer((Answer<Void>) invocation -> {
+            JsonArray params = invocation.getArgument(1);
+
+            ctx.assertEquals(params, new JsonArray()
+                    .add(Field.STUDENT_ID)
+                    .add(Field.STRUCTURE_ID)
+                    .add(Field.TYPE));
+
+            return null;
+        }).when(sql).prepared(Mockito.anyString(), Mockito.any(JsonArray.class), Mockito.any(Handler.class));
+        Whitebox.invokeMethod(alertService, "resetStudentAlertsCount",
+                Field.STRUCTURE_ID, Field.STUDENT_ID, Field.TYPE);
+
+
+    }
+}


### PR DESCRIPTION
- Le bouton "Réinitialiser" dans la popup Carnet oublié de la vue calendaire permet désormais de réinitialiser le comptage des carnet oubliés


https://entsupport.gdapublic.fr/browse/MA-856