### PR TITLE
feat(export): #MA-807 prepare export csv and pdf type to event list

### DIFF
--- a/common/src/main/java/fr/openent/presences/common/helper/EventsHelper.java
+++ b/common/src/main/java/fr/openent/presences/common/helper/EventsHelper.java
@@ -52,9 +52,10 @@ public class EventsHelper {
             JsonObject event = (JsonObject) o;
             String eventStartDate = event.getString("start_date");
             String eventHalfDay = DateHelper.setTimeToDate(eventStartDate, halfDay, DateHelper.HOUR_MINUTES_SECONDS, DateHelper.SQL_FORMAT);
-            // We group events by day and if start event date is before halfDay (yyyy-MM-dd_<true|false>)
+            // We group events by day and if start event date is before halfDay (studentId-yyyy-MM-dd_<true|false>)
             String groupKey =
-                    DateHelper.getDateString(eventStartDate, DateHelper.SQL_FORMAT, DateHelper.YEAR_MONTH_DAY)
+                    event.getJsonObject("student", new JsonObject()).getString("id", "") + "-" +
+                            DateHelper.getDateString(eventStartDate, DateHelper.SQL_FORMAT, DateHelper.YEAR_MONTH_DAY)
                             + "_" + DateHelper.isDateBefore(eventStartDate, eventHalfDay);
 
             if (dateGroupedEvents.containsKey(groupKey)) dateGroupedEvents.get(groupKey).add(event);

--- a/common/src/main/java/fr/openent/presences/common/helper/FutureHelper.java
+++ b/common/src/main/java/fr/openent/presences/common/helper/FutureHelper.java
@@ -33,7 +33,22 @@ public class FutureHelper {
             if (event.isRight()) {
                 promise.complete(event.right().getValue());
             } else {
-                LOGGER.error(event.left().getValue());
+                String message = String.format("[PresencesCommon@%s::handlerJsonArray]: %s",
+                        FutureHelper.class.getSimpleName(), event.left().getValue());
+                LOGGER.error(message);
+                promise.fail(event.left().getValue());
+            }
+        };
+    }
+
+    public static Handler<Either<String, JsonObject>> handlerJsonObject(Promise<JsonObject> promise) {
+        return event -> {
+            if (event.isRight()) {
+                promise.complete(event.right().getValue());
+            } else {
+                String message = String.format("[PresencesCommon@%s::handlerJsonObject]: %s",
+                        FutureHelper.class.getSimpleName(), event.left().getValue());
+                LOGGER.error(message);
                 promise.fail(event.left().getValue());
             }
         };

--- a/common/src/main/java/fr/openent/presences/common/helper/PersonHelper.java
+++ b/common/src/main/java/fr/openent/presences/common/helper/PersonHelper.java
@@ -3,7 +3,9 @@ package fr.openent.presences.common.helper;
 import fr.openent.presences.model.Person.Student;
 import fr.openent.presences.model.Person.User;
 import fr.wseduc.webutils.Either;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.entcore.common.neo4j.Neo4j;
@@ -63,6 +65,12 @@ public class PersonHelper {
                 "u.firstName as firstName, u.id as id, c.name as classeName, c.id as classId";
         JsonObject params = new JsonObject().put("structureId", structureId).put("idStudents", studentIds);
         Neo4j.getInstance().execute(query, params, Neo4jResult.validResultHandler(handler));
+    }
+
+    public Future<JsonArray> getStudentsInfo(String structureId, List<String> studentIds) {
+        Promise<JsonArray> promise = Promise.promise();
+        getStudentsInfo(structureId, studentIds, FutureHelper.handlerJsonArray(promise));
+        return promise.future();
     }
 
 }

--- a/common/src/main/java/fr/openent/presences/common/service/ExportPDFService.java
+++ b/common/src/main/java/fr/openent/presences/common/service/ExportPDFService.java
@@ -1,13 +1,15 @@
 package fr.openent.presences.common.service;
 
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpServerRequest;
+import org.entcore.common.pdf.Pdf;
 import org.entcore.common.user.UserInfos;
 
 public interface ExportPDFService {
     /**
-     * Generation of a PDF from a XHTML template
+     * Generation of a PDF from an XHTML template
      *
      * @param request Http request
      * @param html    html text string wished to be converted into Pdf
@@ -15,4 +17,14 @@ public interface ExportPDFService {
      * @param handler Handler returning data buffer type
      */
     void generatePDF(HttpServerRequest request, String html, UserInfos user, Handler<Buffer> handler);
+
+    /**
+     * Generation of a PDF
+     *
+     * @param filename  filename for pdf name
+     * @param buffer    Buffer wanted to generate PDF (usually done after a template rendered) or HTML content
+     *
+     * @return {@link Pdf} result
+     */
+    Future<Pdf> generatePDF(String filename, String buffer);
 }

--- a/common/src/main/java/fr/openent/presences/common/viescolaire/Viescolaire.java
+++ b/common/src/main/java/fr/openent/presences/common/viescolaire/Viescolaire.java
@@ -1,6 +1,7 @@
 package fr.openent.presences.common.viescolaire;
 
 import fr.openent.presences.common.helper.DateHelper;
+import fr.openent.presences.common.helper.FutureHelper;
 import fr.openent.presences.common.message.MessageResponseHandler;
 import fr.wseduc.webutils.Either;
 import io.vertx.core.Future;
@@ -80,6 +81,12 @@ public class Viescolaire {
                 .put("structureId", structureId);
 
         eb.send(address, action, MessageResponseHandler.messageJsonObjectHandler(handler));
+    }
+
+    public Future<JsonObject> getSlotProfileSetting(String structureId) {
+        Promise<JsonObject> promise = Promise.promise();
+        getSlotProfileSetting(structureId, FutureHelper.handlerJsonObject(promise));
+        return promise.future();
     }
 
     public void getSlotProfiles(String structureId, Handler<Either<String, JsonObject>> handler) {

--- a/common/src/main/java/fr/openent/presences/core/constants/Field.java
+++ b/common/src/main/java/fr/openent/presences/core/constants/Field.java
@@ -5,9 +5,12 @@ public class Field {
     public static final String ID = "id";
     public static final String _ID = "_id";
     public static final String IDS = "ids";
+    public static final String TITLE = "title";
     public static final String CLASSES = "classes";
+    public static final String CREATED = "created";
     public static final String COURSES = "courses";
     public static final String GROUP = "group";
+    public static final String EXCLUDE = "exclude";
     public static final String GROUPNAMES = "groupNames";
     public static final String GROUPS = "groups";
     public static final String LIMIT = "limit";
@@ -27,10 +30,15 @@ public class Field {
     public static final String TEACHER = "teacher";
     public static final String TEACHERS = "teachers";
     public static final String TEACHERIDS = "teacherIds";
+    public static final String TYPEID = "type_id";
+    public static final String OWNER = "owner";
+    public static final String ACTION_ABBREVIATION = "action_abbreviation";
+    public static final String EXPORT_PDF_EVENTS = "export-pdf-events";
 
     // Dates
     public static final String END_DATE = "end_date";
     public static final String ENDDATE = "endDate";
+    public static final String DATE = "date";
     public static final String START_DATE = "start_date";
     public static final String STARTDATE = "startDate";
     public static final String START = "start";
@@ -38,6 +46,8 @@ public class Field {
     public static final String START_TIME = "startTime";
     public static final String END_TIME = "endTime";
     public static final String DESCENDING_DATE = "descendingDate";
+    public static final String DISPLAY_START_DATE = "display_start_date";
+    public static final String DISPLAY_END_DATE = "display_end_date";
 
     // School
     public static final String SCHOOL_YEAR = "schoolYear";
@@ -50,6 +60,7 @@ public class Field {
 
     // Reason
     public static final String REASON = "reason";
+    public static final String MULTIPLE = "multiple";
 
     // i18n
     public static final String LOCALE = "locale";
@@ -58,6 +69,7 @@ public class Field {
     // Multiple slots
     public static final String MULTIPLE_SLOT = "multiple_slot";
     public static final String ALLOW_MULTIPLE_SLOTS = "allow_multiple_slots";
+    public static final String END_OF_HALF_DAY = "end_of_half_day";
 
     // Registers
     public static final String COURSE_ID = "course_id";
@@ -98,6 +110,10 @@ public class Field {
 
     // Alert
     public static final String TYPE = "type";
+    public static final String ALERT_ABSENCE_THRESHOLD = "alert_absence_threshold";
+    public static final String ALERT_LATENESS_THRESHOLD = "alert_lateness_threshold";
+    public static final String ALERT_INCIDENT_THRESHOLD = "alert_incident_threshold";
+    public static final String ALERT_FORGOTTEN_NOTEBOOK_THRESHOLD = "alert_forgotten_notebook_threshold";
 
     // Presence
     public static final String COMMENT = "comment";
@@ -106,10 +122,25 @@ public class Field {
     // Statement
     public static final String IDSTATEMENT = "idStatement";
 
+    // event || event type
+    public static final String ABSENCE = "absence";
+    public static final String LATENESS = "lateness";
+    public static final String DEPARTURE = "departure";
+    public static final String REMARK = "remark";
+    public static final String FORGOTTEN_NOTEBOOK = "forgotten_notebook";
+    public static final String PUNISHMENT = "punishment";
+    public static final String SANCTION = "sanction";
+    public static final String FOLLOWED = "followed";
+    public static final String MASSMAILED = "massmailed";
+
     // Absence
     public static final String REGULARIZED = "regularized";
     public static final String REASONID = "reasonId";
     public static final String EVENT_RECOVERY_METHOD = "event_recovery_method";
+    public static final String RECOVERY_METHOD = "recovery_method";
+    public static final String EVENT_TYPE = "event_type";
+    public static final String COUNSELLOR_INPUT = "counsellor_input";
+    public static final String COUNSELLOR_REGULARISATION = "counsellor_regularisation";
 
     // Indicator
     public static final String DATA = "data";

--- a/common/src/main/java/fr/openent/presences/enums/EventType.java
+++ b/common/src/main/java/fr/openent/presences/enums/EventType.java
@@ -1,5 +1,10 @@
 package fr.openent.presences.enums;
 
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 public enum EventType {
     ABSENCE(1),
     LATENESS(2),
@@ -10,8 +15,8 @@ public enum EventType {
     PUNISHMENT(7),
     SANCTION(8);
 
-
     private final Integer type_id;
+    private static Map<Integer, EventType> eventTypeMap;
 
     EventType(Integer type_id) {
         this.type_id = type_id;
@@ -19,5 +24,12 @@ public enum EventType {
 
     public Integer getType() {
         return this.type_id;
+    }
+
+    public static EventType getEventType(Integer typeId) {
+        if (eventTypeMap == null) {
+            eventTypeMap = Arrays.stream(values()).collect(Collectors.toMap(EventType::getType, Function.identity()));
+        }
+        return eventTypeMap.get(typeId);
     }
 }

--- a/common/src/main/java/fr/openent/presences/enums/ExportType.java
+++ b/common/src/main/java/fr/openent/presences/enums/ExportType.java
@@ -1,0 +1,17 @@
+package fr.openent.presences.enums;
+
+public enum ExportType {
+    CSV("CSV"),
+    PDF("PDF");
+
+
+    private final String type;
+
+    ExportType(String type) {
+        this.type = type;
+    }
+
+    public String type() {
+        return this.type;
+    }
+}

--- a/common/src/main/java/fr/openent/presences/model/Settings.java
+++ b/common/src/main/java/fr/openent/presences/model/Settings.java
@@ -1,0 +1,61 @@
+package fr.openent.presences.model;
+
+import fr.openent.presences.core.constants.Field;
+import io.vertx.core.json.JsonObject;
+
+public class Settings {
+
+    private final Number alertAbsenceThreshold;
+    private final Number alertLatenessThreshold;
+    private final Number alertIncidentThreshold;
+    private final Number alertForgottenThreshold;
+    private final String recoveryMethod;
+    private final Boolean multipleSlot;
+    private String endOfHalfDayTimeSlot;
+
+    public Settings(JsonObject settings) {
+        this.alertAbsenceThreshold = settings.getInteger(Field.ALERT_ABSENCE_THRESHOLD);
+        this.alertLatenessThreshold = settings.getInteger(Field.ALERT_LATENESS_THRESHOLD);
+        this.alertIncidentThreshold = settings.getInteger(Field.ALERT_INCIDENT_THRESHOLD);
+        this.alertForgottenThreshold = settings.getInteger(Field.ALERT_FORGOTTEN_NOTEBOOK_THRESHOLD);
+        this.recoveryMethod = settings.getString(Field.EVENT_RECOVERY_METHOD);
+        this.multipleSlot = settings.getBoolean(Field.ALLOW_MULTIPLE_SLOTS);
+    }
+
+    public Number alertAbsenceThreshold() {
+        return alertAbsenceThreshold;
+    }
+
+    public Number alertLatenessThreshold() {
+        return alertLatenessThreshold;
+    }
+
+    public Number alertIncidentThreshold() {
+        return alertIncidentThreshold;
+    }
+
+    public Number alertForgottenThreshold() {
+        return alertForgottenThreshold;
+    }
+
+    public String recoveryMethod() {
+        return recoveryMethod;
+    }
+
+    public Boolean multipleSlot() {
+        return multipleSlot;
+    }
+
+    public Settings setEndOfHalfDayTimeSlot(String endOfHalfDayTimeSlot) {
+        this.endOfHalfDayTimeSlot = endOfHalfDayTimeSlot;
+        return this;
+    }
+
+    public String endOfHalfDayTimeSlot() {
+        return endOfHalfDayTimeSlot;
+    }
+
+}
+
+
+

--- a/common/src/main/resources/ts/core/enum/export-type.enum.ts
+++ b/common/src/main/resources/ts/core/enum/export-type.enum.ts
@@ -1,0 +1,6 @@
+export enum EXPORT_TYPE {
+    CSV = 'CSV',
+    PDF = 'PDF',
+}
+
+export type ExportType = 'CSV' | 'PDF';

--- a/presences/deployment/presences/conf.json.template
+++ b/presences/deployment/presences/conf.json.template
@@ -19,6 +19,11 @@
         "mode" : "${mode}",
         "entcore.port" : 8009,
         "sql": true,
-        "db-schema": "presences"
+        "db-schema": "presences",
+        "node-pdf-generator" : {
+            "pdf-connector-id": "exportpdf",
+            "auth": "${nodePdfToken}",
+            "url" : "${nodePdfUri}"
+        }
       }
     }

--- a/presences/src/main/java/fr/openent/presences/Presences.java
+++ b/presences/src/main/java/fr/openent/presences/Presences.java
@@ -76,7 +76,7 @@ public class Presences extends BaseServer {
         ebViescoAddress = "viescolaire";
         final EventBus eb = getEventBus(vertx);
         Storage storage = new StorageFactory(vertx, config).getStorage();
-        CommonPresencesServiceFactory commonPresencesServiceFactory = new CommonPresencesServiceFactory(vertx, storage);
+        CommonPresencesServiceFactory commonPresencesServiceFactory = new CommonPresencesServiceFactory(vertx, storage, config);
 
 //        final String exportCron = config.getString("export-cron");
 
@@ -86,7 +86,7 @@ public class Presences extends BaseServer {
         addController(new CourseController(eb));
         addController(new RegisterController(eb));
         addController(new AbsenceController(eb));
-        addController(new EventController(eb));
+        addController(new EventController(eb, commonPresencesServiceFactory));
         addController(new LatenessEventController(eb));
         addController(new ExemptionController(eb));
         addController(new SearchController(eb));

--- a/presences/src/main/java/fr/openent/presences/helper/EventByStudentHelper.java
+++ b/presences/src/main/java/fr/openent/presences/helper/EventByStudentHelper.java
@@ -1,0 +1,21 @@
+package fr.openent.presences.helper;
+
+import fr.openent.presences.model.Event.EventByStudent;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class EventByStudentHelper {
+
+    private EventByStudentHelper() { throw new IllegalStateException("Helper class"); }
+
+    public static List<EventByStudent> eventByStudentList(JsonArray eventsByStudents) {
+        return eventsByStudents.stream().map(eventByStudent -> new EventByStudent((JsonObject) eventByStudent)).collect(Collectors.toList());
+    }
+
+    public static List<JsonObject> eventByStudentToJsonArray(List<EventByStudent> eventsByStudents) {
+        return eventsByStudents.stream().map(EventByStudent::toJSON).collect(Collectors.toList());
+    }
+}

--- a/presences/src/main/java/fr/openent/presences/helper/EventHelper.java
+++ b/presences/src/main/java/fr/openent/presences/helper/EventHelper.java
@@ -10,6 +10,7 @@ import fr.openent.presences.common.service.impl.DefaultUserService;
 import fr.openent.presences.enums.Events;
 import fr.openent.presences.model.Absence;
 import fr.openent.presences.model.Event.Event;
+import fr.openent.presences.model.Event.EventByStudent;
 import fr.openent.presences.model.Event.EventType;
 import fr.openent.presences.model.Event.RegisterEvent;
 import fr.openent.presences.model.Person.Student;
@@ -234,6 +235,14 @@ public class EventHelper {
             eventList.add(event);
         }
         return eventList;
+    }
+
+    public static List<Event> getEventListFromJsonArray(JsonArray events) {
+        return events.stream().map(event -> new Event((JsonObject) event)).collect(Collectors.toList());
+    }
+
+    public static List<JsonObject> getEventListToJsonArray(List<Event> events) {
+        return events.stream().map(Event::toJSON).collect(Collectors.toList());
     }
 
     public static JsonArray getMainEventsJsonArrayFromEventList(List<Event> events) {

--- a/presences/src/main/java/fr/openent/presences/helper/SlotHelper.java
+++ b/presences/src/main/java/fr/openent/presences/helper/SlotHelper.java
@@ -1,10 +1,13 @@
 package fr.openent.presences.helper;
 
 import fr.openent.presences.common.helper.DateHelper;
+import fr.openent.presences.common.helper.FutureHelper;
 import fr.openent.presences.common.message.MessageResponseHandler;
 import fr.openent.presences.model.Slot;
 import fr.wseduc.webutils.Either;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -59,6 +62,12 @@ public class SlotHelper {
                 .put("structureId", structureId);
 
         eb.send("viescolaire", action, MessageResponseHandler.messageJsonObjectHandler(handler));
+    }
+
+    public Future<JsonObject> getTimeSlots(String structureId) {
+        Promise<JsonObject> promise = Promise.promise();
+        getTimeSlots(structureId, FutureHelper.handlerJsonObject(promise));
+        return promise.future();
     }
 
     /**

--- a/presences/src/main/java/fr/openent/presences/model/Event/Event.java
+++ b/presences/src/main/java/fr/openent/presences/model/Event/Event.java
@@ -1,5 +1,6 @@
 package fr.openent.presences.model.Event;
 
+import fr.openent.presences.core.constants.Field;
 import fr.openent.presences.model.Person.Student;
 import fr.openent.presences.model.Person.User;
 import fr.openent.presences.model.Reason;
@@ -61,6 +62,27 @@ public class Event {
         this.type = event.getString("type", null);
         this.isExclude = event.getBoolean("exclude", null);
         this.actionAbbreviation = event.getString("action_abbreviation", null);
+    }
+
+    public Event(JsonObject event) {
+        this.id = event.getInteger(Field.ID, null);
+        this.startDate = event.getString(Field.START_DATE, null);
+        this.endDate = event.getString(Field.END_DATE, null);
+        this.date = event.getString(Field.DATE, null);
+        this.comment = event.getString(Field.COMMENT, null);
+        this.counsellorInput = event.getBoolean(Field.COUNSELLOR_INPUT, false);
+        this.student = new Student(event.getJsonObject(Field.STUDENT, new JsonObject()));
+        this.registerId = event.getInteger(Field.REGISTER_ID, null);
+        this.eventType = new EventType(event.getJsonObject(Field.EVENT_TYPE, new JsonObject()), EventType.MANDATORY_ATTRIBUTE);
+        this.reason = new Reason(event.getJsonObject(Field.REASON, new JsonObject()), Reason.MANDATORY_ATTRIBUTE);
+        this.owner = new User(event.getJsonObject(Field.OWNER, new JsonObject()));
+        this.created = event.getString(Field.CREATED, null);
+        this.counsellorRegularisation = event.getBoolean(Field.COUNSELLOR_REGULARISATION, false);
+        this.followed = event.getBoolean(Field.FOLLOWED, false);
+        this.massmailed = event.getBoolean(Field.MASSMAILED, false);
+        this.type = event.getString(Field.TYPE, null);
+        this.isExclude = event.getBoolean(Field.EXCLUDE, null);
+        this.actionAbbreviation = event.getString(Field.ACTION_ABBREVIATION, null);
     }
 
     public Event() {

--- a/presences/src/main/java/fr/openent/presences/model/Event/EventByStudent.java
+++ b/presences/src/main/java/fr/openent/presences/model/Event/EventByStudent.java
@@ -1,0 +1,69 @@
+package fr.openent.presences.model.Event;
+
+import fr.openent.presences.core.constants.Field;
+import fr.openent.presences.helper.EventHelper;
+import fr.openent.presences.model.Person.Student;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.util.List;
+
+public class EventByStudent {
+
+    private Student student;
+    private final String startDate;
+    private final String endDate;
+    private final EventType eventType;
+    private final String recoveryMethod;
+    private final List<Event> events;
+
+
+    public EventByStudent(JsonObject eventByStudent) {
+        this.student = new Student(eventByStudent.getString(Field.STUDENT_ID, null));
+        this.startDate = eventByStudent.getString(Field.START_DATE, null);
+        this.endDate = eventByStudent.getString(Field.END_DATE, null);
+        this.eventType = new EventType(eventByStudent.getInteger(Field.TYPEID, null));
+        this.recoveryMethod =  eventByStudent.getString(Field.RECOVERY_METHOD, null);
+        this.events = EventHelper.getEventListFromJsonArray(eventByStudent.getJsonArray(Field.EVENTS, new JsonArray()), Event.MANDATORY_ATTRIBUTE);
+    }
+
+    public JsonObject toJSON() {
+        return new JsonObject()
+                .put(Field.STUDENT, this.student.toJSON())
+                .put(Field.START_DATE, this.startDate)
+                .put(Field.END_DATE, this.endDate)
+                .put(Field.EVENT_TYPE, this.eventType.toJSON())
+                .put(Field.RECOVERY_METHOD, this.recoveryMethod)
+                .put(Field.EVENTS, EventHelper.getEventListToJsonArray(this.events));
+    }
+
+    public EventByStudent setStudent(Student student) {
+        this.student = student;
+        return this;
+    }
+
+    public Student student() {
+        return student;
+    }
+
+
+    public String startDate() {
+        return startDate;
+    }
+
+    public String endDate() {
+        return endDate;
+    }
+
+    public EventType eventType() {
+        return eventType;
+    }
+
+    public String recoveryMethod() {
+        return recoveryMethod;
+    }
+
+    public List<Event> events() {
+        return events;
+    }
+
+}

--- a/presences/src/main/java/fr/openent/presences/service/CommonPresencesServiceFactory.java
+++ b/presences/src/main/java/fr/openent/presences/service/CommonPresencesServiceFactory.java
@@ -1,25 +1,31 @@
 package fr.openent.presences.service;
 
+import fr.openent.presences.common.helper.PersonHelper;
+import fr.openent.presences.common.service.ExportPDFService;
 import fr.openent.presences.common.service.ExportZIPService;
 import fr.openent.presences.common.service.StructureService;
 import fr.openent.presences.common.service.UserService;
 import fr.openent.presences.common.service.impl.DefaultStructureService;
 import fr.openent.presences.common.service.impl.DefaultUserService;
+import fr.openent.presences.common.service.impl.ExportPDFServiceImpl;
 import fr.openent.presences.common.service.impl.ExportZIPServiceImpl;
-import fr.openent.presences.service.impl.DefaultArchiveService;
-import fr.openent.presences.service.impl.DefaultEventService;
-import fr.openent.presences.service.impl.DefaultReasonService;
+import fr.openent.presences.helper.EventHelper;
+import fr.openent.presences.helper.SlotHelper;
+import fr.openent.presences.service.impl.*;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.json.JsonObject;
 import org.entcore.common.storage.Storage;
 
 public class CommonPresencesServiceFactory {
     private final Vertx vertx;
     private final Storage storage;
+    private final JsonObject config;
 
-    public CommonPresencesServiceFactory(Vertx vertx, Storage storage) {
+    public CommonPresencesServiceFactory(Vertx vertx, Storage storage, JsonObject config) {
         this.vertx = vertx;
         this.storage = storage;
+        this.config = config;
     }
 
     // Common
@@ -35,10 +41,30 @@ public class CommonPresencesServiceFactory {
         return new ExportZIPServiceImpl(vertx, storage);
     }
 
+    public ExportPDFService exportPDFService() {
+        return new ExportPDFServiceImpl(vertx, config);
+    }
+
+    public SettingsService settingsService() {
+        return new DefaultSettingsService();
+    }
+
+    public EventHelper eventHelper() {
+        return new EventHelper(this.vertx.eventBus());
+    }
+
+    public PersonHelper personHelper() { return new PersonHelper();}
+
+    public SlotHelper slotHelper() { return new SlotHelper(this.vertx.eventBus());}
+
     // Presences Service
 
     public EventService eventService() {
         return new DefaultEventService(vertx.eventBus());
+    }
+
+    public ExportEventService exportEventService() {
+        return new DefaultExportEventService(this);
     }
 
     public ReasonService reasonService() {

--- a/presences/src/main/java/fr/openent/presences/service/EventService.java
+++ b/presences/src/main/java/fr/openent/presences/service/EventService.java
@@ -1,6 +1,5 @@
 package fr.openent.presences.service;
 
-import fr.openent.presences.model.Event.Event;
 import fr.wseduc.webutils.Either;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -28,6 +27,11 @@ public interface EventService {
      * @param page              page
      * @param handler           function handler returning data
      */
+
+    void getEvents(String structureId, String startDate, String endDate,
+              List<String> eventType, List<String> listReasonIds, Boolean noReason, List<String> userId, JsonArray userIdFromClasses,
+              Boolean regularized, Boolean followed, Integer page, Handler<Either<String, JsonArray>> handler);
+
     void get(String structureId, String startDate, String endDate, String startTime, String endTime,
              List<String> eventType, List<String> listReasonIds, Boolean noReason, List<String> userId,
              Boolean regularized, Boolean followed, Integer page, Handler<AsyncResult<JsonArray>> handler);
@@ -46,30 +50,6 @@ public interface EventService {
      * @param handler   Function handler returning data
      */
     void get(String startDate, String endDate, List<Number> eventType, List<String> users, Handler<Either<String, JsonArray>> handler);
-
-    /**
-     * Get events. Will after export this into csv
-     *
-     * @param structureId       structure identifier
-     * @param startDate         startDate start date
-     * @param endDate           endDate end date
-     * @param eventType         event type
-     * @param listReasonIds     reasonId reason_id
-     * @param noReason          noReason filter
-     * @param userId            userId userId neo4j
-     * @param userIdFromClasses userId fetched from classes neo4j
-     * @param classes           classes list
-     * @param regularized       regularized filter
-     * @param followed          followed filter
-     * @param handler           Function handler returning data
-     */
-    void getCsvData(String structureId, String startDate, String endDate, List<String> eventType, List<String> listReasonIds,
-                    Boolean noReason, List<String> userId, JsonArray userIdFromClasses, List<String> classes,
-                    Boolean regularized, Boolean followed, Handler<AsyncResult<List<Event>>> handler);
-
-    Future<List<Event>> getCsvData(String structureId, String startDate, String endDate, List<String> eventType, List<String> listReasonIds,
-                                  Boolean noReason, List<String> userId, JsonArray userIdFromClasses, List<String> classes,
-                                  Boolean regularized, Boolean followed);
 
     /**
      * Get events page number
@@ -198,6 +178,11 @@ public interface EventService {
     void getEventsByStudent(Integer eventType, List<String> students, String structure, Boolean justified, List<Integer> reasonsId, Boolean massmailed,
                             String startDate, String endDate, boolean noReasons, String recoveryMethodUsed, String limit, String offset,
                             Boolean regularized, Handler<Either<String, JsonArray>> handler);
+
+    Future<JsonArray> getEventsByStudent(Integer eventType, List<String> students, String structure, Boolean justified,
+                                         List<Integer> reasonsId, Boolean massmailed, Boolean compliance, String startDate, String endDate,
+                                         boolean noReasons, String recoveryMethodUsed, String limit, String offset,
+                                         Boolean regularized);
 
     void getEventsByStudent(Integer eventType, List<String> students, String structure, Boolean justified,
                             List<Integer> reasonsId, Boolean massmailed, Boolean compliance, String startDate, String endDate,

--- a/presences/src/main/java/fr/openent/presences/service/ExportEventService.java
+++ b/presences/src/main/java/fr/openent/presences/service/ExportEventService.java
@@ -1,0 +1,79 @@
+package fr.openent.presences.service;
+
+import fr.openent.presences.model.Event.Event;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.util.List;
+
+public interface ExportEventService {
+
+
+    /**
+     * Get events. Will after export this into csv (or PDF)
+     *
+     * @param structureId       structure identifier
+     * @param startDate         startDate start date
+     * @param endDate           endDate end date
+     * @param eventType         event type
+     * @param listReasonIds     reasonId reason_id
+     * @param noReason          noReason filter
+     * @param userId            userId userId neo4j
+     * @param userIdFromClasses userId fetched from classes neo4j
+     * @param classes           classes list
+     * @param regularized       regularized filter
+     * @param followed          followed filter
+     * @param handler           Function handler returning data
+     */
+    void getCsvData(String structureId, String startDate, String endDate, List<String> eventType, List<String> listReasonIds,
+                    Boolean noReason, List<String> userId, JsonArray userIdFromClasses, List<String> classes,
+                    Boolean regularized, Boolean followed, Handler<AsyncResult<List<Event>>> handler);
+
+    /**
+     * Get events. Will after export this into csv (or PDF)
+     *
+     * @param structureId       structure identifier
+     * @param startDate         startDate start date
+     * @param endDate           endDate end date
+     * @param eventType         event type
+     * @param listReasonIds     reasonId reason_id
+     * @param noReason          noReason filter
+     * @param userId            userId userId neo4j
+     * @param userIdFromClasses userId fetched from classes neo4j
+     * @param classes           classes list
+     * @param regularized       regularized filter
+     * @param followed          followed filter
+     * @return list of {@link Event}
+     */
+    Future<List<Event>> getCsvData(String structureId, String startDate, String endDate, List<String> eventType, List<String> listReasonIds,
+                                   Boolean noReason, List<String> userId, JsonArray userIdFromClasses, List<String> classes,
+                                   Boolean regularized, Boolean followed);
+
+    /**
+     * Get events. Will after export this into csv (or PDF)
+     *
+     * @param domain            domain request sent
+     * @param local             accepted langage
+     * @param structureId       structure identifier
+     * @param startDate         startDate start date
+     * @param endDate           endDate end date
+     * @param eventType         event type
+     * @param listReasonIds     reasonId reason_id
+     * @param noReason          noReason filter
+     * @param userId            userId userId neo4j
+     * @param userIdFromClasses userId fetched from classes neo4j
+     * @param classes           classes list
+     * @param regularized       regularized filter
+     * @return {@link JsonObject} will be build as
+     * title -> {@link String}
+     * event type -> {@link List} of {@link fr.openent.presences.model.Event.EventByStudent} as JsonObject
+     * ... event type...
+     */
+    Future<JsonObject> getPdfData(String domain, String local, String structureId, String startDate, String endDate,
+                                  List<String> eventType, List<String> listReasonIds, Boolean noReason, List<String> userId,
+                                  JsonArray userIdFromClasses, List<String> classes, Boolean regularized);
+
+}

--- a/presences/src/main/java/fr/openent/presences/service/SettingsService.java
+++ b/presences/src/main/java/fr/openent/presences/service/SettingsService.java
@@ -7,6 +7,8 @@ import io.vertx.core.json.JsonObject;
 public interface SettingsService {
     void retrieve(String structureId, Handler<Either<String, JsonObject>> handler);
 
+    Future<JsonObject> retrieve(String structureId);
+
     /**
      * Retrieve multiple slot setting.
      *

--- a/presences/src/main/java/fr/openent/presences/service/impl/DefaultArchiveService.java
+++ b/presences/src/main/java/fr/openent/presences/service/impl/DefaultArchiveService.java
@@ -7,11 +7,8 @@ import fr.openent.presences.core.constants.Field;
 import fr.openent.presences.db.DBService;
 import fr.openent.presences.export.EventsCSVExport;
 import fr.openent.presences.model.Event.Event;
-import fr.openent.presences.service.ArchiveService;
+import fr.openent.presences.service.*;
 
-import fr.openent.presences.service.CommonPresencesServiceFactory;
-import fr.openent.presences.service.EventService;
-import fr.openent.presences.service.ReasonService;
 import fr.openent.presences.worker.EventExportWorker;
 import fr.wseduc.webutils.I18n;
 import io.vertx.core.CompositeFuture;
@@ -35,12 +32,14 @@ import static fr.wseduc.webutils.Utils.handlerToAsyncHandler;
 public class DefaultArchiveService extends DBService implements ArchiveService {
     private final EventBus eb;
     private final EventService eventService;
+    private final ExportEventService exportEventService;
     private final ReasonService reasonService;
 
     private final Logger log = LoggerFactory.getLogger(DefaultArchiveService.class);
 
     public DefaultArchiveService(CommonPresencesServiceFactory commonPresencesServiceFactory) {
         this.eventService = commonPresencesServiceFactory.eventService();
+        this.exportEventService = commonPresencesServiceFactory.exportEventService();
         this.reasonService = commonPresencesServiceFactory.reasonService();
         this.eb = commonPresencesServiceFactory.eventBus();
     }
@@ -250,7 +249,7 @@ public class DefaultArchiveService extends DBService implements ArchiveService {
         Promise<JsonObject> promise = Promise.promise();
         String start = splittedDateSchoolYear.getString(Field.START_DATE);
         String end = splittedDateSchoolYear.getString(Field.END_DATE);
-        eventService.getCsvData(structure.getString(Field.ID), start, end, eventType, reasonIds, true, new ArrayList<>(),
+        exportEventService.getCsvData(structure.getString(Field.ID), start, end, eventType, reasonIds, true, new ArrayList<>(),
                 new JsonArray(), null, null, null)
                 .compose(events -> writeCSV(events, start, end, exportProcess, domain, locale))
                 .onSuccess(res -> promise.complete(exportProcess))

--- a/presences/src/main/java/fr/openent/presences/service/impl/DefaultExportEventService.java
+++ b/presences/src/main/java/fr/openent/presences/service/impl/DefaultExportEventService.java
@@ -1,0 +1,383 @@
+package fr.openent.presences.service.impl;
+
+import fr.openent.presences.common.helper.DateHelper;
+import fr.openent.presences.common.helper.EventsHelper;
+import fr.openent.presences.common.helper.PersonHelper;
+import fr.openent.presences.common.viescolaire.Viescolaire;
+import fr.openent.presences.core.constants.Field;
+import fr.openent.presences.db.DBService;
+import fr.openent.presences.enums.EventType;
+import fr.openent.presences.helper.EventByStudentHelper;
+import fr.openent.presences.helper.EventHelper;
+import fr.openent.presences.helper.ReasonHelper;
+import fr.openent.presences.model.Event.Event;
+import fr.openent.presences.model.Event.EventByStudent;
+import fr.openent.presences.model.Person.Student;
+import fr.openent.presences.model.Reason;
+import fr.openent.presences.model.Settings;
+import fr.openent.presences.service.*;
+import fr.wseduc.webutils.I18n;
+import io.vertx.core.*;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class DefaultExportEventService extends DBService implements ExportEventService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultExportEventService.class);
+    private final EventService eventService;
+    private final SettingsService settingsService;
+    private final EventHelper eventHelper;
+    private final PersonHelper personHelper;
+    private final ReasonService reasonService;
+
+
+    public DefaultExportEventService(CommonPresencesServiceFactory commonPresencesServiceFactory) {
+        this.eventService = commonPresencesServiceFactory.eventService();
+        this.settingsService = commonPresencesServiceFactory.settingsService();
+        this.eventHelper = commonPresencesServiceFactory.eventHelper();
+        this.personHelper = commonPresencesServiceFactory.personHelper();
+        this.reasonService = commonPresencesServiceFactory.reasonService();
+    }
+
+    @Override
+    public void getCsvData(String structureId, String startDate, String endDate, List<String> eventType,
+                           List<String> listReasonIds, Boolean noReason, List<String> userId, JsonArray userIdFromClasses,
+                           List<String> classes, Boolean regularized, Boolean followed, Handler<AsyncResult<List<Event>>> handler) {
+        eventService.getEvents(structureId, startDate, endDate, eventType, listReasonIds, noReason, userId, userIdFromClasses,
+                regularized, followed, null, eventHandler -> {
+                    if (eventHandler.isLeft()) {
+                        String err = "[Presences@DefaultEventService::getCsvData] Failed to fetch events: " + eventHandler.left().getValue() ;
+                        LOGGER.error(err, eventHandler.left().getValue());
+                        handler.handle(Future.failedFuture(eventHandler.left().getValue()));
+                    } else {
+                        List<Event> events = EventHelper.getEventListFromJsonArray(eventHandler.right().getValue(), Event.MANDATORY_ATTRIBUTE);
+
+                        List<Integer> reasonIds = new ArrayList<>();
+                        List<String> studentIds = new ArrayList<>();
+                        List<String> ownerIds = new ArrayList<>();
+                        List<Integer> eventTypeIds = new ArrayList<>();
+
+                        for (Event event : events) {
+                            reasonIds.add(event.getReason().getId());
+                            if (!studentIds.contains(event.getStudent().getId())) {
+                                studentIds.add(event.getStudent().getId());
+                            }
+                            if (!ownerIds.contains(event.getOwner().getId())) {
+                                ownerIds.add(event.getOwner().getId());
+                            }
+                            eventTypeIds.add(event.getEventType().getId());
+                        }
+
+                        // remove potential null value for each list
+                        reasonIds.removeAll(Collections.singletonList(null));
+                        studentIds.removeAll(Collections.singletonList(null));
+                        ownerIds.removeAll(Collections.singletonList(null));
+                        eventTypeIds.removeAll(Collections.singletonList(null));
+
+                        Future<JsonObject> reasonFuture = Future.future();
+                        Future<JsonObject> studentFuture = Future.future();
+                        Future<JsonObject> ownerFuture = Future.future();
+                        Future<JsonObject> eventTypeFuture = Future.future();
+
+                        eventHelper.addReasonsToEvents(events, reasonIds, reasonFuture);
+                        eventHelper.addStudentsToEvents(events, studentIds, structureId, studentFuture);
+                        eventHelper.addOwnerToEvents(events, ownerIds, ownerFuture);
+                        eventHelper.addEventTypeToEvents(events, eventTypeIds, eventTypeFuture);
+
+                        CompositeFuture.all(reasonFuture, eventTypeFuture, studentFuture, ownerFuture)
+                                .setHandler(eventResult -> {
+                                    if (eventResult.failed()) {
+                                        String message = "[Presences@DefaultEventService::getCsvData] Failed to add " +
+                                                "reasons, eventType, students or owner to corresponding event ";
+                                        LOGGER.error(message + eventResult.cause().getMessage());
+                                        handler.handle(Future.failedFuture(message));
+                                    } else {
+                                        handler.handle(Future.succeededFuture(events));
+                                    }
+                                });
+                    }
+                });
+    }
+
+    @Override
+    public Future<List<Event>> getCsvData(String structureId, String startDate, String endDate, List<String> eventType,
+                                          List<String> listReasonIds, Boolean noReason, List<String> userId, JsonArray userIdFromClasses,
+                                          List<String> classes, Boolean regularized, Boolean followed) {
+        Promise<List<Event>> promise = Promise.promise();
+
+        getCsvData(structureId, startDate, endDate, eventType, listReasonIds, noReason, userId, userIdFromClasses,
+                classes, regularized, followed, event -> {
+                    if (event.failed()) {
+                        promise.fail(event.cause());
+                    } else {
+                        promise.complete(event.result());
+                    }
+                });
+
+        return promise.future();
+    }
+
+    @Override
+    public Future<JsonObject> getPdfData(String domain, String local, String structureId, String startDate, String endDate,
+                                         List<String> eventType, List<String> listReasonIds, Boolean noReason, List<String> userId,
+                                         JsonArray userIdFromClasses, List<String> classes, Boolean regularized) {
+        Promise<JsonObject> promise = Promise.promise();
+        if (userId != null && !userId.isEmpty()) {
+            userIdFromClasses.addAll(new JsonArray(userId));
+        }
+
+        Future<JsonObject> settingsFuture = settingsService.retrieve(structureId);
+        Future<JsonObject> slotsSettingsFuture = Viescolaire.getInstance().getSlotProfileSetting(structureId);
+        Future<JsonArray> reasonFuture = reasonService.fetchReason(structureId);
+
+        CompositeFuture.all(settingsFuture, slotsSettingsFuture, reasonFuture)
+                .onSuccess(ar -> {
+                    Settings settings = new Settings(settingsFuture.result())
+                            .setEndOfHalfDayTimeSlot(slotsSettingsFuture.result().getString(Field.END_OF_HALF_DAY));
+                    List<Reason> reasons = ReasonHelper.getReasonListFromJsonArray(reasonFuture.result(), Reason.MANDATORY_ATTRIBUTE);
+
+                    processEvents(settings, structureId, startDate, endDate, eventType, listReasonIds, noReason, userIdFromClasses)
+                            .compose(eventByStudent -> formatEventsDataPdf(startDate, endDate, domain, local, settings, reasons, eventByStudent, eventType))
+                            .onSuccess(promise::complete)
+                            .onFailure(err -> {
+                                String message = String.format("[Presences@%s::processEvents]: An error has occurred " +
+                                        "during process events steps: %s", this.getClass().getSimpleName(), err.getMessage());
+                                LOGGER.error(message, err);
+                                promise.fail(err.getMessage());
+                            });
+                })
+                .onFailure(err -> {
+                    String message = String.format("[Presences@%s::processEvents]: An error has occurred during retrieve settings: %s",
+                            this.getClass().getSimpleName(), err.getMessage());
+                    LOGGER.error(message, err);
+                    promise.fail(err.getMessage());
+                });
+
+        return promise.future();
+    }
+
+    /**
+     * fetch all event by type and by students and proceed on extra fetching (student, reason...)
+     *
+     * @param setting               Presences settings {@link Settings}
+     * @param structureId           Structure identifier
+     * @param startDate             start date
+     * @param endDate               end date
+     * @param eventType             list of event type
+     * @param listReasonIds         list of reason identifiers
+     * @param noReason              boolean if filtering noReason or not
+     * @param userIdFromClasses     userId fetched from classes data
+     * @return {@link Future<List>} of {@link EventByStudent}
+     */
+    @SuppressWarnings("unchecked")
+    private Future<List<EventByStudent>> processEvents(Settings setting, String structureId, String startDate, String endDate,
+                                            List<String> eventType, List<String> listReasonIds, Boolean noReason,
+                                            JsonArray userIdFromClasses) {
+        Promise<List<EventByStudent>> promise = Promise.promise();
+        List<Integer> eventsTypes = eventType.stream().map(Integer::parseInt).collect(Collectors.toList());
+        List<Integer> reasonIds = listReasonIds != null ? listReasonIds.stream().map(Integer::parseInt).collect(Collectors.toList()) : new ArrayList<>();
+
+        List<Future<JsonArray>> eventsTypeResult = new ArrayList<>();
+        Promise<JsonArray> init = Promise.promise();
+        Future<JsonArray> current = init.future();
+
+        for (Integer type: eventsTypes) {
+            current = current.compose(v -> {
+                Future<JsonArray> next = this.eventService.getEventsByStudent(type, userIdFromClasses.getList(), structureId,
+                        null, reasonIds, null, null, startDate, endDate, noReason,
+                        setting.recoveryMethod(), null, null, null);
+                eventsTypeResult.add(next);
+                return next;
+            });
+        }
+        current
+                .compose(aVoid -> mergeEventByStudent(eventsTypeResult))
+                .compose(eventByStudents -> fetchStudentForEvents(eventByStudents, structureId))
+                .onSuccess(promise::complete)
+                .onFailure(err -> {
+                    String message = String.format("[Presences@%s::processEvents]: An error has occurred during process events steps: %s",
+                            this.getClass().getSimpleName(), err.getMessage());
+                    LOGGER.error(message, err);
+                    promise.fail(err.getMessage());
+                });
+        init.complete();
+        return promise.future();
+    }
+
+
+    /**
+     * format list of eventData with pdf format
+     *
+     * @param startDate             start date
+     * @param endDate               end date
+     * @param domain                domain url server
+     * @param local                 language request
+     * @param settings              presences settings {@link Settings}
+     * @param reasons               list of reason by current structure fetched {@link Reason}
+     * @param eventByStudents       Presences settings List of {@link EventByStudent}
+     * @param eventsTypes           List of event types
+     * @return {@link Future<JsonObject>} with format pdf to process
+     */
+    private Future<JsonObject> formatEventsDataPdf(String startDate, String endDate, String domain, String local,
+                                                    Settings settings, List<Reason> reasons, List<EventByStudent> eventByStudents,
+                                                    List<String> eventsTypes) {
+        Promise<JsonObject> promise = Promise.promise();
+        JsonObject formatPdf = new JsonObject();
+        for (String type: eventsTypes) {
+            JsonArray mergeEventsByDates = getFormattedEventByStudents(settings, eventByStudents, type);
+            // process absence event to display extra data
+            addDataToAbsenceEvent(type, mergeEventsByDates, reasons, domain, local);
+            formatPdf.put(EventType.getEventType(Integer.parseInt(type)).name(), mergeEventsByDates);
+        }
+        formatPdf.put(Field.TITLE, Field.EXPORT_PDF_EVENTS + "_" + startDate + "_" + endDate);
+        promise.complete(formatPdf);
+        return promise.future();
+    }
+
+    /**
+     * Add extra data for pdf format to process
+     *
+     * @param type                  event type
+     * @param mergeEventsByDates    result of new built events
+     * @param reasons               list of reason by current structure fetched {@link Reason}
+     * @param domain                domain url server
+     * @param local                 language request
+     *
+     */
+    @SuppressWarnings("unchecked")
+    private void addDataToAbsenceEvent(String type, JsonArray mergeEventsByDates, List<Reason> reasons, String domain, String local) {
+        ((List<JsonObject>) mergeEventsByDates.getList()).forEach(event -> {
+
+            event.put(Field.DATE, DateHelper.getDateString(event.getString(Field.START_DATE), DateHelper.YEAR_MONTH_DAY));
+            event.put(Field.DISPLAY_START_DATE, DateHelper.getDateString(event.getString(Field.DISPLAY_START_DATE), DateHelper.HOUR_MINUTES));
+            event.put(Field.DISPLAY_END_DATE, DateHelper.getDateString(event.getString(Field.DISPLAY_END_DATE), DateHelper.HOUR_MINUTES));
+
+            if (EventType.ABSENCE.getType().equals(Integer.parseInt(type))) {
+                List<Event> events = EventHelper.getEventListFromJsonArray(event.getJsonArray(Field.EVENTS, new JsonArray()));
+                events.forEach(e -> {
+                    if (e.getReason().getId() != null) {
+                        e.setReason(reasons.stream()
+                                .filter(reason -> e.getReason().getId().equals(reason.getId()))
+                                .findFirst()
+                                .orElse(null));
+                    }
+                });
+
+                event.put(Field.REGULARIZED, events
+                        .stream()
+                        .map(Event::isCounsellorRegularisation)
+                        .collect(Collectors.toList())
+                        .stream()
+                        .allMatch(Boolean::valueOf) ?
+                        I18n.getInstance().translate("presences.exemptions.csv.attendance.true", domain, local) :
+                        I18n.getInstance().translate("presences.exemptions.csv.attendance.false", domain, local));
+
+                Boolean allSameReason = events
+                        .stream()
+                        .map(e -> e.getReason().getId())
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList())
+                        .stream()
+                        .allMatch(e -> {
+                            if (events.get(0).getReason().getId() != null) {
+                                return events.get(0).getReason().getId().equals(e);
+                            }
+                            return false;
+                        });
+
+                String reasonLabel =  events.get(0).getReason().getLabel() != null ? events.get(0).getReason().getLabel() :
+                        I18n.getInstance().translate("presences.memento.absence.type.NO_REASON", domain, local);
+                event.put(Field.REASON, Boolean.TRUE.equals(allSameReason) ? reasonLabel : Field.MULTIPLE);
+            }
+        });
+    }
+
+    /**
+     * with defined event type, will fetch grouped events by its type and build event and its slots event
+     *
+     * @param settings              presences settings {@link Settings}
+     * @param eventByStudents       Presences settings List of {@link EventByStudent}
+     * @param type                  List of event type
+     *
+     * @return {@link JsonArray}    with format pdf to process
+     */
+    @SuppressWarnings("unchecked")
+    private JsonArray getFormattedEventByStudents(Settings settings, List<EventByStudent> eventByStudents, String type) {
+        // split eventByStudent by each looped type
+        List<EventByStudent> eventByStudentByType = eventByStudents
+                .stream()
+                .filter(eventByStudent -> eventByStudent.eventType().getId().equals(Integer.parseInt(type)))
+                .collect(Collectors.toList());
+        List<JsonObject> eventByStudentByTypeFormat = EventByStudentHelper.eventByStudentToJsonArray(eventByStudentByType);
+
+        // create new list of event instance to factorize events slots
+        JsonArray result = EventsHelper.mergeEventsByDates(new JsonArray(eventByStudentByTypeFormat), settings.endOfHalfDayTimeSlot());
+
+        return new JsonArray(((List<JsonObject>) result.getList())
+                .stream()
+                .sorted((event1, event2) ->
+                        event1.getJsonObject(Field.STUDENT).getString(Field.ID)
+                                .compareToIgnoreCase(event2.getJsonObject(Field.STUDENT).getString(Field.ID))
+                )
+                .collect(Collectors.toList()));
+    }
+
+    /**
+     * merge all event by student in one
+     *
+     * @param eventsTypeResult      Presences settings List of {@link Future} {@link JsonArray} response
+     * @return {@link Future<List>} of {@link EventByStudent}
+     */
+    private Future<List<EventByStudent>> mergeEventByStudent(List<Future<JsonArray>> eventsTypeResult) {
+        Promise<List<EventByStudent>> promise = Promise.promise();
+
+        promise.complete(Stream.of(eventsTypeResult)
+                .flatMap(Collection::stream)
+                .map(eventByStudentsResult -> EventByStudentHelper.eventByStudentList(eventByStudentsResult.result()))
+                .collect(Collectors.toList())
+                .stream()
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList()));
+
+        return promise.future();
+    }
+
+    /**
+     * fetch all students data and inject into event by student list
+     *
+     * @param eventByStudents       Presences settings List of {@link EventByStudent} response
+     * @param structureId           Structure identifier
+     * @return {@link Future<List>} of {@link EventByStudent}
+     */
+    private Future<List<EventByStudent>> fetchStudentForEvents(List<EventByStudent> eventByStudents, String structureId) {
+        Promise<List<EventByStudent>> promise = Promise.promise();
+        List<String> studentIds = eventByStudents.stream().map(eventByStudent -> eventByStudent.student().getId()).collect(Collectors.toList());
+        studentIds.removeAll(Collections.singletonList(null));
+
+        personHelper.getStudentsInfo(structureId, studentIds)
+                .onSuccess(studentsRes -> {
+                    List<Student> students = personHelper.getStudentListFromJsonArray(studentsRes);
+                    Map<String, Student> studentMap = students
+                            .stream()
+                            .collect(Collectors.toMap(Student::getId, Function.identity(), (student1, student2) -> student1));
+                    eventByStudents.forEach(eventByStudent -> {
+                        if (studentMap.containsKey(eventByStudent.student().getId())) {
+                            eventByStudent.setStudent(studentMap.get(eventByStudent.student().getId()));
+                        }
+                    });
+                    promise.complete(eventByStudents);
+
+                })
+                .onFailure(promise::fail);
+        return promise.future();
+    }
+
+
+}

--- a/presences/src/main/java/fr/openent/presences/service/impl/DefaultSettingsService.java
+++ b/presences/src/main/java/fr/openent/presences/service/impl/DefaultSettingsService.java
@@ -31,6 +31,22 @@ public class DefaultSettingsService extends DBService implements SettingsService
     }
 
     @Override
+    public Future<JsonObject> retrieve(String structureId) {
+        Promise<JsonObject> promise = Promise.promise();
+        retrieve(structureId, event -> {
+            if (event.isLeft()) {
+                String message = String.format("[Presences@%s::retrieve] an error has occurred during retrieving settings: %s",
+                        this.getClass().getSimpleName(), event.left().getValue());
+                log.error(message, event.left());
+                promise.fail(event.left().getValue());
+            } else {
+                promise.complete(event.right().getValue());
+            }
+        });
+        return promise.future();
+    }
+
+    @Override
     public Future<JsonObject> retrieveMultipleSlots(String structureId) {
         Promise<JsonObject> promise = Promise.promise();
         String query = "SELECT allow_multiple_slots " +

--- a/presences/src/main/java/fr/openent/presences/worker/EventExportWorker.java
+++ b/presences/src/main/java/fr/openent/presences/worker/EventExportWorker.java
@@ -35,7 +35,7 @@ public class EventExportWorker extends BusModBase implements Handler<Message<Jso
     public void start() {
         super.start();
         Storage storage = new StorageFactory(vertx, config).getStorage();
-        CommonPresencesServiceFactory commonPresencesServiceFactory = new CommonPresencesServiceFactory(vertx, storage);
+        CommonPresencesServiceFactory commonPresencesServiceFactory = new CommonPresencesServiceFactory(vertx, storage, config);
         this.emailSender = new EmailFactory(vertx, config).getSender();
         this.archiveService = commonPresencesServiceFactory.archiveService();
         eb.consumer(this.getClass().getName(), this);

--- a/presences/src/main/resources/i18n/fr.json
+++ b/presences/src/main/resources/i18n/fr.json
@@ -45,6 +45,7 @@
   "presences.absence.number.presents": "Nombre d'élèves présents dans l'établissement",
   "presences.absence.period": "Période",
   "presences.absence.reason": "Motif",
+  "presences.absence.recap": "Récapitulatif",
   "presences.absence.reason.this": "Motif de l'absence",
   "presences.absence.reason.absence": "Motifs d'absence",
   "presences.absence.reason.form.title": "Motifs d'absences individuelles",

--- a/presences/src/main/resources/public/template/events/header.html
+++ b/presences/src/main/resources/public/template/events/header.html
@@ -66,10 +66,10 @@
 
     <!-- export csv/pdf -->
     <div class="four cell">
-        <button class="right-magnet forbidden" disabled data-ng-click="vm.exportPdf()">
+        <button class="right-magnet" data-ng-click="vm.export(vm.exportType.PDF)">
             <i18n>presences.export.topdf</i18n>
         </button>
-        <button class="right-magnet" data-ng-click="vm.exportCsv()">
+        <button class="right-magnet" data-ng-click="vm.export(vm.exportType.CSV)">
             <i18n>presences.export.tocsv</i18n>
         </button>
     </div>

--- a/presences/src/main/resources/public/ts/controllers/events.ts
+++ b/presences/src/main/resources/public/ts/controllers/events.ts
@@ -22,6 +22,7 @@ import {INFINITE_SCROLL_EVENTER} from '@common/core/enum/infinite-scroll-eventer
 import {ABSENCE_FORM_EVENTS, LATENESS_FORM_EVENTS} from '@common/core/enum/presences-event';
 import {SNIPLET_FORM_EMIT_EVENTS} from '@common/model';
 import {IEventSlot} from '@presences/models/Event';
+import {EXPORT_TYPE, ExportType} from "@common/core/enum/export-type.enum";
 
 declare let window: any;
 
@@ -228,9 +229,8 @@ interface ViewModel {
     adaptReason(): void;
 
     /* Export*/
-    exportPdf(): void;
-
-    exportCsv(): void;
+    exportType: typeof EXPORT_TYPE;
+    export(exportType: ExportType): void;
 }
 
 export const eventsController = ng.controller('EventsController', ['$scope', '$route', '$location', '$timeout',
@@ -311,6 +311,7 @@ export const eventsController = ng.controller('EventsController', ['$scope', '$r
 
         vm.structureTimeSlot = {} as IStructureSlot;
         vm.timeSlotHourPeriod = TimeSlotHourPeriod;
+        vm.exportType = EXPORT_TYPE;
 
         const loadFormFilter = async (): Promise<void> => {
             let formFilters = await Me.preference(PresencesPreferenceUtils.PREFERENCE_KEYS.PRESENCE_EVENT_LIST_FILTER);
@@ -1012,11 +1013,7 @@ export const eventsController = ng.controller('EventsController', ['$scope', '$r
         /* ----------------------------
           Export methods
         ---------------------------- */
-        vm.exportPdf = function () {
-            console.log("exporting Pdf");
-        };
-
-        vm.exportCsv = (): void => {
+        vm.export = (exportType: ExportType): void => {
             const filter: EventRequest = {
                 structureId: vm.events.structureId,
                 startDate: vm.events.startDate,
@@ -1030,7 +1027,7 @@ export const eventsController = ng.controller('EventsController', ['$scope', '$r
                 userId: vm.events.userId,
                 classes: vm.events.classes,
             };
-            window.open(eventService.exportCSV(filter));
+            window.open(eventService.export(filter, exportType));
         };
 
         /* ----------------------------

--- a/presences/src/main/resources/public/ts/services/EventService.ts
+++ b/presences/src/main/resources/public/ts/services/EventService.ts
@@ -3,6 +3,7 @@ import http, {AxiosResponse} from 'axios';
 import {ActionBody, EventResponse, Events, IEventBody, IStudentEventRequest, IStudentEventResponse} from '../models';
 import {DateUtils} from '@common/utils';
 import {EventAbsenceSummary} from '@presences/models/Event/EventAbsenceSummary';
+import {EXPORT_TYPE, ExportType} from "@common/core/enum/export-type.enum";
 
 export interface EventService {
     get(eventRequest: EventRequest): Promise<{ pageCount: number, events: EventResponse[], all: EventResponse[] }>;
@@ -13,7 +14,7 @@ export interface EventService {
 
     getStudentEvent(studentEventRequest: IStudentEventRequest): Promise<IStudentEventResponse>;
 
-    exportCSV(eventRequest: EventRequest): string;
+    export(eventRequest: EventRequest, exportType: ExportType): string;
 
     getAbsentsCounts(structureId: string): Promise<EventAbsenceSummary>;
 
@@ -136,11 +137,12 @@ export const eventService: EventService = {
         }
     },
 
-    exportCSV(eventRequest: EventRequest): string {
+    export(eventRequest: EventRequest, exportType: ExportType): string {
         const dateFormat: string = DateUtils.FORMAT['YEAR-MONTH-DAY'];
 
         const url: string = `/presences/events/export`;
-        const structureId: string = `?structureId=${eventRequest.structureId}`;
+        const type: string = `?type=${EXPORT_TYPE[exportType]}`;
+        const structureId: string = `&structureId=${eventRequest.structureId}`;
         const startDate: string = `&startDate=${DateUtils.format(eventRequest.startDate, dateFormat)}`;
         const endDate: string = `&endDate=${DateUtils.format(eventRequest.endDate, dateFormat)}`;
         const noReason: string = eventRequest.noReason ? `&noReason=${eventRequest.noReason}` : "";
@@ -149,8 +151,9 @@ export const eventService: EventService = {
         const userId: string = eventRequest.userId.length === 0 ? "" : `&userId=${eventRequest.userId}`;
         const classes: string = eventRequest.classes.length === 0 ? "" : `&classes=${eventRequest.classes}`;
         const regularized: string = (eventRequest.regularized != null) ? `&regularized=${(eventRequest.regularized)}` : "";
+        const basedUrl: string = `${url}${type}${structureId}`;
 
-        return `${url}${structureId}${startDate}${endDate}${noReason}${eventType}${listReasonIds}${userId}${classes}${regularized}`;
+        return `${basedUrl}${startDate}${endDate}${noReason}${eventType}${listReasonIds}${userId}${classes}${regularized}`;
     },
 
 

--- a/presences/src/main/resources/template/pdf/event-list-recap.xhtml
+++ b/presences/src/main/resources/template/pdf/event-list-recap.xhtml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="fr" lang="fr">
+
+<head>
+    <title>{{#i18n}}presences.absence.recap{{/i18n}}</title>
+    <style type="text/css">
+        .event {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-content: center;
+            margin-bottom: 8px;
+        }
+        .title {
+            background: #fff;
+            box-shadow: 0 4px 6px rgb(0 0 0 / 12%);
+            border-bottom: none;
+            margin-bottom: 8px;
+            padding: 4px;
+            align-self: center;
+        }
+        table{border-collapse:collapse}
+        table thead tr {
+            background:#fff;box-shadow:0 4px 6px rgba(0,0,0,.12);
+            border-bottom:none
+        }
+        td {
+            padding:5px 15px
+        }
+        tr {
+            border-bottom:1px solid #ccc;background:0 0
+        }
+    </style>
+
+</head>
+
+<body>
+    <!-- Absence event area -->
+    {{#ABSENCE}}
+    {{#-first}}
+    <div class="event">
+        <span class="title">{{#i18n}}presences.register.event_type.absences{{/i18n}}</span>
+        <table>
+            <!-- header -->
+            <thead>
+            <tr>
+                <td>{{#i18n}}presences.csv.header.student.firstName{{/i18n}}</td>
+                <td>{{#i18n}}presences.csv.header.student.lastName{{/i18n}}</td>
+                <td>{{#i18n}}presences.csv.header.student.className{{/i18n}}</td>
+                <td style="width: 15%;">{{#i18n}}presences.presences.csv.header.date{{/i18n}}</td>
+                <td style="width: 15%;">{{#i18n}}presences.hour{{/i18n}}</td>
+                <td style="width: 15%;">{{#i18n}}presences.registry.csv.header.motive{{/i18n}}</td>
+                <td>{{#i18n}}presences.widgets.absences.regularized{{/i18n}}</td>
+            </tr>
+            </thead>
+
+            <!-- content -->
+            <tbody>
+
+            <!-- dynamic value -->
+            {{#ABSENCE}}
+            <tr>
+                <td>{{student.firstName}}</td>
+                <td>{{student.lastName}}</td>
+                <td>{{student.classeName}}</td>
+                <td style="width: 15%;">{{date}}</td>
+                <td style="width: 15%;">{{display_start_date}} - {{display_end_date}}</td>
+                <td>{{reason}}</td>
+                <td>{{regularized}}</td>
+            </tr>
+            {{/ABSENCE}}
+            </tbody>
+        </table>
+    </div>
+    {{/-first}}
+    {{/ABSENCE}}
+
+    <!-- Lateness event area -->
+    {{#LATENESS}}
+    {{#-first}}
+    <div class="event">
+        <span class="title">{{#i18n}}presences.register.event_type.lateness{{/i18n}}</span>
+        <table>
+            <!-- header -->
+            <thead>
+            <tr>
+                <td>{{#i18n}}presences.csv.header.student.firstName{{/i18n}}</td>
+                <td>{{#i18n}}presences.csv.header.student.lastName{{/i18n}}</td>
+                <td>{{#i18n}}presences.csv.header.student.className{{/i18n}}</td>
+                <td>{{#i18n}}presences.presences.csv.header.date{{/i18n}}</td>
+                <td>{{#i18n}}presences.hour{{/i18n}}</td>
+            </tr>
+            </thead>
+
+            <!-- content -->
+            <tbody>
+
+            <!-- dynamic value -->
+            {{#LATENESS}}
+            <tr>
+                <td>{{student.firstName}}</td>
+                <td>{{student.lastName}}</td>
+                <td>{{student.classeName}}</td>
+                <td style="width: 15%;">{{date}}</td>
+                <td style="width: 15%;">{{display_start_date}} - {{display_end_date}}</td>
+                <td>{{reason}}</td>
+                <td>{{regularized}}</td>
+            </tr>
+            {{/LATENESS}}
+            </tbody>
+        </table>
+    </div>
+    {{/-first}}
+    {{/LATENESS}}
+
+    <!-- Departure event area -->
+    {{#DEPARTURE}}
+    {{#-first}}
+    <div class="event">
+        <span class="title">{{#i18n}}presences.register.event_type.departure{{/i18n}}</span>
+        <table>
+            <!-- header -->
+            <thead>
+            <tr>
+                <td>{{#i18n}}presences.csv.header.student.firstName{{/i18n}}</td>
+                <td>{{#i18n}}presences.csv.header.student.lastName{{/i18n}}</td>
+                <td>{{#i18n}}presences.csv.header.student.className{{/i18n}}</td>
+                <td>{{#i18n}}presences.presences.csv.header.date{{/i18n}}</td>
+                <td>{{#i18n}}presences.hour{{/i18n}}</td>
+            </tr>
+            </thead>
+
+            <!-- content -->
+            <tbody>
+
+            <!-- dynamic value -->
+            {{#DEPARTURE}}
+            <tr>
+                <td>{{student.firstName}}</td>
+                <td>{{student.lastName}}</td>
+                <td>{{student.classeName}}</td>
+                <td style="width: 15%;">{{date}}</td>
+                <td style="width: 15%;">{{display_start_date}} - {{display_end_date}}</td>
+            </tr>
+            {{/DEPARTURE}}
+            </tbody>
+        </table>
+    </div>
+    {{/-first}}
+    {{/DEPARTURE}}
+
+</body>
+
+</html>


### PR DESCRIPTION
Ajout du bouton export pdf dans la liste des événements.

Ce dev peut impacter : 

-  L'export CSV de la liste des événements (vérifier que cela fonctionne)
-  Quand on fait un publipostage avec le code [RECAPITULATIF] (vérifier le comportement des événements "factorisés")