### PR TITLE
fix(statistics): #MA-878: count monday of an ending excluded period a…

### DIFF
--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/impl/Global.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/impl/Global.java
@@ -289,7 +289,7 @@ public class Global extends Indicator {
     @SuppressWarnings("unchecked")
     private boolean hasPeriodNoMatch(JsonArray excludedPeriods, LocalDate date) {
         return ((List<JsonObject>) excludedPeriods.getList()).stream().noneMatch(period ->
-                DateHelper.isDateBetween(date + " " + DateHelper.DEFAULT_START_TIME,
+                DateHelper.isDateBetween(date + " " + DateHelper.DEFAULT_END_TIME,
                         period.getString(Field.START_DATE), period.getString(Field.END_DATE))
         );
     }


### PR DESCRIPTION
[Jira - MA-878](https://entsupport.gdapublic.fr/browse/MA-878)

Initialement, le test de validité ne tenait pas compte des heures de la période d'exclusion. C'est a dire que par défaut, on considérait la validité de la journée dès 00:00, or la journée est validé que lorsque l'on passe à la journée suivante (dans présence, à 23:59:59). Il suffisait donc juste de vérifier que si à 23:59 la journée est toujours contenu par la période d'exclusion, alors celle-ci est exclue.