### PR TITLE
feat(parent-dashboard): #MA-883 get events by parent students

### DIFF
--- a/common/src/main/java/fr/openent/presences/core/constants/Field.java
+++ b/common/src/main/java/fr/openent/presences/core/constants/Field.java
@@ -18,6 +18,8 @@ public class Field {
     public static final String MANUALGROUPS = "manualGroups";
     public static final String NAME = "name";
     public static final String OFFSET = "offset";
+    public static final String ALL = "all";
+    public static final String TOTALS = "totals";
     public static final String SEARCH_TEACHER = "searchTeacher";
     public static final String STRUCTURE = "structure";
     public static final String STRUCTURE_ID = "structure_id";
@@ -25,7 +27,9 @@ public class Field {
     public static final String STUDENT = "student";
     public static final String STUDENTS_CAPS = "STUDENTS";
     public static final String STUDENT_ID = "student_id";
+    public static final String STUDENT_IDS = "student_ids";
     public static final String STUDENTID = "studentId";
+    public static final String STUDENTS_EVENTS = "students_events";
     public static final String SUBJECT = "subject";
     public static final String SUBJECT_ID = "subject_id";
     public static final String SUBJECTID = "subjectId";
@@ -41,10 +45,12 @@ public class Field {
     // Dates
     public static final String END_DATE = "end_date";
     public static final String ENDDATE = "endDate";
+    public static final String END_AT = "end_at";
     public static final String DATE = "date";
     public static final String START_DATE = "start_date";
     public static final String STARTDATE = "startDate";
     public static final String START = "start";
+    public static final String START_AT = "start_at";
     public static final String END = "end";
     public static final String START_TIME = "startTime";
     public static final String END_TIME = "endTime";
@@ -103,6 +109,8 @@ public class Field {
     public static final String LOCKED = "locked";
     public static final String MANUAL = "manual";
     public static final String PUNISHMENTS = "punishments";
+    public static final String PROTAGONIST = "protagonist";
+    public static final String PROTAGONIST_TYPE_ID = "protagonist_type_id";
     public static final String REGISTER_ID = "register_id";
     public static final String REGISTER_STATE_ID = "register_state_id";
     public static final String ROOMLABELS = "roomLabels";
@@ -115,6 +123,7 @@ public class Field {
 
     // Alert
     public static final String TYPE = "type";
+    public static final String TYPES = "types";
     public static final String ALERT_ABSENCE_THRESHOLD = "alert_absence_threshold";
     public static final String ALERT_LATENESS_THRESHOLD = "alert_lateness_threshold";
     public static final String ALERT_INCIDENT_THRESHOLD = "alert_incident_threshold";

--- a/incidents/src/main/java/fr/openent/incidents/controller/StudentController.java
+++ b/incidents/src/main/java/fr/openent/incidents/controller/StudentController.java
@@ -1,20 +1,27 @@
 package fr.openent.incidents.controller;
 
 import fr.openent.incidents.security.StudentEventsViewRight;
+import fr.openent.incidents.security.StudentsEventsViewRight;
 import fr.openent.incidents.service.EventStudentService;
 import fr.openent.incidents.service.impl.DefaultEventStudentService;
+import fr.openent.presences.core.constants.Field;
 import fr.wseduc.rs.ApiDoc;
 import fr.wseduc.rs.Get;
+import fr.wseduc.rs.Post;
 import fr.wseduc.security.ActionType;
 import fr.wseduc.security.SecuredAction;
+import fr.wseduc.webutils.request.RequestUtils;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonArray;
 import org.entcore.common.controller.ControllerHelper;
 import org.entcore.common.http.filter.ResourceFilter;
 
+import java.util.List;
+
 public class StudentController extends ControllerHelper {
 
-    private EventStudentService eventStudentService;
+    private final EventStudentService eventStudentService;
 
     public StudentController(EventBus eb) {
         super();
@@ -26,13 +33,41 @@ public class StudentController extends ControllerHelper {
     @ResourceFilter(StudentEventsViewRight.class)
     @SecuredAction(value = "", type = ActionType.RESOURCE)
     public void getEventsStudent(HttpServerRequest request) {
-        eventStudentService.get(request.params(), result -> {
-            if (result.failed()) {
-                log.error(result.cause().getMessage());
-                renderError(request);
-                return;
-            }
-            renderJson(request, result.result());
+        String studentId = request.params().get(Field.ID);
+        String structureId = request.params().get(Field.STRUCTURE_ID);
+        String limit = request.params().get(Field.LIMIT);
+        String offset = request.params().get(Field.OFFSET);
+        String start = request.params().get(Field.START_AT);
+        String end = request.params().get(Field.END_AT);
+        List<String> types = request.params().getAll(Field.TYPE);
+        eventStudentService.get(structureId, studentId, types, start, end, limit, offset)
+                .onSuccess(result -> renderJson(request, result))
+                .onFailure(error -> {
+                    log.error(error.getMessage());
+                    renderError(request);
+                });
+    }
+
+    @Post("/structures/:structureId/students/events")
+    @ApiDoc("get events by types for a student")
+    @ResourceFilter(StudentsEventsViewRight.class)
+    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @SuppressWarnings("unchecked")
+    public void getEventsStudents(HttpServerRequest request) {
+        RequestUtils.bodyToJson(request, pathPrefix + "studentsEvents", body -> {
+            String structureId = request.getParam(Field.STRUCTUREID);
+            List<String> studentIds = body.getJsonArray(Field.STUDENT_IDS, new JsonArray()).getList();
+            String limit = body.getString(Field.LIMIT);
+            String offset = body.getString(Field.OFFSET);
+            String start = body.getString(Field.START_AT);
+            String end = body.getString(Field.END_AT);
+            List<String> types = body.getJsonArray(Field.TYPES, new JsonArray()).getList();
+            eventStudentService.get(structureId, studentIds, types, start, end, limit, offset)
+                    .onSuccess(result -> renderJson(request, result))
+                    .onFailure(error -> {
+                        log.error(error.getMessage());
+                        renderError(request);
+                    });
         });
     }
 }

--- a/incidents/src/main/java/fr/openent/incidents/helper/PunishmentHelper.java
+++ b/incidents/src/main/java/fr/openent/incidents/helper/PunishmentHelper.java
@@ -56,7 +56,7 @@ public class PunishmentHelper {
                          Handler<AsyncResult<JsonObject>> handler) {
         JsonObject query = new JsonObject().put("structure_id", structureId);
 
-        if (!isStudent && (!WorkflowHelper.hasRight(user, WorkflowActions.PUNISHMENTS_VIEW.toString()) || !WorkflowHelper.hasRight(user, WorkflowActions.SANCTIONS_VIEW.toString()))) {
+        if (!isStudent && user != null && (!WorkflowHelper.hasRight(user, WorkflowActions.PUNISHMENTS_VIEW.toString()) || !WorkflowHelper.hasRight(user, WorkflowActions.SANCTIONS_VIEW.toString()))) {
             query.put("owner_id", user.getUserId());
         }
 

--- a/incidents/src/main/java/fr/openent/incidents/security/StudentsEventsViewRight.java
+++ b/incidents/src/main/java/fr/openent/incidents/security/StudentsEventsViewRight.java
@@ -1,0 +1,30 @@
+package fr.openent.incidents.security;
+
+import fr.openent.incidents.enums.WorkflowActions;
+import fr.openent.presences.common.helper.WorkflowHelper;
+import fr.openent.presences.core.constants.Field;
+import fr.wseduc.webutils.http.Binding;
+import fr.wseduc.webutils.request.RequestUtils;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonArray;
+import org.entcore.common.http.filter.ResourcesProvider;
+import org.entcore.common.user.UserInfos;
+
+import java.util.List;
+
+public class StudentsEventsViewRight implements ResourcesProvider {
+    @Override
+    @SuppressWarnings("unchecked")
+    public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
+        request.pause();
+        RequestUtils.bodyToJson(request, body -> {
+            request.resume();
+            List<String> studentIds = body.getJsonArray(Field.STUDENT_IDS, new JsonArray()).getList();
+            handler.handle(
+                    WorkflowHelper.hasRight(user, WorkflowActions.STUDENT_EVENTS_VIEW.toString()) &&
+                            !studentIds.isEmpty() && user.getChildrenIds().containsAll(studentIds)
+            );
+        });
+    }
+}

--- a/incidents/src/main/java/fr/openent/incidents/service/EventStudentService.java
+++ b/incidents/src/main/java/fr/openent/incidents/service/EventStudentService.java
@@ -1,17 +1,16 @@
 package fr.openent.incidents.service;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
+import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
+
+import java.util.List;
 
 public interface EventStudentService {
 
     /**
      * Get events for dashboard parent
-     *
-     * @param body              data to filter
-     * @param handler           Function handler returning data
      */
-    void get(MultiMap body, Handler<AsyncResult<JsonObject>> handler);
+    Future<JsonObject> get(String structureId, String studentId, List<String> types, String start, String end, String limit, String offset);
+
+    Future<JsonObject> get(String structureId, List<String> studentIds, List<String> types, String startAt, String endAt, String limit, String offset);
 }

--- a/incidents/src/main/java/fr/openent/incidents/service/IncidentsService.java
+++ b/incidents/src/main/java/fr/openent/incidents/service/IncidentsService.java
@@ -1,6 +1,7 @@
 package fr.openent.incidents.service;
 
 import fr.wseduc.webutils.Either;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -43,6 +44,10 @@ public interface IncidentsService {
      * @param handler   Function handler returning data
      */
     void get(String startDate, String endDate, List<String> users, Handler<Either<String, JsonArray>> handler);
+
+    Future<JsonArray> get(String structureId, String startDate, String endDate, List<String> studentIds, String limit, String offset);
+
+    Future<JsonArray> countByStudents(String structureId, String startDate, String endDate, List<String> studentIds);
 
     /**
      * Get Incidents count

--- a/incidents/src/main/java/fr/openent/incidents/service/PunishmentService.java
+++ b/incidents/src/main/java/fr/openent/incidents/service/PunishmentService.java
@@ -22,19 +22,20 @@ public interface PunishmentService {
      * @param handler   Function handler returning data
      */
     void get(UserInfos user, MultiMap body, boolean isStudent, Handler<AsyncResult<JsonObject>> handler);
+
     void get(UserInfos user, String id, String structureId, String startAt, String endAt, List<String> studentIds, List<String> groupIds,
-        List<String> typeIds, List<String> processStates, boolean isStudent, String pageString, String limitString, String offsetString,
-        Handler<AsyncResult<JsonObject>> handler);
+             List<String> typeIds, List<String> processStates, boolean isStudent, String pageString, String limitString, String offsetString,
+             Handler<AsyncResult<JsonObject>> handler);
 
     /**
      * get Sanctions/Punishments by students
      *
      * @param structure  structure identifier
-     * @param startAt   start date
-     * @param endAt     end date
+     * @param startAt    start date
+     * @param endAt      end date
      * @param students   List of students
      * @param typeIds    List of punishment type
-     * @param  eventType Punishment event type ("SANCTION"/ "PUNISHMENT")
+     * @param eventType  Punishment event type ("SANCTION"/ "PUNISHMENT")
      * @param processed  filter processed
      * @param massmailed filter massmailed
      * @param handler    Function handler returning data
@@ -46,8 +47,8 @@ public interface PunishmentService {
      * get Punishments/Sanctions COUNT By students
      *
      * @param structure  structure identifier
-     * @param startAt   start date
-     * @param endAt     end date
+     * @param startAt    start date
+     * @param endAt      end date
      * @param students   List of students
      * @param typeIds    List of punishment type
      * @param processed  filter processed
@@ -77,38 +78,42 @@ public interface PunishmentService {
      */
     void count(UserInfos user, MultiMap body, boolean isStudent, Handler<AsyncResult<Long>> handler);
 
+
+    void count(UserInfos user, String structureId, String startAt, String endAt, List<String> studentIds,
+               List<String> groupIds, List<String> typeIds, List<String> processStates, boolean isStudent, Handler<AsyncResult<Long>> handler);
+
     /**
      * create punishment
      *
-     * @param user               current user logged
-     * @param body               data to store
-     * @param handler            Function handler returning data
+     * @param user    current user logged
+     * @param body    data to store
+     * @param handler Function handler returning data
      */
     void create(UserInfos user, JsonObject body, Handler<AsyncResult<JsonArray>> handler);
 
     /**
      * put punishment
      *
-     * @param user               current user logged
-     * @param body               data to update
-     * @param handler            Function handler returning data
+     * @param user    current user logged
+     * @param body    data to update
+     * @param handler Function handler returning data
      */
     void update(UserInfos user, JsonObject body, Handler<AsyncResult<JsonObject>> handler);
 
     /**
      * delete punishment
      *
-     * @param body             data containing id to delete
-     * @param handler          Function handler returning data
+     * @param body    data containing id to delete
+     * @param handler Function handler returning data
      */
     void delete(UserInfos user, MultiMap body, Handler<AsyncResult<JsonObject>> handler);
 
     /**
      * get absences by students
      *
-     * @param studentIds    student list identifiers
-     * @param starDate      start period to get
-     * @param endDate       end period to get
+     * @param studentIds student list identifiers
+     * @param starDate   start period to get
+     * @param endDate    end period to get
      */
     void getAbsencesByStudentIds(List<String> studentIds, String starDate, String endDate, Handler<AsyncResult<Map<String, List<JsonObject>>>> handler);
 }

--- a/incidents/src/main/java/fr/openent/incidents/service/impl/DefaultEventStudentService.java
+++ b/incidents/src/main/java/fr/openent/incidents/service/impl/DefaultEventStudentService.java
@@ -2,16 +2,16 @@ package fr.openent.incidents.service.impl;
 
 import fr.openent.incidents.service.*;
 import fr.openent.presences.common.helper.FutureHelper;
-import fr.wseduc.webutils.Either;
+import fr.openent.presences.core.constants.Field;
 import io.vertx.core.*;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import org.entcore.common.user.UserInfos;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 
 public class DefaultEventStudentService implements EventStudentService {
@@ -33,102 +33,136 @@ public class DefaultEventStudentService implements EventStudentService {
     }
 
     @Override
-    public void get(MultiMap body, Handler<AsyncResult<JsonObject>> handler) {
-        String student = body.get("id");
-        String structure = body.get("structure_id");
-        String limit = body.get("limit");
-        String offset = body.get("offset");
-        String start = body.get("start_at");
-        String end = body.get("end_at");
-        List<String> types = body.getAll("type");
-        body.set("id", (String) null);
-
-        if (!validTypes(types)) {
-            String message = "[Presences@DefaultEventStudentService::get] Types are not valid.";
-            handler.handle(Future.failedFuture(message));
-            return;
-        }
-
-        Future<JsonArray> protagonistsFuture = Future.future();
-        Future<JsonArray> typesFuture = Future.future();
-
-        // Get incident types to map it thanks type_id on incident events results
-        incidentsTypeService.get(structure, typesResult -> {
-            if (typesResult.isLeft()) {
-                String message = ("[Presences@DefaultEventStudentService::get] Fail to retrieve incidents types.");
-                typesFuture.fail(message + " " + typesResult.left().getValue());
-                return;
-            }
-
-            typesFuture.complete(typesResult.right().getValue());
-        });
-
-        // Get protagonist types to map it thanks protagonist_type_id on incident events results
-        protagonistTypeService.get(structure, protagonistResult -> {
-            if (protagonistResult.isLeft()) {
-                String message = "[Presences@DefaultEventStudentService::get] Fail to retrieve protagonist types.";
-                protagonistsFuture.fail(message + " " + protagonistResult.left().getValue());
-                return;
-            }
-            protagonistsFuture.complete(protagonistResult.right().getValue());
-        });
-
-        CompositeFuture.all(protagonistsFuture, typesFuture).setHandler(incidentSettingsResult -> {
-            if (incidentSettingsResult.failed()) {
-                log.error(incidentSettingsResult.cause().getMessage());
-                handler.handle(Future.failedFuture(incidentSettingsResult.cause().getMessage()));
-                return;
-            }
-
-            // Maps are easier to manipulate to retrieve one occurrence by id.
-            Map<Integer, JsonObject> protagonists = new HashMap<>();
-            for (Object o : protagonistsFuture.result()) {
-                JsonObject protagonist = (JsonObject) o;
-                protagonists.put(protagonist.getInteger("id"), protagonist);
-            }
-
-            Map<Integer, JsonObject> incidentTypes = new HashMap<>();
-            for (Object o : typesFuture.result()) {
-                JsonObject type = (JsonObject) o;
-                incidentTypes.put(type.getInteger("id"), type);
-            }
-
-            getSortedEventsByTypes(body, types, structure, student, protagonists, incidentTypes, start, end, limit, offset, false, result -> {
-                if (result.failed()) {
-                    handler.handle(Future.failedFuture(result.cause()));
-                    return;
-                }
-
-                Future<JsonObject> future = Future.future();
-                if (limit == null && offset == null) { // If we get all result, we just need to get array size to get total results
-                    future.complete(getTotalsByTypes(types, false, result.result()));
-                } else { // Else, we use same queries with a count result
-                    getSortedEventsByTypes(body, types, structure, student, protagonists, incidentTypes, start, end, null, null,
-                            true, resultAllEvents -> {
-                                if (resultAllEvents.failed()) {
-                                    handler.handle(Future.failedFuture(resultAllEvents.cause()));
-                                    return;
-                                }
-                                future.complete(getTotalsByTypes(types, true, resultAllEvents.result()));
-                            });
-                }
-
-                CompositeFuture.all(Collections.singletonList(future)).setHandler(resultTotals -> {
-                    if (resultTotals.failed()) {
-                        String message = "[Presences@DefaultEventStudentService::get] Failed to get totals from events.";
-                        handler.handle(Future.failedFuture(message + " " + resultTotals.cause()));
-                        return;
-                    }
-
-                    JsonObject response = new JsonObject()
-                            .put("limit", limit)
-                            .put("offset", offset)
-                            .put("all", result.result())
-                            .put("totals", future.result());
-                    handler.handle(Future.succeededFuture(response));
+    public Future<JsonObject> get(String structureId, String studentId, List<String> types, String startAt, String endAt, String limit, String offset) {
+        Promise<JsonObject> promise = Promise.promise();
+        Map<Integer, JsonObject> protagonists = new HashMap<>();
+        Map<Integer, JsonObject> incidentTypes = new HashMap<>();
+        setProtagonistsAndIncidentTypes(structureId, protagonists, incidentTypes)
+                .compose(res -> getEventsData(types, structureId, Collections.singletonList(studentId), protagonists, incidentTypes, startAt, endAt, limit, offset))
+                .onFailure(promise::fail)
+                .onSuccess(result -> {
+                    JsonObject response = result.get(studentId)
+                            .put(Field.LIMIT, limit)
+                            .put(Field.OFFSET, offset);
+                    promise.complete(response);
                 });
-            });
+        return promise.future();
+    }
+
+    @Override
+    public Future<JsonObject> get(String structureId, List<String> studentIds, List<String> types, String startAt, String endAt, String limit, String offset) {
+        Promise<JsonObject> promise = Promise.promise();
+        Map<Integer, JsonObject> protagonists = new HashMap<>();
+        Map<Integer, JsonObject> incidentTypes = new HashMap<>();
+        setProtagonistsAndIncidentTypes(structureId, protagonists, incidentTypes)
+                .compose(res -> getEventsData(types, structureId, studentIds, protagonists, incidentTypes, startAt, endAt, limit, offset))
+                .onFailure(promise::fail)
+                .onSuccess(result -> {
+                    JsonObject response = new JsonObject()
+                            .put(Field.LIMIT, limit)
+                            .put(Field.OFFSET, offset)
+                            .put(Field.STUDENTS_EVENTS, result);
+                    promise.complete(response);
+                });
+        return promise.future();
+    }
+
+
+    public Future<Void> setProtagonistsAndIncidentTypes(String structureId, Map<Integer, JsonObject> protagonists,
+                                                        Map<Integer, JsonObject> incidentTypes) {
+        Promise<Void> promise = Promise.promise();
+
+        Future<Map<Integer, JsonObject>> protagonistsFuture = getProtagonists(structureId);
+        Future<Map<Integer, JsonObject>> typesFuture = getIncidentTypes(structureId);
+        CompositeFuture.all(protagonistsFuture, typesFuture)
+                .onSuccess(result -> {
+                    protagonists.putAll(protagonistsFuture.result());
+                    incidentTypes.putAll(typesFuture.result());
+                    promise.complete();
+                })
+                .onFailure(error -> {
+                    String message =
+                            String.format("[Incidents@%s::setProtagonistsAndIncidentTypes] Fail to get protagonist data.",
+                                    this.getClass().getSimpleName());
+                    log.error(String.format("%s %s", message, error.getMessage()));
+                    promise.fail(error);
+                });
+
+        return promise.future();
+    }
+
+    @SuppressWarnings("unchecked")
+    public Future<Map<Integer, JsonObject>> getIncidentTypes(String structureId) {
+        Promise<Map<Integer, JsonObject>> promise = Promise.promise();
+        incidentsTypeService.get(structureId, typesResult -> {
+            if (typesResult.isLeft()) {
+                String message =
+                        String.format("[Incidents@%s::getIncidentTypes] Fail to retrieve incidents types.",
+                                this.getClass().getSimpleName());
+                log.error(String.format("%s %s", message, typesResult.left().getValue()));
+                promise.fail(message);
+                return;
+            }
+            promise.complete(
+                    ((List<JsonObject>) typesResult.right().getValue().getList()).stream()
+                            .collect(Collectors.toMap(type -> type.getInteger(Field.ID), type -> type))
+            );
         });
+        return promise.future();
+    }
+
+    @SuppressWarnings("unchecked")
+    public Future<Map<Integer, JsonObject>> getProtagonists(String structureId) {
+        Promise<Map<Integer, JsonObject>> promise = Promise.promise();
+
+        protagonistTypeService.get(structureId, protagonistResult -> {
+            if (protagonistResult.isLeft()) {
+                String message =
+                        String.format("[Incidents@%s::getProtagonists] Fail to retrieve protagonist types.",
+                                this.getClass().getSimpleName());
+                log.error(String.format("%s %s", message, protagonistResult.left().getValue()));
+                promise.fail(message);
+                return;
+            }
+
+            promise.complete(
+                    ((List<JsonObject>) protagonistResult.right().getValue().getList()).stream()
+                            .collect(Collectors.toMap(protagonist -> protagonist.getInteger(Field.ID), protagonist -> protagonist))
+            );
+        });
+
+        return promise.future();
+    }
+
+    private Future<Map<String, JsonObject>> getEventsData(List<String> types, String structureId, List<String> studentIds,
+                                                          Map<Integer, JsonObject> protagonists, Map<Integer, JsonObject> incidentTypes,
+                                                          String start, String end, String limit, String offset) {
+        Promise<Map<String, JsonObject>> promise = Promise.promise();
+
+        Map<String, JsonObject> studentsEvents = studentIds.stream()
+                .collect(Collectors.toMap(
+                        studentId -> studentId,
+                        studentId -> new JsonObject()
+                                .put(Field.ALL, new JsonObject(types.stream().collect(Collectors.toMap(type -> type, type -> new JsonArray()))))
+                                .put(Field.TOTALS, new JsonObject(types.stream().collect(Collectors.toMap(type -> type, type -> 0))))
+                ));
+
+
+        Future<Map<String, JsonObject>> eventsCountFuture = getCountEvents(types, structureId, studentIds, start, end, studentsEvents);
+        Future<Map<String, JsonObject>> eventsFuture = getEvents(types, structureId, studentIds, protagonists, incidentTypes, start,
+                end, limit, offset, studentsEvents);
+
+        CompositeFuture.all(eventsCountFuture, eventsFuture)
+                .onSuccess(result -> promise.complete(studentsEvents))
+                .onFailure(error -> {
+                    String message =
+                            String.format("[Incidents@%s::getEventsData] Fail to get events or totals events.",
+                                    this.getClass().getSimpleName());
+                    log.error(String.format("%s %s", message, error.getMessage()));
+                    promise.fail(message);
+                });
+
+        return promise.future();
     }
 
     // check if types are in {{ INCIDENT / PUNISHMENT }}
@@ -151,104 +185,144 @@ public class DefaultEventStudentService implements EventStudentService {
     // Send request to get each events (thanks the great method corresponding to type {{ INCIDENT / PUNISHMENT }}).
     // Handler will return them mapped by type (with the great protagonist for punishment, and great incident type for incident).
     // If isCountGetter,  result will (still by type) will be the total of date.
-    private void getSortedEventsByTypes(MultiMap body, List<String> types, String structure, String student, Map protagonists,
-                                        Map incidentTypes, String start, String end, String limit, String offset,
-                                        Boolean isCountGetter, Handler<AsyncResult<JsonObject>> handler) {
-        List<Future> futures = new ArrayList<>();
-        for (String type : types) {
-            Future<JsonArray> future = Future.future();
-            futures.add(future);
+    private Future<Map<String, JsonObject>> getEvents(List<String> types, String structureId, List<String> studentIds, Map<Integer, JsonObject> protagonists,
+                                                      Map<Integer, JsonObject> incidentTypes, String start, String end, String limit, String offset,
+                                                      Map<String, JsonObject> studentsEvents) {
+        Promise<Map<String, JsonObject>> promise = Promise.promise();
+        List<Future<JsonArray>> futures = new ArrayList<>();
+        for (String type : types)
+            futures.add(getTypedEventsByStudent(type, structureId, studentIds, start, end, limit, offset));
 
-            if (isCountGetter && type.equals(PUNISHMENT)) { // When  isCountGetter, Punishments type have a specific method to get total result.
-                getCountPunishment(body, student, FutureHelper.handlerJsonArray(future));
-            } else {
-                getTypedEventsByStudent(body, type, structure, student, start, end, limit, offset, FutureHelper.handlerJsonArray(future));
-            }
-        }
+        FutureHelper.all(futures)
+                .onSuccess(result -> promise.complete(getSortedByTypesEventsFromFutures(types, protagonists, incidentTypes, futures, studentsEvents)))
+                .onFailure(error -> {
+                    String message =
+                            String.format("[Incidents@%s::getEvents] Fail to retrieve events info.",
+                                    this.getClass().getSimpleName());
+                    log.error(String.format("%s %s", message, error.getMessage()));
+                    promise.fail(message);
+                });
 
-        CompositeFuture.all(futures).setHandler(result -> {
-            if (result.failed()) {
-                String message = "[Presences@DefaultEventStudentService::getSortedEventsByTypes] Failed to retrieve events info.";
-                handler.handle(Future.failedFuture(message + " " + result.cause()));
-                return;
-            }
-            handler.handle(Future.succeededFuture(getSortedByTypesEventsFromFutures(types, protagonists, incidentTypes, futures)));
-        });
+        return promise.future();
+    }
+
+    private Future<Map<String, JsonObject>> getCountEvents(List<String> types, String structureId, List<String> studentIds,
+                                                           String start, String end, Map<String, JsonObject> studentsEvents) {
+        Promise<Map<String, JsonObject>> promise = Promise.promise();
+        List<Future<JsonArray>> futures = new ArrayList<>();
+        for (String type : types)
+            futures.add(getCount(type, structureId, studentIds, start, end));
+
+        FutureHelper.all(futures)
+                .onSuccess(result -> promise.complete(setCountEventsByStudents(types, futures, studentsEvents)))
+                .onFailure(error -> {
+                    String message =
+                            String.format("[Incidents@%s::getCountEvents] Fail to count events.",
+                                    this.getClass().getSimpleName());
+                    log.error(String.format("%s %s", message, error.getMessage()));
+                    promise.fail(message);
+                });
+
+        return promise.future();
     }
 
     // Send Punishment request to get total result for a student (responding to each filters)
-    private void getCountPunishment(MultiMap body, String studentId, Handler<Either<String, JsonArray>> handler) {
-        body.add("limit", "");
-        body.add("offset", "");
-        UserInfos user = new UserInfos();
-        user.setUserId(studentId);
-        punishmentService.count(user, body, true, result -> {
-            if (result.failed()) {
-                handler.handle(new Either.Left<>(result.cause().getMessage()));
-            }
-            handler.handle(new Either.Right<>(new JsonArray().add(new JsonObject().put("count", result.result()))));
-        });
-    }
 
-    // Get events for a student, corresponding to the type mentioned
-    private void getTypedEventsByStudent(MultiMap body, String type, String structureId, String studentId, String start,
-                                         String end, String limit, String offset, Handler<Either<String, JsonArray>> handler) {
+    private Future<JsonArray> getCount(String type, String structureId, List<String> studentIds, String startAt, String endAt) {
+        Promise<JsonArray> promise = Promise.promise();
         switch (type) {
             case INCIDENT:
-                incidentsService.get(structureId, start, end, studentId, limit, offset, handler);
+                incidentsService.countByStudents(structureId, startAt, endAt, studentIds)
+                        .onFailure(promise::fail)
+                        .onSuccess(promise::complete);
                 break;
             case PUNISHMENT:
-                body.add("limit", limit != null ? limit : "");
-                body.add("offset", offset != null ? offset : "");
-                UserInfos user = new UserInfos();
-                user.setUserId(studentId);
-                punishmentService.get(user, body, true, result -> {
-                    if (result.failed()) {
-                        handler.handle(new Either.Left<>(result.cause().getMessage()));
-                    }
-                    handler.handle(new Either.Right<>(result.result().getJsonArray("all")));
-                });
+                punishmentService.getPunishmentCountByStudent(structureId, startAt, endAt, studentIds, Collections.emptyList(),
+                        null, null, FutureHelper.handlerJsonArray(promise));
                 break;
             default:
                 //There is no default case
                 String message = "There is no case for value: " + type + ".";
                 log.error(message);
-                handler.handle(new Either.Left<>(message));
+                promise.fail(message);
         }
+        return promise.future();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, JsonObject> setCountEventsByStudents(List<String> types, List<Future<JsonArray>> resultFutures,
+                                                             Map<String, JsonObject> studentsEvents) {
+        for (int i = 0; i < types.size(); i++) {
+            String type = types.get(i);
+            List<JsonObject> values = resultFutures.get(i).result().getList();
+            if (values.isEmpty()) continue;
+            for (JsonObject countType : values) {
+                JsonObject studentEvents = studentsEvents.get(countType.getString(Field.STUDENT_ID));
+                if (studentEvents != null && studentEvents.containsKey(Field.TOTALS))
+                    studentEvents.getJsonObject(Field.TOTALS).put(type, countType.getInteger(Field.COUNT));
+            }
+        }
+
+        return studentsEvents;
+
+    }
+
+    // Get events for a student, corresponding to the type mentioned
+    private Future<JsonArray> getTypedEventsByStudent(String type, String structureId, List<String> studentIds, String startAt,
+                                                      String endAt, String limit, String offset) {
+        Promise<JsonArray> promise = Promise.promise();
+        switch (type) {
+            case INCIDENT:
+                incidentsService.get(structureId, startAt, endAt, studentIds, limit, offset)
+                        .onFailure(promise::fail)
+                        .onSuccess(promise::complete);
+                break;
+            case PUNISHMENT:
+                punishmentService.get(null, null, structureId, startAt, endAt, studentIds, Collections.emptyList(),
+                        Collections.emptyList(), Collections.emptyList(), false, null, limit, offset, result -> {
+                            if (result.failed()) {
+                                promise.fail(result.cause().getMessage());
+                            }
+                            promise.complete(result.result().getJsonArray(Field.ALL));
+                        });
+                break;
+            default:
+                //There is no default case
+                String message =
+                        String.format("[Incidents@%s::getCountEvents] There is no case for value: %s.",
+                                this.getClass().getSimpleName(), type);
+                log.error(message);
+                promise.fail(message);
+        }
+        return promise.future();
     }
 
     //Map events result (resultFutures) by types {{ INCIDENT / PUNISHMENT }}
-    private JsonObject getSortedByTypesEventsFromFutures(List<String> types, Map protagonists, Map incidentTypes,
-                                                         List<Future> resultFutures) {
-        JsonObject sorted_events = new JsonObject();
+    @SuppressWarnings("unchecked")
+    private Map<String, JsonObject> getSortedByTypesEventsFromFutures(List<String> types, Map<Integer, JsonObject> protagonists,
+                                                                      Map<Integer, JsonObject> incidentTypes,
+                                                                      List<Future<JsonArray>> resultFutures,
+                                                                      Map<String, JsonObject> studentsEvents) {
         for (int i = 0; i < types.size(); i++) {
             String type = types.get(i);
-            sorted_events.put(type, new JsonArray());
-
-            JsonArray values = (JsonArray) resultFutures.get(i).result();
+            JsonArray values = resultFutures.get(i).result();
             if (values == null || values.isEmpty()) continue;
             ((List<JsonObject>) values.getList()).forEach(event -> {
-                event.put("protagonist", protagonists.get(event.getInteger("protagonist_type_id")));
+                JsonObject studentEvents;
+                event.put(Field.PROTAGONIST, protagonists.get(event.getInteger(Field.PROTAGONIST_TYPE_ID)));
                 if (type.equals(INCIDENT)) {
-                    event.put("type", incidentTypes.get(event.getInteger("type_id")));
-                }
-                sorted_events.getJsonArray(type).add(event);
+                    event.put(Field.TYPE, incidentTypes.get(event.getInteger(Field.TYPEID)));
+                    studentEvents = studentsEvents.get(event.getString(Field.STUDENT_ID, ""));
+                } else
+                    studentEvents = studentsEvents.get(event.getJsonObject(Field.STUDENT, new JsonObject()).getString(Field.ID, ""));
+
+
+                if (studentEvents != null && studentEvents.containsKey(Field.ALL))
+                    studentEvents.getJsonObject(Field.ALL).getJsonArray(type, new JsonArray()).add(event);
+
             });
         }
-        return sorted_events;
-    }
-
-    // Retrieve totals by types
-    private JsonObject getTotalsByTypes(List<String> types, Boolean isFromCountPunishment, JsonObject sorted_events) {
-        JsonObject totals = new JsonObject();
-        for (String type : types) {
-            if (isFromCountPunishment && type.equals(PUNISHMENT)) {
-                totals.put(type, sorted_events.getJsonArray(type).getJsonObject(0).getLong("count"));
-            } else {
-                totals.put(type, sorted_events.getJsonArray(type).size());
-            }
-        }
-        return totals;
+        return studentsEvents;
     }
 
 }

--- a/incidents/src/main/java/fr/openent/incidents/service/impl/DefaultPunishmentService.java
+++ b/incidents/src/main/java/fr/openent/incidents/service/impl/DefaultPunishmentService.java
@@ -604,6 +604,17 @@ public class DefaultPunishmentService implements PunishmentService {
             punishmentHelper.countPunishments(punishment.getTable(), result.result(), handler);
         });
     }
+    @Override
+    public void count(UserInfos user, String structureId, String startAt, String endAt, List<String> studentIds,
+                      List<String> groupIds, List<String> typeIds, List<String> processStates, boolean isStudent, Handler<AsyncResult<Long>> handler) {
+        punishmentHelper.getQuery(user, null, structureId, startAt, endAt, studentIds, groupIds, typeIds, processStates, isStudent, result -> {
+            if (result.failed()) {
+                handler.handle(Future.failedFuture(result.cause().getMessage()));
+                return;
+            }
+            punishmentHelper.countPunishments(punishment.getTable(), result.result(), handler);
+        });
+    }
 
     @Override
     public void delete(UserInfos user, MultiMap body, Handler<AsyncResult<JsonObject>> handler) {

--- a/incidents/src/main/resources/jsonschema/studentsEvents.json
+++ b/incidents/src/main/resources/jsonschema/studentsEvents.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "Students Events schema",
+  "properties": {
+    "student_ids": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "limit": {
+      "type": "string"
+    },
+    "offset": {
+      "type": "string"
+    },
+    "start_at": {
+      "type": "string"
+    },
+    "end_at": {
+      "type": "string"
+    },
+    "types": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string"
+          }
+        ]
+      }
+    }
+  },
+  "required": [
+    "student_ids"
+  ]
+}

--- a/presences/src/main/java/fr/openent/presences/controller/StudentController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/StudentController.java
@@ -1,19 +1,25 @@
 package fr.openent.presences.controller;
 
+import fr.openent.presences.core.constants.Field;
 import fr.openent.presences.security.StudentEventsViewRight;
+import fr.openent.presences.security.StudentsEventsViewRight;
 import fr.openent.presences.service.EventStudentService;
 import fr.openent.presences.service.impl.DefaultEventStudentService;
 import fr.wseduc.rs.*;
 import fr.wseduc.security.ActionType;
 import fr.wseduc.security.SecuredAction;
+import fr.wseduc.webutils.request.RequestUtils;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonArray;
 import org.entcore.common.controller.ControllerHelper;
 import org.entcore.common.http.filter.ResourceFilter;
 
+import java.util.List;
+
 public class StudentController extends ControllerHelper {
 
-    private EventStudentService eventStudentService;
+    private final EventStudentService eventStudentService;
 
     public StudentController(EventBus eb) {
         super();
@@ -25,13 +31,45 @@ public class StudentController extends ControllerHelper {
     @ResourceFilter(StudentEventsViewRight.class)
     @SecuredAction(value = "", type = ActionType.RESOURCE)
     public void getEventsStudent(HttpServerRequest request) {
-        eventStudentService.get(request.params(), result -> {
-            if (result.failed()) {
-                log.error(result.cause().getMessage());
-                renderError(request);
-                return;
-            }
-            renderJson(request, result.result());
+        String structureId = request.params().get(Field.STRUCTURE_ID);
+        String studentId = request.params().get(Field.ID);
+        String limit = request.params().get(Field.LIMIT);
+        String offset = request.params().get(Field.OFFSET);
+        String start = request.params().get(Field.START_AT);
+        String end = request.params().get(Field.END_AT);
+        List<String> types = request.params().getAll(Field.TYPE);
+
+
+        eventStudentService.get(structureId, studentId, types, start, end, limit, offset)
+                .onSuccess(result -> renderJson(request, result))
+                .onFailure(error -> {
+                    log.error(error.getMessage());
+                    renderError(request);
+                });
+    }
+
+    @Post("structures/:structureId/students/events")
+    @ApiDoc("get events by types for a student")
+    @ResourceFilter(StudentsEventsViewRight.class)
+    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @SuppressWarnings("unchecked")
+    public void getEventsStudents(HttpServerRequest request) {
+        RequestUtils.bodyToJson(request, pathPrefix + "studentsEvents", body -> {
+            String structureId = request.getParam(Field.STRUCTUREID);
+            List<String> studentIds = body.getJsonArray(Field.STUDENT_IDS, new JsonArray()).getList();
+            String limit = body.getString(Field.LIMIT);
+            String offset = body.getString(Field.OFFSET);
+            String start = body.getString(Field.START_AT);
+            String end = body.getString(Field.END_AT);
+            List<String> types = body.getJsonArray(Field.TYPES, new JsonArray()).getList();
+
+            eventStudentService.get(structureId, studentIds, types, start, end, limit, offset)
+                    .onSuccess(result -> renderJson(request, result))
+                    .onFailure(error -> {
+                        log.error(error.getMessage());
+                        renderError(request);
+                    });
         });
+
     }
 }

--- a/presences/src/main/java/fr/openent/presences/security/StudentsEventsViewRight.java
+++ b/presences/src/main/java/fr/openent/presences/security/StudentsEventsViewRight.java
@@ -1,0 +1,30 @@
+package fr.openent.presences.security;
+
+import fr.openent.presences.common.helper.WorkflowHelper;
+import fr.openent.presences.core.constants.Field;
+import fr.openent.presences.enums.WorkflowActions;
+import fr.wseduc.webutils.http.Binding;
+import fr.wseduc.webutils.request.RequestUtils;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonArray;
+import org.entcore.common.http.filter.ResourcesProvider;
+import org.entcore.common.user.UserInfos;
+
+import java.util.List;
+
+public class StudentsEventsViewRight implements ResourcesProvider {
+    @Override
+    @SuppressWarnings("unchecked")
+    public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
+        request.pause();
+        RequestUtils.bodyToJson(request, body -> {
+            request.resume();
+            List<String> studentIds = body.getJsonArray(Field.STUDENT_IDS, new JsonArray()).getList();
+            handler.handle(
+                    WorkflowHelper.hasRight(user, WorkflowActions.STUDENT_EVENTS_VIEW.toString()) &&
+                            !studentIds.isEmpty() && user.getChildrenIds().containsAll(studentIds)
+            );
+        });
+    }
+}

--- a/presences/src/main/java/fr/openent/presences/service/EventStudentService.java
+++ b/presences/src/main/java/fr/openent/presences/service/EventStudentService.java
@@ -1,12 +1,7 @@
 package fr.openent.presences.service;
 
-import fr.wseduc.webutils.Either;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
-import io.vertx.core.MultiMap;
-import io.vertx.core.json.JsonArray;
+import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
-import org.entcore.common.user.UserInfos;
 
 import java.util.List;
 
@@ -15,8 +10,16 @@ public interface EventStudentService {
     /**
      * Get events for dashboard parent
      *
-     * @param body              data to filter
-     * @param handler           Function handler returning data
+     * @param structureId structure identifier
+     * @param studentId   student identifier
+     * @param types       event types needed
+     * @param start       start date to get events
+     * @param end         end date to get events
+     * @param limit       data to filter
+     * @param offset      data to filter
+     * @return future returning data
      */
-    void get(MultiMap body, Handler<AsyncResult<JsonObject>> handler);
+    Future<JsonObject> get(String structureId, String studentId, List<String> types, String start, String end, String limit, String offset);
+
+    Future<JsonObject> get(String structureId, List<String> studentIds, List<String> types, String start, String end, String limit, String offset);
 }

--- a/presences/src/main/java/fr/openent/presences/service/NotebookService.java
+++ b/presences/src/main/java/fr/openent/presences/service/NotebookService.java
@@ -1,6 +1,7 @@
 package fr.openent.presences.service;
 
 import fr.wseduc.webutils.Either;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -22,15 +23,17 @@ public interface NotebookService {
     /**
      * Retrieve forgotten notebook from student based on student_id and date since filter is possible
      *
-     * @param studentId     student identifier
-     * @param startDate     beginning date to filter. Format is : YYYY-DD-MM
-     * @param endDate       end date to filter. Format is : YYYY-DD-MM
-     * @param limit         limit of occurrences.
-     * @param offset        offset to get occurrences.
-     * @param structureId   structure identifier
-     * @param handler       Function handler returning data. Returns a JsonArray
+     * @param studentId   student identifier
+     * @param startDate   beginning date to filter. Format is : YYYY-DD-MM
+     * @param endDate     end date to filter. Format is : YYYY-DD-MM
+     * @param limit       limit of occurrences.
+     * @param offset      offset to get occurrences.
+     * @param structureId structure identifier
+     * @return future returning data. Returns a JsonArray
      */
-    void studentGet(String studentId, String startDate, String endDate, String limit, String offset, String structureId, Handler<Either<String, JsonObject>> handler);
+    Future<JsonObject> studentGet(String studentId, String startDate, String endDate, String limit, String offset, String structureId);
+
+    Future<JsonObject> studentsGet(String structureId, List<String> studentIds, String startDate, String endDate, String limit, String offset);
 
     /**
      * Retrieve forgotten notebook based on a list of student_id and date

--- a/presences/src/main/java/fr/openent/presences/service/impl/DefaultEventStudentService.java
+++ b/presences/src/main/java/fr/openent/presences/service/impl/DefaultEventStudentService.java
@@ -1,13 +1,11 @@
 package fr.openent.presences.service.impl;
 
-import fr.openent.presences.common.helper.DateHelper;
 import fr.openent.presences.common.helper.EventsHelper;
 import fr.openent.presences.common.helper.FutureHelper;
+import fr.openent.presences.core.constants.Field;
 import fr.openent.presences.service.EventService;
 import fr.openent.presences.service.EventStudentService;
 import fr.openent.presences.service.ReasonService;
-import fr.openent.presences.service.SettingsService;
-import fr.wseduc.webutils.Either;
 import io.vertx.core.*;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.json.JsonArray;
@@ -15,7 +13,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
-import java.text.ParseException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -30,6 +27,7 @@ public class DefaultEventStudentService implements EventStudentService {
     private final String LATENESS = "LATENESS";
     private final String DEPARTURE = "DEPARTURE";
 
+    private final String MORNING = "MORNING";
     private final String HALF_DAY = "HALF_DAY";
     private final String HOUR = "HOUR";
     private final String DAY = "DAY";
@@ -38,7 +36,6 @@ public class DefaultEventStudentService implements EventStudentService {
 
     private final EventService eventService;
     private final ReasonService reasonService = new DefaultReasonService();
-    private final SettingsService settingsService = new DefaultSettingsService();
     private final EventBus eb;
 
     public DefaultEventStudentService(EventBus eventBus) {
@@ -48,138 +45,148 @@ public class DefaultEventStudentService implements EventStudentService {
     }
 
     @Override
-    public void get(MultiMap body, Handler<AsyncResult<JsonObject>> handler) {
-        String student = body.get("id");
-        String structure = body.get("structure_id");
-        String limit = body.get("limit");
-        String offset = body.get("offset");
-        String start = body.get("start_at");
-        String end = body.get("end_at");
-        List<String> types = body.getAll("type");
+    public Future<JsonObject> get(String structureId, String studentId, List<String> types, String start, String end, String limit, String offset) {
+        Promise<JsonObject> promise = Promise.promise();
+
+        JsonObject settings = new JsonObject();
+        Map<Integer, JsonObject> reasons = new HashMap<>();
+        setSettingsAndReasons(structureId, types, settings, reasons)
+                .compose(res -> getEventsData(types, structureId, Collections.singletonList(studentId), reasons, settings, start, end, limit, offset))
+                .onFailure(promise::fail)
+                .onSuccess(result -> {
+                    JsonObject response = result.get(studentId)
+                            .put(Field.LIMIT, limit)
+                            .put(Field.OFFSET, offset)
+                            .put(Field.RECOVERY_METHOD, settings.getString(Field.EVENT_RECOVERY_METHOD));
+                    promise.complete(response);
+                });
+
+        return promise.future();
+    }
+
+    @Override
+    public Future<JsonObject> get(String structureId, List<String> studentIds, List<String> types, String start, String end, String limit, String offset) {
+        Promise<JsonObject> promise = Promise.promise();
+
+        JsonObject settings = new JsonObject();
+        Map<Integer, JsonObject> reasons = new HashMap<>();
+        setSettingsAndReasons(structureId, types, settings, reasons)
+                .compose(res -> getEventsData(types, structureId, studentIds, reasons, settings, start, end, limit, offset))
+                .onFailure(promise::fail)
+                .onSuccess(result -> {
+                    JsonObject response = new JsonObject()
+                            .put(Field.LIMIT, limit)
+                            .put(Field.OFFSET, offset)
+                            .put(Field.STUDENTS_EVENTS, result)
+                            .put(Field.RECOVERY_METHOD, settings.getString(Field.EVENT_RECOVERY_METHOD));
+                    promise.complete(response);
+                });
+
+        return promise.future();
+    }
+
+    private Future<JsonObject> setSettingsAndReasons(String structureId, List<String> types,
+                                                     JsonObject settings, Map<Integer, JsonObject> reasons) {
+        Promise<JsonObject> promise = Promise.promise();
 
         if (!validTypes(types)) {
-            String message = "[Presences@DefaultEventStudentService::get] Types are not valid.";
-            handler.handle(Future.failedFuture(message));
-            return;
+            String message =
+                    String.format("[Presences@%s::setSettingsAndReasons] Types are not valid.",
+                            this.getClass().getSimpleName());
+            log.error(message);
+            promise.fail(message);
+            return promise.future();
         }
-
-        Future<Map<Integer, JsonObject>> reasonFuture = Future.future();
-        Future<JsonObject> viscoSettingsFuture = Future.future();
-        Future<JsonObject> settingsFuture = Future.future();
-        Future<JsonObject> timeSlotsFuture = Future.future();
-
-        CompositeFuture.all(reasonFuture, viscoSettingsFuture, settingsFuture, timeSlotsFuture).setHandler(settingsResult -> {
-            if (settingsResult.failed()) {
-                log.error(settingsResult.cause().getMessage());
-                handler.handle(Future.failedFuture(settingsResult.cause().getMessage()));
-                return;
-            }
-            Map<Integer, JsonObject> reasons = reasonFuture.result();
-            JsonObject settings = viscoSettingsFuture.result();
-            settings.mergeIn(settingsFuture.result());
-            settings.mergeIn(timeSlotsFuture.result());
-
-            getEvents(types, structure, student, reasons, settings, start, end, "HOUR", limit, offset, result -> {
-                if (result.failed()) {
-                    handler.handle(Future.failedFuture(result.cause()));
-                    return;
-                }
-
-                Future<JsonObject> future = Future.future();
-                getTotals(student, structure, limit, offset, start, end, types, reasons, settings, result, future);
-
-                future.setHandler(resultTotals -> {
-                    if (resultTotals.failed()) {
-                        String message = "[Presences@DefaultEventStudentService::get] Failed to get totals from events.";
-                        handler.handle(Future.failedFuture(message + " " + resultTotals.cause()));
-                        return;
-                    }
-
-                    JsonObject response = new JsonObject()
-                            .put("limit", limit)
-                            .put("offset", offset)
-                            .put("all", result.result())
-                            .put("totals", future.result())
-                            .put("recovery_method", settings.getString("event_recovery_method"));
-                    handler.handle(Future.succeededFuture(response));
-                });
-            });
-        });
 
         // Get reasons types to map it thanks reason_id on absences justified events results
-        getReasons(structure, reasonFuture);
+        Future<Map<Integer, JsonObject>> reasonFuture = getReasons(structureId);
         // Get viscolaire settings to get Half Day Date configured by the current structure
         //  (if absences events are configured by Half Days).
-        getHalfDay(structure, viscoSettingsFuture);
-        // Get presence settings to get recovery method (for absences events configuration retrieving)
-        getSettings(structure, settingsFuture);
+        Future<JsonObject> viscoSettingsFuture = getHalfDay(structureId);
         // Get timeSlots settings configured by the current structure, to configure absences events times
-        // (if they are retrieved by Hald Days or by Days)
-        getTimeSlots(structure, timeSlotsFuture);
+        // (if they are retrieved by Half Days or by Days)
+        Future<JsonObject> timeSlotsFuture = getTimeSlots(structureId);
+
+        CompositeFuture.all(reasonFuture, viscoSettingsFuture, timeSlotsFuture)
+                .onFailure(error -> {
+                    String message =
+                            String.format("[Presences@%s::setSettingsAndReasons] Fail to get settings.",
+                                    this.getClass().getSimpleName());
+                    log.error(String.format("%s %s", message, error.getMessage()));
+                    promise.fail(message);
+                })
+                .onSuccess(settingsResult -> {
+                    reasons.putAll(reasonFuture.result());
+                    settings.mergeIn(viscoSettingsFuture.result());
+                    settings.mergeIn(timeSlotsFuture.result());
+                    promise.complete(settings);
+                });
+        return promise.future();
     }
 
-    private void getTotals(String student, String structure, String limit, String offset, String start, String end,
-                           List<String> types, Map<Integer, JsonObject> reasons, JsonObject settings,
-                           AsyncResult<JsonObject> result, Future<JsonObject> future) {
-        if (limit == null && offset == null) { // If we get all result, we just need to get array size to get total results
-            future.complete(getTotalsByTypes(types, result.result()));
-        } else { // Else, we use same queries with a count result
-            getEvents(types, structure, student, reasons, settings, start, end, null, null, null, resultAllEvents -> {
-                if (resultAllEvents.failed()) {
-                    future.fail(resultAllEvents.cause());
-                    return;
-                }
-                future.complete(getTotalsByTypes(types, resultAllEvents.result()));
-            });
-        }
+    private Future<Map<String, JsonObject>> getEventsData(List<String> types, String structureId, List<String> studentIds, Map<Integer, JsonObject> reasons,
+                                                          JsonObject settings, String start, String end, String limit, String offset) {
+        Promise<Map<String, JsonObject>> promise = Promise.promise();
+
+        Map<String, JsonObject> studentsEvents = studentIds.stream()
+                .collect(Collectors.toMap(
+                        studentId -> studentId,
+                        studentId -> new JsonObject()
+                                .put(Field.ALL, new JsonObject(types.stream().collect(Collectors.toMap(type -> type, type -> new JsonArray()))))
+                                .put(Field.TOTALS, new JsonObject(types.stream().collect(Collectors.toMap(type -> type, type -> 0))))
+                ));
+
+
+        Future<Map<String, JsonObject>> eventsCountFuture = getCountEvents(types, structureId, studentIds, reasons, start,
+                end, studentsEvents);
+        Future<Map<String, JsonObject>> eventsFuture = getEvents(settings, types, structureId, studentIds, reasons, start,
+                end, limit, offset, studentsEvents);
+
+        CompositeFuture.all(eventsCountFuture, eventsFuture)
+                .onSuccess(result -> promise.complete(studentsEvents))
+                .onFailure(error -> {
+                    String message =
+                            String.format("[Presences@%s::getEventsData] Fail to get events or totals events.",
+                                    this.getClass().getSimpleName());
+                    log.error(String.format("%s %s", message, error.getMessage()));
+                    promise.fail(message);
+                });
+
+        return promise.future();
     }
 
-    private void getTimeSlots(String structure, Future<JsonObject> timeSlotsFuture) {
-        getTimeSlots(structure, timeslotsResult -> {
-            if (timeslotsResult.failed()) {
-                timeSlotsFuture.fail(timeslotsResult.cause().getMessage());
-                return;
-            }
-
-            timeSlotsFuture.complete(timeslotsResult.result());
-        });
+    private Future<JsonObject> getTimeSlots(String structure) {
+        Promise<JsonObject> promise = Promise.promise();
+        getTimeSlots(structure, promise);
+        return promise.future();
     }
 
-    private void getSettings(String structure, Future<JsonObject> settingsFuture) {
-        settingsService.retrieve(structure, settingsResult -> {
-            if (settingsResult.isLeft()) {
-                settingsFuture.fail(settingsResult.left().getValue());
-                return;
-            }
-            settingsFuture.complete(settingsResult.right().getValue());
-        });
+    private Future<JsonObject> getHalfDay(String structure) {
+        Promise<JsonObject> promise = Promise.promise();
+        getViscoSettings(structure, promise);
+        return promise.future();
     }
 
-    private void getHalfDay(String structure, Future<JsonObject> viscoSettingsFuture) {
-        getViscoSettings(structure, viscoResult -> {
-            if (viscoResult.failed()) {
-                viscoSettingsFuture.fail(viscoResult.cause().getMessage());
-                return;
-            }
-
-            viscoSettingsFuture.complete(viscoResult.result());
-        });
-    }
-
-    private void getReasons(String structure, Future<Map<Integer, JsonObject>> reasonFuture) {
+    private Future<Map<Integer, JsonObject>> getReasons(String structure) {
+        Promise<Map<Integer, JsonObject>> promise = Promise.promise();
         reasonService.fetchReason(structure, resultReason -> {
             if (resultReason.isLeft()) {
-                String message = "[Presences@DefaultEventStudentService::get] Failed to get structure absence reasons.";
-                reasonFuture.fail(message + " " + resultReason.left().getValue());
+                String message =
+                        String.format("[Presences@%s::getReasons] Fail to get structure absence reasons.",
+                                this.getClass().getSimpleName());
+                log.error(String.format("%s %s", message, resultReason.left().getValue()));
+                promise.fail(message);
                 return;
             }
             Map<Integer, JsonObject> reasons = new HashMap<>();
             for (Object o : resultReason.right().getValue()) {
                 JsonObject reason = (JsonObject) o;
-                reasons.put(reason.getInteger("id"), reason);
+                reasons.put(reason.getInteger(Field.ID), reason);
             }
-            reasonFuture.complete(reasons);
+            promise.complete(reasons);
         });
+
+        return promise.future();
     }
 
     // check if types are in {{ NO_REASON / UNREGULARIZED / REGULARIZED / LATENESS / DEPARTURE }}
@@ -234,165 +241,171 @@ public class DefaultEventStudentService implements EventStudentService {
         });
     }
 
-
     // Send request to get each events (thanks the great method corresponding to type {{ NO_REASON / UNREGULARIZED / REGULARIZED / LATENESS / DEPARTURE }}).
     // Handler will return them mapped by type.
-    private void getEvents(List<String> types, String structure, String student, Map<Integer, JsonObject> reasons, JsonObject settings,
-                           String start, String end, String recovery, String limit, String offset, Handler<AsyncResult<JsonObject>> handler) {
+    private Future<Map<String, JsonObject>> getEvents(JsonObject settings, List<String> types, String structure, List<String> studentIds, Map<Integer, JsonObject> reasons,
+                                                      String start, String end, String limit, String offset, Map<String, JsonObject> studentsEvents) {
+        Promise<Map<String, JsonObject>> promise = Promise.promise();
         List<Integer> reasonsIds = new ArrayList<>(reasons.keySet());
-        List<Future> futures = new ArrayList<>();
-        for (String type : types) {
-            Future<JsonArray> future = Future.future();
-            futures.add(future);
-            getEventsByStudent(type, structure, reasonsIds, student, start, end, recovery, limit, offset, FutureHelper.handlerJsonArray(future));
-        }
+        List<Future<JsonArray>> futures = new ArrayList<>();
+        for (String type : types)
+            futures.add(getEventsByStudent(type, structure, reasonsIds, studentIds, start, end, limit, offset));
 
-        CompositeFuture.all(futures).setHandler(result -> {
-            if (result.failed()) {
-                String message = "[Presences@DefaultEventStudentService::getEvents] Failed to retrieve events info.";
-                handler.handle(Future.failedFuture(message + " " + result.cause()));
-                return;
-            }
 
-            JsonObject sortedEvents = getEventsFromFutures(types, reasons, settings, recovery, futures, handler);
-            if (sortedEvents != null) {
-                handler.handle(Future.succeededFuture(sortedEvents));
-            }
-        });
+        FutureHelper.all(futures)
+                .onFailure(error -> {
+                    String message =
+                            String.format("[Presences@%s::getEvents] Fail to retrieve events info.",
+                                    this.getClass().getSimpleName());
+                    log.error(String.format("%s %s", message, error.getMessage()));
+                    promise.fail(message);
+                })
+                .onSuccess(result -> promise.complete(setEventsByStudents(types, reasons, settings, futures, studentsEvents)));
+
+        return promise.future();
+    }
+
+    private Future<Map<String, JsonObject>> getCountEvents(List<String> types, String structure, List<String> studentIds, Map<Integer, JsonObject> reasons,
+                                                           String start, String end, Map<String, JsonObject> studentsEvents) {
+        Promise<Map<String, JsonObject>> promise = Promise.promise();
+        List<Integer> reasonsIds = new ArrayList<>(reasons.keySet());
+        List<Future<JsonArray>> futures = new ArrayList<>();
+        for (String type : types)
+            futures.add(getCountEventsByStudent(type, structure, reasonsIds, studentIds, start, end));
+
+        FutureHelper.all(futures)
+                .onFailure(error -> {
+                    String message =
+                            String.format("[Presences@%s::getCountEvents] Fail to retrieve count events info.",
+                                    this.getClass().getSimpleName());
+                    log.error(String.format("%s %s", message, error.getMessage()));
+                    promise.fail(message);
+                })
+                .onSuccess(result -> promise.complete(setCountEventsByStudents(types, futures, studentsEvents)));
+
+        return promise.future();
     }
 
     // Get events for a student, corresponding to the type mentioned
-    private void getEventsByStudent(String type, String structureId, List<Integer> reasonsIds, String studentId, String start, String end,
-                                    String recovery, String limit, String offset, Handler<Either<String, JsonArray>> handler) {
+    private Future<JsonArray> getEventsByStudent(String type, String structureId, List<Integer> reasonsIds, List<String> studentIds, String start, String end,
+                                                 String limit, String offset) {
+        Promise<JsonArray> promise = Promise.promise();
         switch (type) {
             case NO_REASON:
-                eventService.getEventsByStudent(1, Collections.singletonList(studentId), structureId, null,
-                        new ArrayList<>(), null, start, end, true, recovery, false, handler);
+                eventService.getEventsByStudent(1, studentIds, structureId, null,
+                        new ArrayList<>(), null, start, end, true, HOUR, false,
+                        FutureHelper.handlerJsonArray(promise));
                 break;
             case UNREGULARIZED:
-                eventService.getEventsByStudent(1, Collections.singletonList(studentId), structureId, null,
-                        reasonsIds, null, start, end, false, recovery, false, handler);
+                eventService.getEventsByStudent(1, studentIds, structureId, null,
+                        reasonsIds, null, start, end, false, HOUR, false,
+                        FutureHelper.handlerJsonArray(promise));
                 break;
             case REGULARIZED:
-                eventService.getEventsByStudent(1, Collections.singletonList(studentId), structureId, null,
-                        reasonsIds, null, start, end, false, recovery, true, handler);
+                eventService.getEventsByStudent(1, studentIds, structureId, null,
+                        reasonsIds, null, start, end, false, HOUR, true,
+                        FutureHelper.handlerJsonArray(promise));
                 break;
             case LATENESS:
-                eventService.getEventsByStudent(2, Collections.singletonList(studentId), structureId,
+                eventService.getEventsByStudent(2, studentIds, structureId,
                         null, new ArrayList<>(), null, start, end, true, null,
-                        limit, offset, null, handler);
+                        limit, offset, null, FutureHelper.handlerJsonArray(promise));
                 break;
             case DEPARTURE:
-                eventService.getEventsByStudent(3, Collections.singletonList(studentId), structureId,
+                eventService.getEventsByStudent(3, studentIds, structureId,
                         null, new ArrayList<>(), null, start, end, true, null,
-                        limit, offset, null, handler);
+                        limit, offset, null, FutureHelper.handlerJsonArray(promise));
                 break;
             default:
                 //There is no default case
-                String message = "There is no case for value: " + type + ".";
+                String message =
+                        String.format("[Presences@%s::getEventsByStudent] There is no case for value: %s.",
+                                this.getClass().getSimpleName(), type);
                 log.error(message);
-                handler.handle(new Either.Left<>(message));
+                promise.fail(message);
         }
+        return promise.future();
+    }
+
+    private Future<JsonArray> getCountEventsByStudent(String type, String structureId, List<Integer> reasonsIds, List<String> studentIds, String start, String end) {
+        Promise<JsonArray> promise = Promise.promise();
+        switch (type) {
+            case NO_REASON:
+                eventService.getCountEventByStudent(1, studentIds, structureId, null, 0,
+                        new ArrayList<>(), null, start, end, true, null, false, FutureHelper.handlerJsonArray(promise));
+                break;
+            case UNREGULARIZED:
+                eventService.getCountEventByStudent(1, studentIds, structureId, null, 0,
+                        reasonsIds, null, start, end, false, null, false, FutureHelper.handlerJsonArray(promise));
+                break;
+            case REGULARIZED:
+                eventService.getCountEventByStudent(1, studentIds, structureId, null, 0,
+                        reasonsIds, null, start, end, false, null, true, FutureHelper.handlerJsonArray(promise));
+                break;
+            case LATENESS:
+                eventService.getCountEventByStudent(2, studentIds, structureId, null, 0,
+                        new ArrayList<>(), null, start, end, true, null, null,
+                        FutureHelper.handlerJsonArray(promise));
+                break;
+            case DEPARTURE:
+                eventService.getCountEventByStudent(3, studentIds, structureId,
+                        null, 0, new ArrayList<>(), null, start, end, true, null,
+                        null, FutureHelper.handlerJsonArray(promise));
+                break;
+            default:
+                //There is no default case
+                String message =
+                        String.format("[Presences@%s::getCountEventsByStudent] There is no case for value: %s.",
+                                this.getClass().getSimpleName(), type);
+                log.error(message);
+                promise.fail(message);
+        }
+        return promise.future();
     }
 
     //Map events result (resultFutures) by types {{ NO_REASON / UNREGULARIZED / REGULARIZED / LATENESS / DEPARTURE }}
     @SuppressWarnings("unchecked")
-    private JsonObject getEventsFromFutures(List<String> types, Map reasons, JsonObject settings, String recoveryRequired,
-                                            List<Future> resultFutures, Handler<AsyncResult<JsonObject>> handler) {
-        JsonObject sorted_events = new JsonObject();
-        String recovery = recoveryRequired != null ? recoveryRequired : settings.getString("event_recovery_method");
+    private Map<String, JsonObject> setEventsByStudents(List<String> types, Map<Integer, JsonObject> reasons, JsonObject settings,
+                                                        List<Future<JsonArray>> resultFutures, Map<String, JsonObject> studentsEvents) {
         for (int i = 0; i < types.size(); i++) {
             String type = types.get(i);
-            sorted_events.put(type, new JsonArray());
 
-            List<JsonObject> values = ((JsonArray) resultFutures.get(i).result()).getList();
+            List<JsonObject> values = resultFutures.get(i).result().getList();
             if (values.isEmpty()) continue;
 
-            if (Boolean.TRUE.equals(isAbsence(type)) && (recovery.equals(HALF_DAY) || recovery.equals(DAY))) {
-                for (JsonObject dataType : values) {
-                    try {
-                        addAbsencesByRecovery(sorted_events, dataType, settings, type, recovery, reasons);
-                    } catch (ParseException e) {
-                        handler.handle(Future.failedFuture(e.getMessage()));
-                        return null;
-                    }
-                }
-            } else {
-                List<JsonObject> events = (List<JsonObject>) values.stream()
-                        .flatMap(dataType -> dataType.getJsonArray("events").getList().stream())
-                        .collect(Collectors.toList());
+            isAbsence(type);
+            List<JsonObject> events = (List<JsonObject>) values.stream()
+                    .flatMap(dataType -> dataType.getJsonArray(Field.EVENTS).getList().stream())
+                    .collect(Collectors.toList());
 
-                EventsHelper.mergeEventsByDates(new JsonArray(events), settings.getString("end_of_half_day"))
-                        .forEach(o -> {
-                            JsonObject event = (JsonObject) o;
-                            event.put("reason", reasons.get(event.getInteger("reason_id")));
-                            sorted_events.getJsonArray(type).add(event);
-                        });
+            EventsHelper.mergeEventsByDates(new JsonArray(events), settings.getString(Field.END_OF_HALF_DAY))
+                    .forEach(o -> {
+                        JsonObject event = (JsonObject) o;
+                        event.put(Field.REASON, reasons.get(event.getInteger(Field.REASON_ID)));
+                        JsonObject studentEvents = studentsEvents.get(event.getString(Field.STUDENT_ID));
+                        if (studentEvents != null && studentEvents.containsKey(Field.ALL))
+                            studentEvents.getJsonObject(Field.ALL).getJsonArray(type, new JsonArray()).add(event);
+                    });
+        }
+        return studentsEvents;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, JsonObject> setCountEventsByStudents(List<String> types, List<Future<JsonArray>> resultFutures,
+                                                             Map<String, JsonObject> studentsEvents) {
+        for (int i = 0; i < types.size(); i++) {
+            String type = types.get(i);
+            List<JsonObject> values = resultFutures.get(i).result().getList();
+            if (values.isEmpty()) continue;
+            for (JsonObject countType : values) {
+                JsonObject studentEvents = studentsEvents.get(countType.getString(Field.STUDENT_ID));
+                if (studentEvents != null && studentEvents.containsKey(Field.TOTALS))
+                    studentEvents.getJsonObject(Field.TOTALS).put(type, countType.getInteger(Field.COUNT));
             }
         }
-        return sorted_events;
-    }
 
-    // If absences events are recovered by Half Days or Days, map start_date and end_date events to correspond to it.
-    private void addAbsencesByRecovery(JsonObject sorted_events, JsonObject eventsData, JsonObject settings,
-                                       String type, String recovery, Map reasons) throws ParseException {
-        JsonArray slots = settings.getJsonArray("slots");
+        return studentsEvents;
 
-        String halfDay = settings.getString("end_of_half_day");
-        String startFirstSlot = slots.getJsonObject(0).getString("startHour");
-        String endLastSlot = slots.getJsonObject(slots.size() - 1).getString("endHour");
-
-        Date start = DateHelper.parse(eventsData.getString("start_date"), DateHelper.SQL_DATE_FORMAT);
-        Date end = DateHelper.parse(eventsData.getString("end_date"), DateHelper.SQL_DATE_FORMAT);
-
-        String startDateResult;
-        String endDateResult;
-
-        if (recovery.equals(HALF_DAY)) {
-            String MORNING = "MORNING";
-            if (eventsData.getString("period").equals(MORNING)) {
-                startDateResult = formatDateAndTime(start, startFirstSlot);
-                endDateResult = formatDateAndTime(end, halfDay);
-            } else { // For afternoon start_date is half day and end_date is end of day
-                startDateResult = formatDateAndTime(start, halfDay);
-                endDateResult = formatDateAndTime(end, endLastSlot);
-            }
-            eventsData.put("start_date", startDateResult);
-            eventsData.put("end_date", endDateResult);
-        } else { // For DAY start_date is start of day and end_date is end of day
-            startDateResult = formatDateAndTime(start, startFirstSlot);
-            endDateResult = formatDateAndTime(end, endLastSlot);
-
-            eventsData.put("start_date", startDateResult);
-            eventsData.put("end_date", endDateResult);
-        }
-        addReasonToRecoveredAbsence(eventsData, reasons);
-        eventsData.remove("events");
-        sorted_events.getJsonArray(type).add(eventsData);
-    }
-
-    private String formatDateAndTime(Date date, String time) throws ParseException {
-        return DateHelper.getDateString(date, DateHelper.YEAR_MONTH_DAY) + " " +
-                DateHelper.getTimeString(time, DateHelper.HOUR_MINUTES);
-    }
-
-    // Add reasons on justified absences
-    private void addReasonToRecoveredAbsence(JsonObject eventsData, Map reasons) {
-        ArrayList<Integer> distinctReasons = (ArrayList<Integer>) eventsData.getJsonArray("events")
-                .stream().map(event -> ((JsonObject) event).getInteger("reason_id"))
-                .distinct().collect(Collectors.toList());
-
-        if (distinctReasons.size() > 1) eventsData.put("reason", reasons.get(-1)); // multiple reasons
-        else eventsData.put("reason", reasons.get(distinctReasons.get(0)));
-    }
-
-    // Retrieve totals by types
-    private JsonObject getTotalsByTypes(List<String> types, JsonObject sorted_events) {
-        JsonObject totals = new JsonObject();
-        for (String type : types) {
-            totals.put(type, sorted_events.getJsonArray(type).size());
-        }
-        return totals;
     }
 
     // Absence are events {{NO_REASON}} {{REGULARIZED}} and {{UNREGULARIZED}}

--- a/presences/src/main/resources/jsonschema/studentsEvents.json
+++ b/presences/src/main/resources/jsonschema/studentsEvents.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "title": "Students Events schema",
+  "properties": {
+    "student_ids": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "limit": {
+      "type": "string"
+    },
+    "offset": {
+      "type": "string"
+    },
+    "start_at": {
+      "type": "string"
+    },
+    "end_at": {
+      "type": "string"
+    },
+    "types": {
+      "type": "array",
+      "items": {
+        "anyOf": [
+          {
+            "type": "string"
+          }
+        ]
+      }
+    }
+  },
+  "required": [
+    "student_ids"
+  ]
+}


### PR DESCRIPTION
[Jira - MA-883](https://entsupport.gdapublic.fr/browse/MA-883)

À l'instar des endpoints permettant de de récupérer les évènement d'un étudiant (d'un parent), l'idée ici était de faire la même chose mais pour les plusieurs étudiants d'un même parent en même temps (en apportant quelques optimisations).   