### PR TITLE
feat(statistics): #MA-747 Store and Retrieve statistics Weekly

### DIFF
--- a/common/src/main/java/fr/openent/presences/common/helper/FutureHelper.java
+++ b/common/src/main/java/fr/openent/presences/common/helper/FutureHelper.java
@@ -1,7 +1,9 @@
 package fr.openent.presences.common.helper;
 
 import fr.wseduc.webutils.Either;
+import fr.openent.presences.core.constants.Field;
 import io.vertx.core.*;
+import io.vertx.core.eventbus.Message;
 import io.vertx.core.impl.CompositeFutureImpl;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -96,6 +98,18 @@ public class FutureHelper {
                 handler.handle(Future.failedFuture(event.left().getValue()));
             }
         };
+    }
+
+    public static void busArrayHandler(Future<JsonArray> future, Message<JsonObject> message) {
+        future
+                .onSuccess(result -> message.reply((new JsonObject()).put(Field.STATUS, Field.OK).put(Field.RESULT, result)))
+                .onFailure(error -> message.reply((new JsonObject()).put(Field.STATUS, Field.ERROR).put(Field.MESSAGE, error)));
+    }
+
+    public static void busObjectHandler(Future<JsonObject> future, Message<JsonObject> message) {
+        future
+                .onSuccess(result -> message.reply((new JsonObject()).put(Field.STATUS, Field.OK).put(Field.RESULT, result)))
+                .onFailure(error -> message.reply((new JsonObject()).put(Field.STATUS, Field.ERROR).put(Field.MESSAGE, error)));
     }
 
     public static <T> CompositeFuture all(List<Future<T>> futures) {

--- a/common/src/main/java/fr/openent/presences/common/message/MessageResponseHandler.java
+++ b/common/src/main/java/fr/openent/presences/common/message/MessageResponseHandler.java
@@ -1,6 +1,7 @@
 package fr.openent.presences.common.message;
 
 import fr.wseduc.webutils.Either;
+import fr.openent.presences.core.constants.Field;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 import io.vertx.core.eventbus.Message;
@@ -14,28 +15,28 @@ public class MessageResponseHandler {
 
     public static Handler<AsyncResult<Message<JsonObject>>> messageJsonArrayHandler(Handler<Either<String, JsonArray>> handler) {
         return event -> {
-            if (event.succeeded() && "ok".equals(event.result().body().getString("status"))) {
-                handler.handle(new Either.Right<>(event.result().body().getJsonArray("result")));
+            if (event.succeeded() && Field.OK.equals(event.result().body().getString(Field.STATUS))) {
+                handler.handle(new Either.Right<>(event.result().body().getJsonArray(Field.RESULT, event.result().body().getJsonArray(Field.RESULTS))));
             } else {
                 if (event.failed()) {
                     handler.handle(new Either.Left<>(event.cause().getMessage()));
                     return;
                 }
-                handler.handle(new Either.Left<>(event.result().body().getString("message")));
+                handler.handle(new Either.Left<>(event.result().body().getString(Field.MESSAGE)));
             }
         };
     }
 
     public static Handler<AsyncResult<Message<JsonObject>>> messageJsonObjectHandler(Handler<Either<String, JsonObject>> handler) {
         return event -> {
-            if (event.succeeded() && "ok".equals(event.result().body().getString("status"))) {
-                handler.handle(new Either.Right<>(event.result().body().getJsonObject("result")));
+            if (event.succeeded() && Field.OK.equals(event.result().body().getString(Field.STATUS))) {
+                handler.handle(new Either.Right<>(event.result().body().getJsonObject(Field.RESULT)));
             } else {
                 if (event.failed()) {
                     handler.handle(new Either.Left<>(event.cause().getMessage()));
                     return;
                 }
-                handler.handle(new Either.Left<>(event.result().body().getString("message")));
+                handler.handle(new Either.Left<>(event.result().body().getString(Field.MESSAGE)));
             }
         };
     }

--- a/common/src/main/java/fr/openent/presences/common/presences/Presences.java
+++ b/common/src/main/java/fr/openent/presences/common/presences/Presences.java
@@ -2,9 +2,12 @@ package fr.openent.presences.common.presences;
 
 import fr.openent.presences.common.helper.FutureHelper;
 import fr.openent.presences.common.message.MessageResponseHandler;
+import fr.openent.presences.core.constants.Field;
 import fr.wseduc.webutils.Either;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -134,6 +137,21 @@ public class Presences {
                 .put("structure", structure)
                 .put("action", "get-settings");
         eb.send(address, action, MessageResponseHandler.messageJsonObjectHandler(handler));
+    }
+
+    public Future<JsonArray> getRegistersWithGroups(String structureId, List<Integer> registerIds, List<Integer> stateIds,
+                                                    String startAt, String endAt) {
+        Promise<JsonArray> promise = Promise.promise();
+        JsonObject action = new JsonObject()
+                .put(Field.STRUCTUREID, structureId)
+                .put(Field.REGISTERIDS, registerIds)
+                .put(Field.STATEIDS, stateIds)
+                .put(Field.STARTAT, startAt)
+                .put(Field.ENDAT, endAt)
+                .put("action", "get-registers-with-groups");
+        eb.send(address, action, MessageResponseHandler.messageJsonArrayHandler(FutureHelper.handlerJsonArray(promise)));
+
+        return promise.future();
     }
 
     private static class PresencesHolder {

--- a/common/src/main/java/fr/openent/presences/common/statistics_presences/StatisticsPresences.java
+++ b/common/src/main/java/fr/openent/presences/common/statistics_presences/StatisticsPresences.java
@@ -2,6 +2,7 @@ package fr.openent.presences.common.statistics_presences;
 
 import fr.openent.presences.common.helper.FutureHelper;
 import fr.openent.presences.common.message.MessageResponseHandler;
+import fr.openent.presences.core.constants.Field;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -58,6 +59,17 @@ public class StatisticsPresences {
         JsonObject action = new JsonObject()
                 .put("action", "get-statistics-indicator");
         eb.request(address, action, MessageResponseHandler.messageJsonObjectHandler(FutureHelper.handlerJsonObject(handler)));
+    }
+
+    public Future<JsonObject> postWeeklyAudiences(String structureId, List<Integer> registerIds) {
+        Promise<JsonObject> promise = Promise.promise();
+        JsonObject action = new JsonObject()
+                .put(Field.ACTION, "post-weekly-audiences")
+                .put(Field.STRUCTUREID, structureId)
+                .put(Field.REGISTERIDS, registerIds);
+
+        eb.request(address, action, MessageResponseHandler.messageJsonObjectHandler(FutureHelper.handlerJsonObject(promise)));
+        return promise.future();
     }
 
     private static class StatisticsPresencesHolder {

--- a/common/src/main/java/fr/openent/presences/common/viescolaire/Viescolaire.java
+++ b/common/src/main/java/fr/openent/presences/common/viescolaire/Viescolaire.java
@@ -3,6 +3,7 @@ package fr.openent.presences.common.viescolaire;
 import fr.openent.presences.common.helper.DateHelper;
 import fr.openent.presences.common.helper.FutureHelper;
 import fr.openent.presences.common.message.MessageResponseHandler;
+import fr.openent.presences.core.constants.Field;
 import fr.wseduc.webutils.Either;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
@@ -12,6 +13,8 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
+
+import java.util.List;
 
 public class Viescolaire {
     private static final Logger LOGGER = LoggerFactory.getLogger(Viescolaire.class);
@@ -143,14 +146,27 @@ public class Viescolaire {
             }
         });
     }
-//
-//    public void getGroupsPeriods(String structureId, List<String> groups, Handler<Either<String, JsonArray>> handler) {
-//        JsonObject action = new JsonObject()
-//                .put("action", "periode.getPeriodes")
-//                .put("idGroupes", new JsonArray(groups))
-//                .put("idEtablissement", structureId);
-//        eb.send(address, action, MessageResponseHandler.messageJsonArrayHandler(handler));
-//    }
+
+    public Future<JsonArray> getCountStudentsByAudiences(List<String> audienceIds) {
+        Promise<JsonArray> promise = Promise.promise();
+        JsonObject action = new JsonObject()
+                .put(Field.ACTION, "classe.getNbElevesGroupe")
+                .put(Field.IDGROUPES, audienceIds);
+
+        eb.request(address, action, MessageResponseHandler.messageJsonArrayHandler(FutureHelper.handlerJsonArray(promise)));
+        return promise.future();
+    }
+
+    public Future<JsonArray> getAudienceTimeslots(String structureId, List<String> audienceIds) {
+        Promise<JsonArray> promise = Promise.promise();
+        JsonObject action = new JsonObject()
+                .put(Field.ACTION, "timeslot.getAudienceTimeslot")
+                .put(Field.STRUCTUREID, structureId)
+                .put(Field.AUDIENCEIDS, audienceIds);
+
+        eb.request(address, action, MessageResponseHandler.messageJsonArrayHandler(FutureHelper.handlerJsonArray(promise)));
+        return promise.future();
+    }
 
     private static class ViescolaireHolder {
         private static final Viescolaire instance = new Viescolaire();

--- a/common/src/main/java/fr/openent/presences/core/constants/Field.java
+++ b/common/src/main/java/fr/openent/presences/core/constants/Field.java
@@ -17,6 +17,8 @@ public class Field {
     public static final String GROUPNAMES = "groupNames";
     public static final String GROUPS = "groups";
     public static final String AUDIENCES = "audiences";
+    public static final String AUDIENCEIDS = "audienceIds";
+    public static final String AUDIENCE_ID = "audience_id";
     public static final String LIMIT = "limit";
     public static final String MANUALGROUPS = "manualGroups";
     public static final String NAME = "name";
@@ -28,6 +30,7 @@ public class Field {
     public static final String STRUCTURES = "structures";
     public static final String STRUCTURE_ID = "structure_id";
     public static final String STRUCTUREID = "structureId";
+    public static final String STRUCTUREIDS = "structureIds";
     public static final String STUDENT = "student";
     public static final String STUDENTS = "students";
     public static final String STUDENTS_CAPS = "STUDENTS";
@@ -56,14 +59,18 @@ public class Field {
     public static final String END_DATE = "end_date";
     public static final String ENDDATE = "endDate";
     public static final String END_AT = "end_at";
+    public static final String ENDAT = "endAt";
     public static final String DATE = "date";
     public static final String START_DATE = "start_date";
     public static final String STARTDATE = "startDate";
     public static final String START = "start";
     public static final String START_AT = "start_at";
+    public static final String STARTAT = "startAt";
     public static final String END = "end";
     public static final String START_TIME = "startTime";
     public static final String END_TIME = "endTime";
+    public static final String STARTHOUR = "startHour";
+    public static final String ENDHOUR = "endHour";
     public static final String DESCENDING_DATE = "descendingDate";
     public static final String DISPLAY_START_DATE = "display_start_date";
     public static final String DISPLAY_END_DATE = "display_end_date";
@@ -97,6 +104,7 @@ public class Field {
     // Registers
     public static final String COURSE_ID = "course_id";
     public static final String STATE_ID = "state_id";
+    public static final String STATEIDS = "stateIds";
     public static final String NOTIFIED = "notified";
     public static final String SPLIT_SLOT = "split_slot";
     public static final String IS_OPENED_BY_PERSONNEL = "is_opened_by_personnel";
@@ -134,6 +142,7 @@ public class Field {
     public static final String PROTAGONIST = "protagonist";
     public static final String PROTAGONIST_TYPE_ID = "protagonist_type_id";
     public static final String REGISTER_ID = "register_id";
+    public static final String REGISTERIDS = "registerIds";
     public static final String REGISTER_STATE_ID = "register_state_id";
     public static final String ROOMLABELS = "roomLabels";
     public static final String STARTCOURSE = "startCourse";
@@ -201,6 +210,7 @@ public class Field {
     public static final String DATA = "data";
     public static final String COUNT = "count";
     public static final String RATE = "rate";
+    public static final String MAX = "max";
     public static final String SLOTS = "slots";
     public static final String ABSENCE_TOTAL = "ABSENCE_TOTAL";
 
@@ -213,24 +223,51 @@ public class Field {
     public static final String $_ID = "$_id";
     public static final String $PROJECT = "$project";
     public static final String CURSOR = "cursor";
+    public static final String ERRMSG = "errmsg";
     public static final String FIRSTBATCH = "firstBatch";
     public static final String $IN = "$in";
     public static final String $GROUP = "$group";
     public static final String $GT = "$gt";
     public static final String $COND = "$cond";
     public static final String $ADDFIELDS = "$addFields";
+    public static final String ISODAYOFWEEK = "isoDayOfWeek";
+    public static final String SUM = "sum";
+    public static final String DATESTRING = "dateString";
+    public static final String DATEFROMSTRING = "dateFromString";
+    public static final String STATUS = "status";
+    public static final String OK = "ok";
+
+    //Viescolaire
+    public static final String SCHOOLID = "schoolId";
+    public static final String IDGROUPES = "idGroupes";
+    public static final String ID_GROUPE = "id_groupe";
+    public static final String NB = "nb";
+
 
     // Query
     public static final String Q = "q";
     public static final String FIELD = "field";
+    public static final String RESULT = "result";
+    public static final String RESULTS = "results";
+    public static final String ERROR = "error";
+    public static final String MESSAGE = "message";
+    public static final String ACTION = "action";
 
     // Statistics
     public static final String INDICATOR = "indicator";
     public static final String MONTHLY = "Monthly";
     public static final String GLOBAL = "Global";
     public static final String CLASS_NAME = "class_name";
+    public static final String CLASSNAME = "className";
+    public static final String CLASSIDS = "classIds";
     public static final String MONTH = "month";
     public static final String YEAR = "year";
+    public static final String PUNISHMENT_TYPE = "punishment_type";
+
+    //Weekly Audiences
+    public static final String SLOT_ID = "slot_id";
+    public static final String TIMESLOTS = "timeslots";
+    public static final String STUDENT_COUNT = "student_count";
 
     //Massmailing
     public static final String MASSMAILING = "massmailing";

--- a/common/src/main/java/fr/openent/presences/core/constants/Field.java
+++ b/common/src/main/java/fr/openent/presences/core/constants/Field.java
@@ -234,7 +234,6 @@ public class Field {
     public static final String SUM = "sum";
     public static final String DATESTRING = "dateString";
     public static final String DATEFROMSTRING = "dateFromString";
-    public static final String STATUS = "status";
     public static final String OK = "ok";
 
     //Viescolaire

--- a/common/src/main/java/fr/openent/statistics_presences/model/StatisticsFilter.java
+++ b/common/src/main/java/fr/openent/statistics_presences/model/StatisticsFilter.java
@@ -20,6 +20,7 @@ public class StatisticsFilter {
     private final List<Integer> punishmentTypes = new ArrayList<>();
     private final List<Integer> sanctionTypes = new ArrayList<>();
     private String structure;
+    private String userId;
     private String start;
     private String end;
     private Integer from;
@@ -70,6 +71,11 @@ public class StatisticsFilter {
         }
     }
 
+    public StatisticsFilter setUserId(String userId) {
+        this.userId = userId;
+        return this;
+    }
+
     public StatisticsFilter setUsers(List<String> users) {
         this.users.addAll(users);
         return this;
@@ -77,6 +83,11 @@ public class StatisticsFilter {
 
     public StatisticsFilter setNewUsers(List<String> users) {
         this.users = users;
+        return this;
+    }
+
+    public StatisticsFilter setAudiences(List<String> audienceIds) {
+        this.audiences = audienceIds;
         return this;
     }
 
@@ -92,12 +103,12 @@ public class StatisticsFilter {
         return this.audiences;
     }
 
-    public void setAudiences(List<String> audiences) {
-        this.audiences = audiences;
-    }
-
     public List<String> users() {
         return this.users;
+    }
+
+    public String userId() {
+        return this.userId;
     }
 
     public List<Integer> reasons() {

--- a/common/src/main/resources/ts/services/TimeslotClasseService.ts
+++ b/common/src/main/resources/ts/services/TimeslotClasseService.ts
@@ -1,0 +1,41 @@
+import {ng} from "entcore";
+import http, {AxiosResponse} from "axios";
+import {IStructureSlot} from "@common/model";
+
+interface TimeslotClasseService {
+    getAudienceTimeslot(audienceId: string): Promise<IStructureSlot>;
+
+    getAllClassFromTimeslot(timeslotId: string): Promise<string[]>;
+
+    createOrUpdateClassTimeslot(timeslotId: string, classId: string): Promise<AxiosResponse>;
+
+    deleteClassTimeslot(classId: string): Promise<AxiosResponse>;
+
+    deleteAllAudienceFromTimeslot(timeslotId: string): Promise<AxiosResponse>;
+}
+
+export const timeslotClasseService: TimeslotClasseService =  {
+    async getAudienceTimeslot(audienceId: string): Promise<IStructureSlot> {
+        const {data}: AxiosResponse = await http.get(`/viescolaire/timeslot/audience/${audienceId}`);
+        return data as IStructureSlot;
+    },
+
+    async getAllClassFromTimeslot(timeslotId: string): Promise<string[]> {
+        const {data}: AxiosResponse = await http.get(`/viescolaire/timeslot/${timeslotId}`);
+        return data as string[];
+    },
+
+    async createOrUpdateClassTimeslot(timeslotId: string, classId: string): Promise<AxiosResponse> {
+        return http.post(`/viescolaire/timeslot/audience`, {timeslot_id: timeslotId, class_id: classId});
+    },
+
+    async deleteAllAudienceFromTimeslot(timeslotId: string): Promise<AxiosResponse> {
+        return http.delete(`/viescolaire/timeslot/${timeslotId}`);
+    },
+
+    async deleteClassTimeslot(classId: string): Promise<AxiosResponse> {
+        return http.delete(`/viescolaire/timeslot/audience/${classId}`);
+    }
+}
+
+export const TimeslotClasseService = ng.service('TimeslotClasseService', (): TimeslotClasseService => timeslotClasseService);

--- a/common/src/main/resources/ts/services/ViescolaireService.ts
+++ b/common/src/main/resources/ts/services/ViescolaireService.ts
@@ -1,6 +1,7 @@
 import {model, ng} from 'entcore'
 import {ISchoolYearPeriod, IStructure, IStructureSlot} from "../model";
 import http from "axios";
+import {Student} from "@common/model/Student";
 
 declare let window: any;
 
@@ -8,6 +9,8 @@ export interface IViescolaireService {
     getSchoolYearDates(structureId): Promise<ISchoolYearPeriod>;
 
     getSlotProfile(structureId: string): Promise<IStructureSlot>;
+
+    getStudent(structureId:string, studentId: string): Promise<Array<Student>>
 
     getBuildOwnStructure(): Array<IStructure>;
 }
@@ -25,6 +28,11 @@ export const ViescolaireService: IViescolaireService = {
         } catch (err) {
             throw err;
         }
+    },
+
+    getStudent: async (structureId: string, studentId: string): Promise<Array<Student>> => {
+        let {data} = await http.get(`viescolaire/eleves?idUser=${studentId}&idStructure=${structureId}`);
+        return data;
     },
 
     getBuildOwnStructure: (): Array<IStructure> => {

--- a/common/src/main/resources/ts/services/__tests__/timeslot-classe.service.test.ts
+++ b/common/src/main/resources/ts/services/__tests__/timeslot-classe.service.test.ts
@@ -1,0 +1,77 @@
+// tricks to fake "mock" entcore ng class in order to use service
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import {timeslotClasseService, TimeslotClasseService} from "@common/services/TimeslotClasseService";
+import {IStructureSlot} from "@common/model";
+
+describe('TimeslotClasseService', () => {
+    it('returns data when API request is correctly called for getAudienceTimeslot method', done => {
+        const audienceId = "audienceId";
+        var mock = new MockAdapter(axios);
+        const data: IStructureSlot = {_id: "", name: "", slots: []};
+
+        mock.onGet(`/viescolaire/timeslot/audience/${audienceId}`).reply(200, data);
+
+        timeslotClasseService.getAudienceTimeslot("audienceId").then(response => {
+            expect(response).toEqual(data);
+            done();
+        });
+    });
+
+    it('returns data when API request is correctly called for getAllClassFromTimeslot method', done => {
+        const timeslotId = "timeslotId";
+        var mock = new MockAdapter(axios);
+        const data = ["ok"];
+
+        mock.onGet(`/viescolaire/timeslot/${timeslotId}`).reply(200, data);
+
+        timeslotClasseService.getAllClassFromTimeslot("timeslotId").then(response => {
+            expect(response).toEqual(data);
+            done();
+        });
+    });
+
+    it('returns data when API request is correctly called for createOrUpdateClassTimeslot method', done => {
+        const timeslotId = "timeslotId";
+        const classId = "classId";
+        var mock = new MockAdapter(axios);
+        const data = {response: true};
+
+        mock.onPost(`/viescolaire/timeslot/audience`, {timeslot_id: timeslotId, class_id: classId}).reply(200, data);
+
+        timeslotClasseService.createOrUpdateClassTimeslot("timeslotId", "classId").then(response => {
+            expect(response.data).toEqual(data);
+            expect(response.config.url).toEqual(`/viescolaire/timeslot/audience`);
+            expect(response.config.data).toEqual(JSON.stringify({timeslot_id: timeslotId, class_id: classId}));
+            done();
+        });
+    });
+
+    it('returns data when API request is correctly called for deleteAllAudienceFromTimeslot method', done => {
+        const timeslotId = "timeslotId";
+        var mock = new MockAdapter(axios);
+        const data = {response: true};
+
+        mock.onDelete(`/viescolaire/timeslot/${timeslotId}`).reply(200, data);
+
+        timeslotClasseService.deleteAllAudienceFromTimeslot("timeslotId").then(response => {
+            expect(response.data).toEqual(data);
+            expect(response.config.url).toEqual(`/viescolaire/timeslot/${timeslotId}`);
+            done();
+        });
+    });
+
+    it('returns data when API request is correctly called for getAudienceTimeslot method', done => {
+        const classId = "classId";
+        var mock = new MockAdapter(axios);
+        const data = {response: true};
+
+        mock.onDelete(`/viescolaire/timeslot/audience/${classId}`).reply(200, data);
+
+        timeslotClasseService.deleteClassTimeslot("classId").then(response => {
+            expect(response.data).toEqual(data);
+            expect(response.config.url).toEqual(`/viescolaire/timeslot/audience/${classId}`);
+            done();
+        });
+    });
+});

--- a/common/src/main/resources/ts/services/__tests__/viescolaire.service.test.ts
+++ b/common/src/main/resources/ts/services/__tests__/viescolaire.service.test.ts
@@ -1,20 +1,64 @@
 // tricks to fake "mock" entcore ng class in order to use service
-jest.mock('entcore', () => ({
-    ng: {service: jest.fn()}
-}))
+import {model, ng} from "@presences/models/__mocks__/entcore";
 
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import {ViescolaireService} from "../ViescolaireService";
+import {IStructure} from "@common/model";
 
 describe('ViescolaireService', () => {
-    it('returns data when API request is correctly called', done => {
+    it('returns data when API request is correctly called for getSchoolYearDates method', done => {
+        const structureId = "structureId";
+        var mock = new MockAdapter(axios);
+        const data = {response: true};
+        mock.onGet('viescolaire/settings/periode/schoolyear?structureId='+structureId).reply(200, data);
+
+        ViescolaireService.getSchoolYearDates("structureId").then(response => {
+            expect(response).toEqual(data);
+            done();
+        });
+    });
+
+    it('returns data when API request is correctly called for getSlotProfile method', done => {
         var mock = new MockAdapter(axios);
         const data = {response: true};
         mock.onGet('/viescolaire/structures/structureId/time-slot').reply(200, data);
+
         ViescolaireService.getSlotProfile("structureId").then(response => {
             expect(response).toEqual(data);
             done();
         });
+    });
+
+    it('returns data when API request is correctly called for getStudent method', done => {
+        const structureId = "structureId";
+        const studentId = "studentId";
+        var mock = new MockAdapter(axios);
+        const data = {response: true};
+        mock.onGet(`viescolaire/eleves?idUser=${studentId}&idStructure=${structureId}`).reply(200, data);
+
+        ViescolaireService.getStudent("structureId", "studentId").then(response => {
+            expect(response).toEqual(data);
+            done();
+        });
+    });
+
+    it('returns data when API request is correctly called for getBuildOwnStructure method', done => {
+        var mock = new MockAdapter(axios);
+        const data = {response: true};
+
+        const structure1: IStructure = {id: "id1", name: "name1"}
+        const structure2: IStructure = {id: "id2", name: "name2"}
+        const expected: Array<IStructure> = [structure1, structure2];
+
+        model.me.structures.push("id1");
+        model.me.structures.push("id2");
+
+        model.me.structureNames.push("name1");
+        model.me.structureNames.push("name2");
+
+        mock.onGet('/viescolaire/structures/structureId/time-slot').reply(200, data);
+        expect(ViescolaireService.getBuildOwnStructure()).toEqual(expected);
+        done();
     });
 });

--- a/presences/src/main/java/fr/openent/presences/Presences.java
+++ b/presences/src/main/java/fr/openent/presences/Presences.java
@@ -97,7 +97,7 @@ public class Presences extends BaseServer {
         addController(new CalendarController(eb));
         addController(new ReasonController());
         addController(new RegistryController(eb));
-        addController(new EventBusController(eb));
+        addController(new EventBusController(eb, commonPresencesServiceFactory));
         addController(new NotebookController());
         addController(new SettingsController());
         addController(new AlertController(eb));

--- a/presences/src/main/java/fr/openent/presences/controller/EventBusController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/EventBusController.java
@@ -1,14 +1,10 @@
 package fr.openent.presences.controller;
 
 import fr.openent.presences.common.bus.BusResultHandler;
-import fr.openent.presences.service.AbsenceService;
-import fr.openent.presences.service.EventService;
-import fr.openent.presences.service.ReasonService;
-import fr.openent.presences.service.SettingsService;
-import fr.openent.presences.service.impl.DefaultAbsenceService;
-import fr.openent.presences.service.impl.DefaultEventService;
-import fr.openent.presences.service.impl.DefaultReasonService;
-import fr.openent.presences.service.impl.DefaultSettingsService;
+import fr.openent.presences.common.helper.FutureHelper;
+import fr.openent.presences.core.constants.Field;
+import fr.openent.presences.service.*;
+import fr.openent.presences.service.impl.*;
 import fr.wseduc.bus.BusAddress;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
@@ -18,6 +14,7 @@ import org.entcore.common.bus.BusResponseHandler;
 import org.entcore.common.controller.ControllerHelper;
 import org.entcore.common.user.UserInfos;
 
+import java.util.Collections;
 import java.util.List;
 
 public class EventBusController extends ControllerHelper {
@@ -26,14 +23,17 @@ public class EventBusController extends ControllerHelper {
     private final ReasonService reasonService = new DefaultReasonService();
     private final SettingsService settingsService = new DefaultSettingsService();
     private final AbsenceService absenceService;
+    private final RegisterService registerService;
     private UserInfos user;
 
-    public EventBusController(EventBus eb) {
+    public EventBusController(EventBus eb, CommonPresencesServiceFactory commonPresencesServiceFactory) {
         this.eventService = new DefaultEventService(eb);
         this.absenceService = new DefaultAbsenceService(eb);
+        this.registerService = new DefaultRegisterService(commonPresencesServiceFactory);
     }
 
     @BusAddress("fr.openent.presences")
+    @SuppressWarnings("unchecked")
     public void bus(final Message<JsonObject> message) {
         JsonObject body = message.body();
         String action = body.getString("action");
@@ -44,6 +44,8 @@ public class EventBusController extends ControllerHelper {
         String structure;
         Integer startAt;
         List<Integer> reasonsId;
+        List<Integer> registerIds;
+        List<Integer> stateIds;
         Boolean massmailed;
         Boolean compliance;
         String startDate;
@@ -120,6 +122,16 @@ public class EventBusController extends ControllerHelper {
             case "get-settings":
                 structure = body.getString("structure");
                 this.settingsService.retrieve(structure, BusResponseHandler.busResponseHandler(message));
+                break;
+            case "get-registers-with-groups":
+                structure = body.getString(Field.STRUCTUREID);
+                registerIds = body.getJsonArray(Field.REGISTERIDS) == null ? Collections.emptyList() :
+                        body.getJsonArray(Field.REGISTERIDS).getList();
+                startDate = body.getString(Field.STARTAT);
+                stateIds = body.getJsonArray(Field.STATEIDS) == null ? Collections.emptyList() :
+                        body.getJsonArray(Field.STATEIDS).getList();
+                endDate = body.getString(Field.ENDAT);
+                FutureHelper.busArrayHandler(this.registerService.listWithGroups(structure, registerIds, stateIds, startDate, endDate), message);
                 break;
             default:
                 message.reply(new JsonObject()

--- a/presences/src/main/java/fr/openent/presences/controller/RegisterController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/RegisterController.java
@@ -1,6 +1,7 @@
 package fr.openent.presences.controller;
 
 import fr.openent.presences.Presences;
+import fr.openent.presences.common.statistics_presences.StatisticsPresences;
 import fr.openent.presences.constants.Actions;
 import fr.openent.presences.constants.EventStores;
 import fr.openent.presences.core.constants.*;
@@ -23,6 +24,8 @@ import org.entcore.common.events.EventStoreFactory;
 import org.entcore.common.http.filter.*;
 import org.entcore.common.user.UserUtils;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class RegisterController extends ControllerHelper {
@@ -86,7 +89,7 @@ public class RegisterController extends ControllerHelper {
     @ApiDoc("Create multiple registers")
     @SecuredAction(value = "", type = ActionType.RESOURCE)
     @ResourceFilter(AdminFilter.class)
-    @Trace(value= Actions.REGISTER_CREATION, body = false)
+    @Trace(value = Actions.REGISTER_CREATION, body = false)
     public void createMultipleRegisters(final HttpServerRequest request) {
         String structureId = request.params().get(Field.STRUCTUREID);
         String startDate = request.getParam(Field.STARTDATE);
@@ -120,6 +123,7 @@ public class RegisterController extends ControllerHelper {
                                 + registerId, either.left().getValue());
                         renderError(request);
                     } else {
+                        StatisticsPresences.getInstance().postWeeklyAudiences(null, Collections.singletonList(registerId));
                         noContent(request);
                     }
                 });
@@ -166,6 +170,6 @@ public class RegisterController extends ControllerHelper {
                             } else {
                                 renderJson(request, either.result());
                             }
-                }));
+                        }));
     }
 }

--- a/presences/src/main/java/fr/openent/presences/service/RegisterService.java
+++ b/presences/src/main/java/fr/openent/presences/service/RegisterService.java
@@ -67,6 +67,18 @@ public interface RegisterService {
                            Boolean isWithTeacherFilter, String limit, String offset);
 
     /**
+     *  List registers based on given parameters with groups
+     * @param structureId           structure identifier (optional)
+     * @param registerIds           {@link List} of register identifiers (optional)
+     * @param stateIds              {@link List} of state identifiers (optional)
+     * @param startAt               start date filter (optional)
+     * @param endAt                 end date filter (optional)
+     *
+     * @return {@link Future} of {@link List}
+     */
+    Future<JsonArray> listWithGroups(String structureId, List<Integer> registerIds, List<Integer> stateIds, String startAt, String endAt);
+
+    /**
      * Create register
      *
      * @param register register

--- a/presences/src/main/java/fr/openent/presences/service/impl/DefaultRegisterService.java
+++ b/presences/src/main/java/fr/openent/presences/service/impl/DefaultRegisterService.java
@@ -172,6 +172,45 @@ public class DefaultRegisterService extends DBService implements RegisterService
     }
 
     @Override
+    public Future<JsonArray> listWithGroups(String structureId, List<Integer> registerIds, List<Integer> stateIds, String startAt, String endAt) {
+        Promise<JsonArray> promise = Promise.promise();
+        String query = " SELECT id, start_date, end_date, course_id, state_id, notified, split_slot, structure_id, " +
+                " rg.group_id as group_id " +
+                " FROM " + Presences.dbSchema + ".register AS register " +
+                " INNER JOIN " + Presences.dbSchema + ".rel_group_register AS rg ON (register.id = rg.register_id) ";
+
+        JsonArray params = new JsonArray();
+
+        if (structureId != null) {
+            query += " AND register.structure_id = ? ";
+            params.add(structureId);
+        }
+
+        if (registerIds != null && !registerIds.isEmpty()) {
+            query += String.format(" AND register.id IN %s", Sql.listPrepared(registerIds));
+            params.addAll(new JsonArray(registerIds));
+        }
+
+        if (stateIds != null && !stateIds.isEmpty()) {
+            query += String.format(" AND register.state_id IN %s", Sql.listPrepared(stateIds));
+            params.addAll(new JsonArray(stateIds));
+        }
+
+        if (startAt != null) {
+            query += " AND ? < register.end_date ";
+            params.add(startAt);
+        }
+
+        if (endAt != null) {
+            query += " AND register.start_date < ? ";
+            params.add(endAt);
+        }
+
+        sql.prepared(query.replaceFirst("AND", "WHERE"), params, SqlResult.validResultHandler(FutureHelper.handlerJsonArray(promise)));
+        return promise.future();
+    }
+
+    @Override
     public void create(JsonObject register, UserInfos user, Handler<Either<String, JsonObject>> handler) {
         fetchIfRegisterExists(register, existsEither -> {
             if (existsEither.isLeft()) {

--- a/presences/src/main/resources/public/sass/global/components/containers/_calendar.scss
+++ b/presences/src/main/resources/public/sass/global/components/containers/_calendar.scss
@@ -46,6 +46,7 @@ $calendar-user-card-height: 56px;
     }
   }
 
+
   .calendar-container {
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.26);
     background-color: $white;
@@ -409,7 +410,6 @@ $calendar-user-card-height: 56px;
           }
         }
       }
-
     }
   }
 

--- a/presences/src/main/resources/public/ts/models/__mocks__/entcore.ts
+++ b/presences/src/main/resources/public/ts/models/__mocks__/entcore.ts
@@ -50,7 +50,9 @@ export const model = {
         userId: '7b6459f5-2765-45b5-8086-d5b3f422e69e',
         type: 'PERSEDUCNAT',
         hasWorkflow: jest.fn(() => true),
-        hasRight: jest.fn(() => true)
+        hasRight: jest.fn(() => true),
+        structures: [],
+        structureNames: []
     },
 };
 

--- a/statistics-presences/deployment/statistics-presences/conf.j2
+++ b/statistics-presences/deployment/statistics-presences/conf.j2
@@ -24,7 +24,8 @@
         {% endif %}
         "indicators": [
             "Global",
-            "Monthly" 
+            "Monthly",
+            "Weekly"
         ],
         "publicConf": {
             "xiti": {

--- a/statistics-presences/deployment/statistics-presences/conf.json.template
+++ b/statistics-presences/deployment/statistics-presences/conf.json.template
@@ -21,7 +21,8 @@
         "report-recipients": [],
         "indicators": [
             "Global",
-            "Monthly"
+            "Monthly",
+            "Weekly"
         ]
       }
     }

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/StatisticsPresences.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/StatisticsPresences.java
@@ -9,10 +9,8 @@ import fr.openent.statistics_presences.bean.Report;
 import fr.openent.statistics_presences.controller.ConfigController;
 import fr.openent.statistics_presences.controller.EventBusController;
 import fr.openent.statistics_presences.controller.StatisticsController;
-import fr.openent.statistics_presences.indicator.Indicator;
-import fr.openent.statistics_presences.indicator.IndicatorGeneric;
-import fr.openent.statistics_presences.indicator.ProcessingScheduledManual;
-import fr.openent.statistics_presences.indicator.ProcessingScheduledTask;
+import fr.openent.statistics_presences.controller.StatisticsWeeklyAudiencesController;
+import fr.openent.statistics_presences.indicator.*;
 import fr.openent.statistics_presences.service.CommonServiceFactory;
 import fr.wseduc.cron.CronTrigger;
 import fr.wseduc.mongodb.MongoDb;
@@ -35,6 +33,7 @@ import static fr.wseduc.webutils.Utils.handlerToAsyncHandler;
 public class StatisticsPresences extends BaseServer {
     public static final String COLLECTION = "presences.statistics";
 
+    public static final String WEEKLY_AUDIENCES_COLLECTION = "presences.statistics_weekly_audiences";
     public static final String VIEW = "statistics_presences.view";
     public static final String VIEW_RESTRICTED = "statistics_presences.view.restricted";
 
@@ -55,6 +54,7 @@ public class StatisticsPresences extends BaseServer {
 
         addController(new EventBusController(commonServiceFactory));
         addController(new StatisticsController(commonServiceFactory));
+        addController(new StatisticsWeeklyAudiencesController(commonServiceFactory));
         addController(new ConfigController());
 
         setSchemas();
@@ -72,6 +72,7 @@ public class StatisticsPresences extends BaseServer {
 
         // worker to be triggered manually
         vertx.deployVerticle(ProcessingScheduledManual.class, new DeploymentOptions().setConfig(config).setWorker(true));
+        vertx.deployVerticle(ProcessingWeeklyAudiencesManual.class, new DeploymentOptions().setConfig(config).setWorker(true));
     }
 
     private void registerCodec() {

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/Register.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/Register.java
@@ -1,0 +1,71 @@
+package fr.openent.statistics_presences.bean;
+
+import fr.openent.presences.core.constants.Field;
+import io.vertx.core.json.JsonObject;
+
+public class Register {
+
+    private Integer id;
+    private String audienceId;
+    private Integer stateId;
+    private String startAt;
+    private String endAt;
+    private String structureId;
+
+    public Register(JsonObject register) {
+        this.id = register.getInteger(Field.ID);
+        this.audienceId = register.getString(Field.GROUP_ID);
+        this.stateId = register.getInteger(Field.STATE_ID);
+        this.startAt = register.getString(Field.START_DATE);
+        this.endAt = register.getString(Field.END_DATE);
+        this.structureId = register.getString(Field.STRUCTURE_ID);
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getAudienceId() {
+        return audienceId;
+    }
+
+    public void setAudienceId(String audienceId) {
+        this.audienceId = audienceId;
+    }
+
+    public Integer getStateId() {
+        return stateId;
+    }
+
+    public void setStateId(Integer stateId) {
+        this.stateId = stateId;
+    }
+
+    public String getStartAt() {
+        return startAt;
+    }
+
+    public void setStartAt(String startAt) {
+        this.startAt = startAt;
+    }
+
+    public String getEndAt() {
+        return endAt;
+    }
+
+    public void setEndAt(String endAt) {
+        this.endAt = endAt;
+    }
+
+    public String getStructureId() {
+        return structureId;
+    }
+
+    public void setStructureId(String structureId) {
+        this.structureId = structureId;
+    }
+}

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/StatProcessSettings.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/StatProcessSettings.java
@@ -1,0 +1,56 @@
+package fr.openent.statistics_presences.bean;
+
+import fr.openent.presences.core.constants.Field;
+import fr.openent.statistics_presences.bean.timeslot.Timeslot;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class StatProcessSettings {
+
+    private String studentName;
+    private List<String> studentClassNames;
+    private List<String> studentClassIds;
+    private List<String> audienceIds;
+    private Timeslot timeslot;
+
+    @SuppressWarnings("unchecked")
+    public void setStudentInfo(JsonObject student) {
+        this.studentName = student.getString(Field.NAME);
+        this.studentClassNames = student.getJsonArray(Field.CLASSNAME, new JsonArray()).getList();
+        this.studentClassIds = student.getJsonArray(Field.CLASSIDS, new JsonArray()).getList();
+    }
+    
+    @SuppressWarnings("unchecked")
+    public void setAudienceIds(JsonArray audienceIds) {
+        this.audienceIds = audienceIds != null ? audienceIds.getList() : new ArrayList<>();
+    }
+
+    public void setTimeslot(JsonObject timeslot) {
+        this.timeslot = new Timeslot(timeslot);
+    }
+
+    public String getStudentName() {
+        return studentName;
+    }
+
+    public List<String> getStudentClassIds() {
+        return studentClassIds;
+    }
+
+    public List<String> getStudentClassNames() {
+        return studentClassNames;
+    }
+
+    public List<String> getAudienceIds() {
+        return audienceIds;
+    }
+
+    public Timeslot getTimeslot() {
+        return timeslot;
+    }
+
+
+}

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/timeslot/Slot.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/timeslot/Slot.java
@@ -1,0 +1,34 @@
+package fr.openent.statistics_presences.bean.timeslot;
+
+import fr.openent.presences.core.constants.Field;
+import io.vertx.core.json.JsonObject;
+
+public class Slot {
+    private String id;
+    private String name;
+    private String startHour;
+    private String endHour;
+
+    public Slot(JsonObject slot) {
+        this.id = slot.getString(Field.ID);
+        this.name = slot.getString(Field.NAME);
+        this.startHour = slot.getString(Field.STARTHOUR);
+        this.endHour = slot.getString(Field.ENDHOUR);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getStartHour() {
+        return startHour;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEndHour() {
+        return endHour;
+    }
+}

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/timeslot/Timeslot.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/timeslot/Timeslot.java
@@ -1,0 +1,47 @@
+package fr.openent.statistics_presences.bean.timeslot;
+
+import fr.openent.presences.core.constants.Field;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Timeslot {
+    private String id;
+    private String structureId;
+    private String audienceId;
+    private List<Slot> slots;
+
+    @SuppressWarnings("unchecked")
+    public Timeslot(JsonObject timeslot) {
+        this.id = timeslot.getString(Field._ID);
+        this.structureId = timeslot.getString(Field.SCHOOLID);
+        this.audienceId = timeslot.getString(Field.AUDIENCEID);
+        this.slots = ((List<JsonObject>) timeslot.getJsonArray(Field.SLOTS, new JsonArray()).getList())
+                .stream()
+                .map(Slot::new)
+                .collect(Collectors.toList());
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getStructureId() {
+        return structureId;
+    }
+
+    public String getAudienceId() {
+        return audienceId;
+    }
+
+    public List<Slot> getSlots() {
+        return slots;
+    }
+
+    public Timeslot setSlots(List<Slot> slots) {
+        this.slots = slots;
+        return this;
+    }
+}

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/weekly/WeeklyAudience.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/weekly/WeeklyAudience.java
@@ -1,0 +1,62 @@
+package fr.openent.statistics_presences.bean.weekly;
+
+import fr.openent.presences.core.constants.Field;
+import io.vertx.core.json.JsonObject;
+
+public class WeeklyAudience {
+    private String structureId;
+    private String audienceId;
+    private Integer registerId;
+    private String slotId;
+    private String startAt;
+    private String endAt;
+    private Integer studentCount;
+
+    public WeeklyAudience setStructureId(String structure) {
+        this.structureId = structure;
+        return this;
+    }
+
+    public WeeklyAudience setAudienceId(String audienceId) {
+        this.audienceId = audienceId;
+        return this;
+    }
+
+    public WeeklyAudience setRegisterId(Integer registerId) {
+        this.registerId = registerId;
+        return this;
+    }
+
+    public WeeklyAudience setStartAt(String date) {
+        this.startAt = date;
+        return this;
+    }
+
+    public WeeklyAudience setEndAt(String date) {
+        this.endAt = date;
+        return this;
+    }
+
+    public WeeklyAudience setSlotId(String slotId) {
+        this.slotId = slotId;
+        return this;
+    }
+
+    public WeeklyAudience setStudentCount(Integer studentCount) {
+        this.studentCount = studentCount;
+        return this;
+    }
+
+    public JsonObject toJSON() {
+        return new JsonObject()
+                .put(Field._ID, new JsonObject()
+                        .put(Field.REGISTER_ID, this.registerId)
+                        .put(Field.AUDIENCE_ID, this.audienceId)
+                        .put(Field.START_AT, this.startAt)
+                        .put(Field.END_AT, this.endAt)
+                )
+                .put(Field.STRUCTURE_ID, this.structureId)
+                .put(Field.SLOT_ID, this.slotId)
+                .put(Field.STUDENT_COUNT, this.studentCount);
+    }
+}

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/weekly/WeeklySearch.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/weekly/WeeklySearch.java
@@ -1,0 +1,161 @@
+package fr.openent.statistics_presences.bean.weekly;
+
+import com.mongodb.QueryBuilder;
+import fr.openent.presences.core.constants.Field;
+import fr.openent.statistics_presences.StatisticsPresences;
+import fr.openent.statistics_presences.indicator.impl.Weekly;
+import fr.openent.statistics_presences.model.StatisticsFilter;
+import fr.openent.statistics_presences.utils.EventType;
+import fr.wseduc.mongodb.AggregationsBuilder;
+import io.vertx.core.json.JsonObject;
+
+public class WeeklySearch {
+    private final StatisticsFilter filter;
+
+    public WeeklySearch(StatisticsFilter filter) {
+        this.filter = filter;
+    }
+
+    public StatisticsFilter filter() {
+        return this.filter;
+    }
+
+    public JsonObject countEventTypedBySlotsCommand() {
+        AggregationsBuilder eventsAggregation = AggregationsBuilder.startWithCollection(StatisticsPresences.COLLECTION);
+        eventsAggregation
+                .withAllowDiskUse(true)
+                .withMatch(matchEvents())
+                .withAddFields(addDayOfWeekField(String.format("$%s", Field.START_DATE)))
+                .withGroup(groupBySlot())
+                .withProjection(project());
+
+        return eventsAggregation.getCommand();
+    }
+
+    public JsonObject countStudentsBySlotsCommand() {
+        AggregationsBuilder eventsAggregation = AggregationsBuilder.startWithCollection(StatisticsPresences.WEEKLY_AUDIENCES_COLLECTION);
+        eventsAggregation
+                .withAllowDiskUse(true)
+                .withMatch(matchCountStudents())
+                .withAddFields(addDayOfWeekField(String.format("$%s.%s", Field._ID, Field.START_AT)))
+                .withGroup(groupStudentCountBySlot())
+                .withProjection(project());
+
+        return eventsAggregation.getCommand();
+    }
+    /**
+     * add a start_at field at the beginning of the pipeline to have start_date in mongo date format (and so handle it)
+     *
+     * @return field start_at
+     */
+    private JsonObject addDayOfWeekField(String dateField) {
+        return new JsonObject()
+                .put(Field.DAYOFWEEK, isoDayOfWeek(dateFromString(dateField)));
+    }
+
+    private QueryBuilder matchEvents() {
+        QueryBuilder matcher = QueryBuilder.start(Field.STRUCTURE).is(this.filter.structure())
+                .and(Field.INDICATOR).is(Weekly.class.getName())
+                .and(Field.START_DATE).lessThan(this.filter.end())
+                .and(Field.END_DATE).greaterThan(this.filter.start());
+
+        if (!this.filter.audiences().isEmpty() && this.filter().userId() == null) {
+            matcher.put(Field.AUDIENCES).in(this.filter().audiences());
+        }
+
+        if (this.filter().userId() != null) {
+            matcher.put(Field.USER).is(this.filter.userId());
+        }
+
+        return filterType(matcher);
+    }
+
+    private QueryBuilder matchCountStudents() {
+        QueryBuilder matcher = QueryBuilder.start(Field.STRUCTURE_ID).is(this.filter.structure())
+                .and(String.format("%s.%s", Field._ID, Field.START_AT)).lessThan(this.filter.end())
+                .and(String.format("%s.%s", Field._ID, Field.END_AT)).greaterThan(this.filter.start());
+
+        if (!this.filter.audiences().isEmpty()) {
+            matcher.put(String.format("%s.%s", Field._ID, Field.AUDIENCE_ID)).in(this.filter().audiences());
+        }
+
+        return matcher;
+    }
+
+    private QueryBuilder filterType(QueryBuilder query) {
+        for (String type : this.filter().types()) {
+            QueryBuilder filterType = QueryBuilder.start(Field.TYPE).is(type);
+            EventType eventType = EventType.valueOf(type);
+
+            switch (eventType) {
+                case UNREGULARIZED:
+                case REGULARIZED:
+                    filterType.and(Field.REASON).in(this.filter().reasons());
+                    break;
+                default:
+                    break;
+            }
+            query.or(filterType.get());
+        }
+
+        return query;
+    }
+
+    private JsonObject groupBySlot() {
+        JsonObject id = new JsonObject()
+                .put(Field.SLOT_ID, String.format("$%s", Field.SLOT_ID))
+                .put(Field.DAYOFWEEK, String.format("$%s", Field.DAYOFWEEK));
+
+        return id(id)
+                .put(Field.COUNT, sum());
+    }
+
+    private JsonObject groupStudentCountBySlot() {
+        JsonObject id = new JsonObject()
+                .put(Field.SLOT_ID, String.format("$%s", Field.SLOT_ID))
+                .put(Field.DAYOFWEEK, String.format("$%s", Field.DAYOFWEEK));
+
+        return id(id)
+                .put(Field.COUNT, this.filter().userId() != null ? sum() : sum(String.format("$%s", Field.STUDENT_COUNT)));
+    }
+
+
+    private JsonObject project() {
+        return new JsonObject()
+                .put(Field._ID, 0)
+                .put(Field.SLOT_ID, String.format("$%s.%s", Field._ID, Field.SLOT_ID))
+                .put(Field.DAYOFWEEK, String.format("$%s.%s", Field._ID, Field.DAYOFWEEK))
+                .put(Field.COUNT, sum(String.format("$%s", Field.COUNT)));
+
+    }
+
+    /*
+    UTILITIES
+     */
+
+    private JsonObject isoDayOfWeek(JsonObject dateParam) {
+        return new JsonObject().put(String.format("$%s", Field.ISODAYOFWEEK), dateParam);
+    }
+
+    private JsonObject dateFromString(String dateParam) {
+
+        JsonObject dateString = new JsonObject().put(Field.DATESTRING, dateParam);
+
+        return new JsonObject()
+                .put(String.format("$%s", Field.DATEFROMSTRING), dateString);
+    }
+
+    private JsonObject sum(String value) {
+
+        return new JsonObject().put(String.format("$%s", Field.SUM), value);
+    }
+
+    private JsonObject sum() {
+        return new JsonObject().put(String.format("$%s", Field.SUM), 1);
+    }
+
+    private JsonObject id(JsonObject value) {
+        return new JsonObject()
+                .put(Field._ID, value);
+    }
+}

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/weekly/WeeklyStat.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/weekly/WeeklyStat.java
@@ -1,0 +1,133 @@
+package fr.openent.statistics_presences.bean.weekly;
+
+import fr.openent.presences.core.constants.Field;
+import fr.openent.statistics_presences.bean.Stat;
+import fr.openent.statistics_presences.utils.EventType;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class WeeklyStat implements Stat {
+    private String indicator;
+    private EventType type;
+    private String user;
+    private String structure;
+    private String startDate;
+    private String endDate;
+    private Integer slots;
+    private String slotId;
+    private String className;
+    private String name;
+    private JsonArray audiences = new JsonArray();
+    private Long reason;
+    private Long punishmentType;
+    private String groupedPunishmentId;
+
+
+    public WeeklyStat setIndicator(String indicator) {
+        this.indicator = indicator;
+        return this;
+    }
+
+    public WeeklyStat setUser(String user) {
+        this.user = user;
+        return this;
+    }
+
+    public WeeklyStat setStructure(String structure) {
+        this.structure = structure;
+        return this;
+    }
+
+    public WeeklyStat setAudiences(JsonArray audiences) {
+        this.audiences = audiences;
+        return this;
+    }
+
+    public WeeklyStat setType(EventType type) {
+        this.type = type;
+        return this;
+    }
+
+    public WeeklyStat setStartDate(String date) {
+        this.startDate = date;
+        return this;
+    }
+
+    public WeeklyStat setEndDate(String date) {
+        this.endDate = date;
+        return this;
+    }
+
+    public WeeklyStat setSlots(Integer count) {
+        this.slots = count;
+        return this;
+    }
+
+    public Integer getSlots() {
+        return slots;
+    }
+
+    public WeeklyStat setSlotId(String slotId) {
+        this.slotId = slotId;
+        return this;
+    }
+
+    public String getSlotId() {
+        return slotId;
+    }
+
+    public WeeklyStat setReason(Long reason) {
+        this.reason = reason;
+        return this;
+    }
+
+
+    public Long getReason() {
+        return reason;
+    }
+
+    public WeeklyStat setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public WeeklyStat setClassName(String className) {
+        this.className = className;
+        return this;
+    }
+
+    public Long getPunishmentType() {
+        return punishmentType;
+    }
+
+    public WeeklyStat setPunishmentType(Long punishmentType) {
+        this.punishmentType = punishmentType;
+        return this;
+    }
+
+    public String getGroupedPunishmentId() {
+        return groupedPunishmentId;
+    }
+
+    public WeeklyStat setGroupedPunishmentId(String groupedPunishmentId) {
+        this.groupedPunishmentId = groupedPunishmentId;
+        return this;
+    }
+
+    public JsonObject toJSON() {
+        return new JsonObject()
+                .put(Field.INDICATOR, this.indicator)
+                .put(Field.USER, this.user)
+                .put(Field.NAME, this.name)
+                .put(Field.CLASS_NAME, this.className)
+                .put(Field.TYPE, this.type.name())
+                .put(Field.REASON, this.reason)
+                .put(Field.PUNISHMENT_TYPE, this.punishmentType)
+                .put(Field.GROUPED_PUNISHMENT_ID, this.groupedPunishmentId)
+                .put(Field.START_DATE, this.startDate)
+                .put(Field.END_DATE, this.endDate)
+                .put(Field.STRUCTURE, this.structure)
+                .put(Field.AUDIENCES, this.audiences)
+                .put(Field.SLOT_ID, this.slotId);
+    }
+}

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/controller/EventBusController.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/controller/EventBusController.java
@@ -1,13 +1,16 @@
 package fr.openent.statistics_presences.controller;
 
 import fr.openent.presences.common.bus.BusResultHandler;
+import fr.openent.presences.common.helper.FutureHelper;
 import fr.openent.presences.core.constants.Field;
 import fr.openent.statistics_presences.StatisticsPresences;
 import fr.openent.statistics_presences.indicator.Indicator;
 import fr.openent.statistics_presences.model.StatisticsFilter;
 import fr.openent.statistics_presences.service.CommonServiceFactory;
 import fr.openent.statistics_presences.service.StatisticsPresencesService;
+import fr.openent.statistics_presences.service.StatisticsWeeklyAudiencesService;
 import fr.openent.statistics_presences.service.impl.DefaultStatisticsPresencesService;
+import fr.openent.statistics_presences.service.impl.DefaultStatisticsWeeklyAudiencesService;
 import fr.wseduc.bus.BusAddress;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;
@@ -20,9 +23,11 @@ import java.util.List;
 public class EventBusController extends ControllerHelper {
 
     private final StatisticsPresencesService statisticsService;
+    private final StatisticsWeeklyAudiencesService weeklyAudiencesService;
 
     public EventBusController(CommonServiceFactory commonServiceFactory) {
         statisticsService = new DefaultStatisticsPresencesService(commonServiceFactory);
+        weeklyAudiencesService = new DefaultStatisticsWeeklyAudiencesService(commonServiceFactory);
     }
 
     @BusAddress("fr.openent.statistics.presences")
@@ -35,6 +40,11 @@ public class EventBusController extends ControllerHelper {
                 String structure = body.getString("structureId");
                 List<String> student = body.getJsonArray("studentIds").getList();
                 statisticsService.create(structure, student, BusResultHandler.busResponseHandler(message));
+                break;
+            case "post-weekly-audiences":
+                String structureId = body.getString(Field.STRUCTUREID);
+                List<Integer> registerIds = body.getJsonArray(Field.REGISTERIDS).getList();
+                FutureHelper.busObjectHandler(weeklyAudiencesService.create(structureId, registerIds), message);
                 break;
             case "get-statistics-graph":
                 structure = body.getString("structureId");

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/controller/StatisticsWeeklyAudiencesController.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/controller/StatisticsWeeklyAudiencesController.java
@@ -1,0 +1,40 @@
+package fr.openent.statistics_presences.controller;
+
+import fr.openent.presences.core.constants.Field;
+import fr.openent.statistics_presences.service.CommonServiceFactory;
+import fr.openent.statistics_presences.service.StatisticsWeeklyAudiencesService;
+import fr.wseduc.rs.ApiDoc;
+import fr.wseduc.rs.Post;
+import fr.wseduc.security.ActionType;
+import fr.wseduc.security.SecuredAction;
+import fr.wseduc.webutils.request.RequestUtils;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonArray;
+import org.entcore.common.controller.ControllerHelper;
+import org.entcore.common.http.filter.AdminFilter;
+import org.entcore.common.http.filter.ResourceFilter;
+import java.util.List;
+
+public class StatisticsWeeklyAudiencesController extends ControllerHelper {
+    private final StatisticsWeeklyAudiencesService weeklyAudiencesService;
+
+    public StatisticsWeeklyAudiencesController(CommonServiceFactory serviceFactory) {
+        this.weeklyAudiencesService = serviceFactory.statisticsWeeklyAudiencesService();
+    }
+
+    @Post("/process/weekly/audiences/tasks")
+    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(AdminFilter.class)
+    @ApiDoc("Generate statistics weekly audiences")
+    @SuppressWarnings("unchecked")
+    public void processStatisticsPrefetch(final HttpServerRequest request) {
+        RequestUtils.bodyToJson(request, pathPrefix + "processWeeklyAudiencesPrefetch", body -> {
+            List<String> structureIds = body.getJsonArray(Field.STRUCTUREIDS, new JsonArray()).getList();
+            String startAt = body.getString(Field.STARTAT);
+            String endAt = body.getString(Field.ENDAT);
+            weeklyAudiencesService.processWeeklyAudiencesPrefetch(structureIds, startAt, endAt)
+                    .onSuccess(res -> renderJson(request, res))
+                    .onFailure(unused -> renderError(request));
+        });
+    }
+}

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/helper/RegisterHelper.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/helper/RegisterHelper.java
@@ -1,0 +1,23 @@
+package fr.openent.statistics_presences.helper;
+
+import fr.openent.statistics_presences.bean.Register;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class RegisterHelper {
+
+    private RegisterHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    @SuppressWarnings("unchecked")
+    public static List<Register> getRegistersFromArray(JsonArray registers) {
+        return ((List<JsonObject>) registers.getList()).stream()
+                .map(Register::new)
+                .collect(Collectors.toList());
+    }
+}
+

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/helper/TimeslotHelper.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/helper/TimeslotHelper.java
@@ -1,0 +1,45 @@
+package fr.openent.statistics_presences.helper;
+
+import fr.openent.presences.common.helper.DateHelper;
+import fr.openent.statistics_presences.bean.timeslot.Slot;
+import fr.openent.statistics_presences.bean.timeslot.Timeslot;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class TimeslotHelper {
+
+    private TimeslotHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    @SuppressWarnings("unchecked")
+    public static List<Timeslot> getTimeslotsFromArray(JsonArray timeslots) {
+        return ((List<JsonObject>) timeslots.getList()).stream()
+                .map(Timeslot::new)
+                .collect(Collectors.toList());
+    }
+
+    public static List<Slot> getSlotsFromPeriod(String startAt, String endAt, List<Slot> slots) {
+        long currentEventStartTime = DateHelper.parseDate(
+                DateHelper.fetchTimeString(startAt, DateHelper.SQL_FORMAT),
+                DateHelper.HOUR_MINUTES
+        ).getTime();
+
+        long currentEventEndTime = DateHelper.parseDate(
+                DateHelper.fetchTimeString(endAt, DateHelper.SQL_FORMAT),
+                DateHelper.HOUR_MINUTES
+        ).getTime();
+
+        return slots
+                .stream()
+                .filter(slot ->
+                        DateHelper.parseDate(slot.getEndHour(), DateHelper.HOUR_MINUTES).getTime() - currentEventStartTime > 0
+                                && currentEventEndTime - DateHelper.parseDate(slot.getStartHour(), DateHelper.HOUR_MINUTES).getTime() > 0
+                )
+                .collect(Collectors.toList());
+    }
+}
+

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/IndicatorGeneric.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/IndicatorGeneric.java
@@ -55,7 +55,9 @@ public class IndicatorGeneric {
     public static Future<JsonObject> retrieveUser(String structureId, String studentId) {
         Promise<JsonObject> promise = Promise.promise();
         String query = "MATCH (s:Structure {id:{structureId}})<-[:BELONGS]-(c:Class)<-[:DEPENDS]-(:ProfileGroup)<-[:IN]-" +
-                "(u:User {id: {studentId}}) RETURN (u.lastName + ' ' + u.firstName) as name, collect(c.name) as className";
+                "(u:User {id: {studentId}}) RETURN (u.lastName + ' ' + u.firstName) as name, collect(c.name) as className, " +
+                "collect(c.id) as classIds";
+
         JsonObject params = new JsonObject()
                 .put("structureId", structureId)
                 .put("studentId", studentId);

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/IndicatorWorker.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/IndicatorWorker.java
@@ -1,10 +1,13 @@
 package fr.openent.statistics_presences.indicator;
 
 import fr.openent.presences.common.helper.FutureHelper;
+import fr.openent.presences.common.viescolaire.Viescolaire;
 import fr.openent.statistics_presences.StatisticsPresences;
 import fr.openent.statistics_presences.bean.Failure;
 import fr.openent.statistics_presences.bean.Report;
 import fr.openent.statistics_presences.bean.Stat;
+import fr.openent.statistics_presences.bean.StatProcessSettings;
+import fr.openent.statistics_presences.bean.timeslot.Timeslot;
 import fr.openent.statistics_presences.utils.EventType;
 import fr.wseduc.mongodb.MongoDb;
 import io.vertx.core.*;
@@ -41,7 +44,7 @@ public abstract class IndicatorWorker extends AbstractVerticle {
         }
         FutureHelper.join(futures).onComplete(this::sendSigTerm);
     }
-    
+
     protected JsonArray reasonIds(String structureId) {
         return settings.get(structureId).getJsonArray("reasonIds", new JsonArray());
     }
@@ -213,17 +216,44 @@ public abstract class IndicatorWorker extends AbstractVerticle {
         List<EventType> eventTypes = Arrays.asList(EventType.values());
         Map<EventType, Future<List<Stat>>> statsByEventTypes = new HashMap<>();
 
-        for (EventType eventType : eventTypes) {
-            statsByEventTypes.put(eventType, fetchEvent(eventType, structureId, studentId));
-        }
+        StatProcessSettings statProcessSettings = new StatProcessSettings();
+
         Future<JsonArray> audienceFuture = IndicatorGeneric.retrieveAudiences(structureId, studentId);
         Future<JsonObject> studentFuture = IndicatorGeneric.retrieveUser(structureId, studentId);
 
-        List<Future> futures = new ArrayList<>(statsByEventTypes.values());
-        futures.add(audienceFuture);
-        futures.add(studentFuture);
+        CompositeFuture.all(audienceFuture, studentFuture)
+                .compose(settingsRes -> {
+                    statProcessSettings.setStudentInfo(studentFuture.result());
+                    statProcessSettings.setAudienceIds(audienceFuture.result());
 
-        CompositeFuture.all(futures)
+                    String classId = !statProcessSettings.getStudentClassIds().isEmpty() ?
+                            statProcessSettings.getStudentClassIds().get(0) : null;
+
+                    return Viescolaire.getInstance().getAudienceTimeslots(structureId, Collections.singletonList(classId));
+                })
+                .compose(timeslots -> {
+                    if (timeslots == null || timeslots.isEmpty()) {
+                        String message = String.format("[StatisticsPresences@%s::processStudent] " +
+                                        "%s error: timeslot not found in structure %s",
+                                this.getClass().getSimpleName(), indicatorName(), structureId);
+                        log.error(message);
+                        return Future.failedFuture(message);
+                    }
+
+                    statProcessSettings.setTimeslot(timeslots.getJsonObject(0));
+
+                    for (EventType eventType : eventTypes) {
+                        statsByEventTypes.put(eventType, fetchEvent(eventType, structureId, studentId, statProcessSettings.getTimeslot()));
+                    }
+
+                    return CompositeFuture.all(new ArrayList<>(statsByEventTypes.values()));
+                })
+                .onFailure(ar -> {
+                    log.error(String.format("[StatisticsPresences@IndicatorWorker::processStudent] " +
+                                    "Failed to process student %s in structure %s for indicator %s", studentId, structureId,
+                            indicatorName()), ar.getCause());
+                    promise.fail(ar.getCause());
+                })
                 .onSuccess(ar -> {
                     log.debug(String.format("[StatisticsPresences@IndicatorWorker::processStudent] Student %s proceed", studentId));
                     List<JsonObject> userStats = new ArrayList<>();
@@ -247,12 +277,6 @@ public abstract class IndicatorWorker extends AbstractVerticle {
                                     }))
                             .collect(Collectors.toList());
                     promise.complete(userStats);
-                })
-                .onFailure(ar -> {
-                    log.error(String.format("[StatisticsPresences@IndicatorWorker::processStudent] " +
-                            "Failed to process student %s in structure %s for indicator %s", studentId, structureId,
-                            indicatorName()), ar.getCause());
-                    promise.fail(ar.getCause());
                 });
 
         return promise.future();
@@ -267,5 +291,5 @@ public abstract class IndicatorWorker extends AbstractVerticle {
         }
     }
 
-    protected abstract Future<List<Stat>> fetchEvent(EventType type, String structureId, String studentId);
+    protected abstract Future<List<Stat>> fetchEvent(EventType type, String structureId, String studentId, Timeslot timeslot);
 }

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/ProcessingWeeklyAudiencesManual.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/ProcessingWeeklyAudiencesManual.java
@@ -1,0 +1,110 @@
+package fr.openent.statistics_presences.indicator;
+
+import fr.openent.presences.common.helper.FutureHelper;
+import fr.openent.presences.common.presences.Presences;
+import fr.openent.presences.core.constants.Field;
+import fr.openent.statistics_presences.helper.RegisterHelper;
+import fr.openent.statistics_presences.service.CommonServiceFactory;
+import io.vertx.core.*;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.vertx.java.busmods.BusModBase;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+public class ProcessingWeeklyAudiencesManual extends BusModBase implements Handler<Message<JsonObject>> {
+    public static final Integer STATE_IN_PROGRESS = 2;
+    public static final Integer STATE_DONE = 3;
+
+    Logger log = LoggerFactory.getLogger(ProcessingWeeklyAudiencesManual.class);
+    private CommonServiceFactory commonServiceFactory;
+
+    @Override
+    public void start() {
+        super.start();
+        this.commonServiceFactory = new CommonServiceFactory(vertx);
+        eb.consumer(this.getClass().getName(), this);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void handle(Message<JsonObject> eventMessage) {
+        log.info(String.format("[StatisticsPresences@%s::process] receiving from route /process/weekly/audiences/tasks",
+                this.getClass().getSimpleName()));
+        eventMessage.reply(new JsonObject().put(Field.STATUS, Field.OK));
+
+        List<String> structureIds = eventMessage.body().getJsonArray(Field.STRUCTUREIDS, new JsonArray()).getList();
+        String startAt = eventMessage.body().getString(Field.STARTAT);
+        String endAt = eventMessage.body().getString(Field.ENDAT);
+
+        processStructures(structureIds, startAt, endAt);
+    }
+
+    /**
+     * Launch process by structure.
+     *
+     * @param structureIds List of structure identifiers.
+     * @param startAt      start period to get registers (optional).
+     * @param endAt        end period to get registers (optional).
+     * @return Future handling structureIds list that succeeded
+     */
+    private void processStructures(List<String> structureIds, String startAt, String endAt) {
+        List<Future<String>> structuresFutures = new ArrayList<>();
+
+        for (String structureId : structureIds) {
+            structuresFutures.add(processStructure(structureId, startAt, endAt));
+        }
+
+        FutureHelper.join(structuresFutures)
+                .onFailure(err -> {
+                    String message = String.format("[StatisticsPresences@%s::sendSigTerm] Some structures failed during processing",
+                            this.getClass().getSimpleName());
+                    log.error(message, err.getMessage());
+                })
+                .onSuccess(res -> {
+                    List<String> structureResultIds = structuresFutures.stream()
+                            .filter(Future::succeeded)
+                            .map(Future::result)
+                            .collect(Collectors.toList());
+
+                    log.info(String.format("[StatisticsPresences@%s::sendSigTerm] process succeeded for structures %s.",
+                            this.getClass().getSimpleName(), structureResultIds));
+                });
+    }
+
+    /**
+     * Launch process structure. The process compute values for each registers of the structure and store it
+     * in the database as weeklyAudience.
+     *
+     * @param structureId structure identifiers.
+     * @param startAt     start of period to get registers (optional).
+     * @param endAt       end of period to get registers (optional).
+     * @return Future handling structureId when it succeeded
+     */
+    private Future<String> processStructure(String structureId, String startAt, String endAt) {
+        Promise<String> promise = Promise.promise();
+
+
+        Presences.getInstance().getRegistersWithGroups(structureId, null, Arrays.asList(STATE_DONE, STATE_IN_PROGRESS),
+                        startAt, endAt)
+                .compose(registersResult -> commonServiceFactory.statisticsWeeklyAudiencesService()
+                        .createFromRegisters(structureId, RegisterHelper.getRegistersFromArray(registersResult)))
+                .onSuccess(result -> promise.complete(structureId))
+                .onFailure(error -> {
+                            String message = String.format("[StatisticsPresences@%s::processStructures] " +
+                                            "Processing weekly audiences failed for structure %s. %s",
+                                    this.getClass().getSimpleName(), structureId, error.getMessage());
+                            log.error(message);
+                            promise.fail(message);
+                        }
+                );
+        return promise.future();
+    }
+}

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/impl/Weekly.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/impl/Weekly.java
@@ -1,0 +1,175 @@
+package fr.openent.statistics_presences.indicator.impl;
+
+import fr.openent.presences.core.constants.Field;
+import fr.openent.statistics_presences.bean.weekly.WeeklySearch;
+import fr.openent.statistics_presences.indicator.Indicator;
+import fr.openent.statistics_presences.indicator.IndicatorGeneric;
+import fr.openent.statistics_presences.model.StatisticsFilter;
+import io.vertx.core.*;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.entcore.common.mongodb.MongoDbResult;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class Weekly extends Indicator {
+    private final Logger log = LoggerFactory.getLogger(Weekly.class);
+
+    public Weekly(Vertx vertx, String name) {
+        super(vertx, name);
+    }
+
+    @Override
+    public void search(StatisticsFilter filter, Handler<AsyncResult<JsonObject>> handler) {
+        setSearchUserWithAudiences(filter)
+                .compose(this::searchProcess)
+                .onComplete(handler);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Future<WeeklySearch> setSearchUserWithAudiences(StatisticsFilter filter) {
+        Promise<WeeklySearch> promise = Promise.promise();
+        WeeklySearch search = new WeeklySearch(filter);
+
+        if (!filter.users().isEmpty()) {
+            filter.setUserId(filter.users().get(0));
+            IndicatorGeneric.retrieveAudiences(filter.structure(), filter.userId())
+                    .onFailure(err -> {
+                        String message = String.format("[StatisticsPresences@%s::setSearchUserWithAudiences] " +
+                                "Indicator %s failed to retrieve settings", this.getClass().getSimpleName(), Weekly.class.getName());
+                        log.error(String.format("%s. %s", message, err.getMessage()));
+                        promise.fail(message);
+                    })
+                    .onSuccess(audienceIds -> {
+                        filter.setAudiences(audienceIds.getList());
+                        promise.complete(search);
+                    });
+        } else if (!filter.audiences().isEmpty()) {
+            filter.setAudiences(Collections.singletonList(filter.audiences().get(0)));
+            promise.complete(search);
+        } else {
+            String message = String.format("[StatisticsPresences@%s::setSearchUserWithAudiences] " +
+                    "Indicator %s search need one audience or one student to retrieve data.", this.getClass().getSimpleName(),
+                    Weekly.class.getName());
+            log.error(message);
+            promise.fail(message);
+        }
+
+        return promise.future();
+    }
+
+
+    @Override
+    public void searchGraph(StatisticsFilter filter, Handler<AsyncResult<JsonObject>> handler) {
+        throw new UnsupportedOperationException();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Future<JsonObject> searchProcess(WeeklySearch search) {
+        Promise<JsonObject> promise = Promise.promise();
+
+
+        Future<JsonArray> countEventsBySlotsFuture = retrieveStatistics(search.countEventTypedBySlotsCommand());
+        Future<JsonArray> studentCountBySlotsFuture = retrieveStatistics(search.countStudentsBySlotsCommand());
+
+        CompositeFuture.all(countEventsBySlotsFuture, studentCountBySlotsFuture)
+                .onSuccess(ar -> {
+                    List<JsonObject> values = (List<JsonObject>) ((List<JsonObject>) studentCountBySlotsFuture.result().getList()).stream()
+                            .map(studentCount ->
+                                formatEventsToRateSlots(countEventsBySlotsFuture.result().getList(), studentCount)
+                            )
+                            .collect(Collectors.toList());
+
+                    setMaxValue(values);
+                    JsonObject response = new JsonObject()
+                            .put(Field.DATA, values);
+
+                    promise.complete(response);
+                })
+                .onFailure(fail -> {
+                    log.error(String.format("[StatisticsPresences@Global::searchProcess] " +
+                            "Indicator %s failed to complete search", Weekly.class.getName()), fail.getCause());
+                    promise.fail(fail.getCause());
+                });
+        return promise.future();
+    }
+
+    private JsonObject formatEventsToRateSlots(List<JsonObject> eventCounts, JsonObject studentCount) {
+        JsonObject eventCount = eventCounts.stream()
+                .filter(eventSlot -> eventSlot.getString(Field.SLOT_ID, "")
+                            .equals(studentCount.getString(Field.SLOT_ID))
+                            && eventSlot.getInteger(Field.DAYOFWEEK) != null && eventSlot.getInteger(Field.DAYOFWEEK)
+                            .equals(studentCount.getInteger(Field.DAYOFWEEK))
+                )
+                .findFirst()
+                .orElse(new JsonObject().put(Field.COUNT, 0));
+
+        return new JsonObject()
+                .put(Field.SLOT_ID, studentCount.getString(Field.SLOT_ID))
+                .put(Field.DAYOFWEEK, studentCount.getInteger(Field.DAYOFWEEK))
+                .put(Field.RATE, getEventRates(studentCount.getInteger(Field.COUNT),
+                        eventCount.getInteger(Field.COUNT)));
+    }
+
+    private double getEventRates(Integer studentCount, Integer eventCount) {
+        double rate = (studentCount == null || eventCount == null ? 0.0 : Math.abs((((double)eventCount) * 100) / ((double)studentCount)));
+        rate = Double.isInfinite(rate) || Double.isNaN(rate) ? 0.0 : rate;
+        return  getValidRate(Math.min(rate, 100));
+    }
+
+    private double getValidRate(double rate) {
+        if (Double.isInfinite(rate) || Double.isNaN(rate)) return 0.0;
+        return BigDecimal.valueOf(Math.min(rate, 100)).setScale(2, RoundingMode.HALF_DOWN).doubleValue();
+    }
+
+    public Future<JsonArray> retrieveStatistics(JsonObject command) {
+        Promise<JsonArray> promise = Promise.promise();
+        if (command == null || command.isEmpty()) {
+            promise.complete(new JsonArray());
+            return promise.future();
+        }
+
+        mongoDb.command(command.toString(), MongoDbResult.validResultHandler(either -> {
+            if (either.isLeft()) {
+                String message = String.format("[StatisticsPresences@%s::retrieveStatistics] " +
+                                "Indicator %s failed to execute mongodb aggregation pipeline", this.getClass().getSimpleName(),
+                        Weekly.class.getName());
+                log.error(String.format("%s. %s", message, either.left().getValue()));
+                promise.fail(message);
+                return;
+            }
+            JsonObject result = either.right().getValue();
+            if (result.getJsonObject(Field.CURSOR) == null) {
+                String error = either.right().getValue().getString(Field.ERRMSG);
+                String message = String.format("[StatisticsPresences@%s::retrieveStatistics] Indicator %s failed to execute " +
+                        "mongodb aggregation pipeline.", this.getClass().getSimpleName(), Weekly.class.getName());
+                log.error(String.format("%s. %s", message, error));
+                promise.fail(message);
+                return;
+            }
+
+
+            promise.complete(result.getJsonObject(Field.CURSOR).getJsonArray(Field.FIRSTBATCH, new JsonArray()));
+        }));
+
+        return promise.future();
+    }
+
+    private void setMaxValue(List<JsonObject> rateSlots) {
+        Double maxRate = rateSlots.stream()
+                .max(Comparator.comparing(rateSlot -> rateSlot.getDouble(Field.RATE, 0.0)))
+                .map(rateSlot -> rateSlot.getDouble(Field.RATE, 0.0))
+                .orElse(null);
+
+        if (maxRate != null && maxRate > 0.0) {
+            rateSlots.stream()
+                    .filter(rateSlot -> maxRate.equals(rateSlot.getDouble(Field.RATE)))
+                    .forEach(rateSlot -> rateSlot.put(Field.MAX, Boolean.TRUE));
+        }
+    }
+}

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/worker/Global.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/worker/Global.java
@@ -3,6 +3,7 @@ package fr.openent.statistics_presences.indicator.worker;
 import fr.openent.presences.core.constants.Field;
 import fr.openent.statistics_presences.bean.Stat;
 import fr.openent.statistics_presences.bean.global.GlobalStat;
+import fr.openent.statistics_presences.bean.timeslot.Timeslot;
 import fr.openent.statistics_presences.indicator.IndicatorGeneric;
 import fr.openent.statistics_presences.indicator.IndicatorWorker;
 import fr.openent.statistics_presences.utils.EventType;
@@ -28,7 +29,7 @@ public class Global extends IndicatorWorker {
      */
     @Override
     @SuppressWarnings("unchecked")
-    protected Future<List<Stat>> fetchEvent(EventType type, String structureId, String studentId) {
+    protected Future<List<Stat>> fetchEvent(EventType type, String structureId, String studentId, Timeslot timeslot) {
         Future<List<Stat>> future;
         switch (type) {
             case INCIDENT:

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/worker/Monthly.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/worker/Monthly.java
@@ -3,6 +3,7 @@ package fr.openent.statistics_presences.indicator.worker;
 import fr.openent.presences.core.constants.Field;
 import fr.openent.statistics_presences.bean.Stat;
 import fr.openent.statistics_presences.bean.monthly.MonthlyStat;
+import fr.openent.statistics_presences.bean.timeslot.Timeslot;
 import fr.openent.statistics_presences.indicator.IndicatorGeneric;
 import fr.openent.statistics_presences.indicator.IndicatorWorker;
 import fr.openent.statistics_presences.utils.EventType;
@@ -34,7 +35,7 @@ public class Monthly extends IndicatorWorker {
      */
     @Override
     @SuppressWarnings("unchecked")
-    protected Future<List<Stat>> fetchEvent(EventType type, String structureId, String studentId) {
+    protected Future<List<Stat>> fetchEvent(EventType type, String structureId, String studentId, Timeslot timeslot) {
         Future<List<Stat>> future;
         switch (type) {
             case INCIDENT:

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/worker/Weekly.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/worker/Weekly.java
@@ -1,0 +1,169 @@
+package fr.openent.statistics_presences.indicator.worker;
+
+import fr.openent.presences.common.helper.DateHelper;
+import fr.openent.presences.core.constants.Field;
+import fr.openent.statistics_presences.bean.Stat;
+import fr.openent.statistics_presences.bean.timeslot.Slot;
+import fr.openent.statistics_presences.bean.weekly.WeeklyStat;
+import fr.openent.statistics_presences.bean.timeslot.Timeslot;
+import fr.openent.statistics_presences.helper.TimeslotHelper;
+import fr.openent.statistics_presences.indicator.IndicatorGeneric;
+import fr.openent.statistics_presences.indicator.IndicatorWorker;
+import fr.openent.statistics_presences.utils.EventType;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class Weekly extends IndicatorWorker {
+
+    /**
+     * Fetch events in queue and set their count values.
+     *
+     * @param type        event type
+     * @param structureId structure identifier
+     * @param studentId   student identifier
+     * @param timeslot   student timeslot
+     * @return future with event process
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    protected Future<List<Stat>> fetchEvent(EventType type, String structureId, String studentId, Timeslot timeslot) {
+        Future<List<Stat>> future;
+        switch (type) {
+            case DEPARTURE:
+                future = retrieveEventCount(structureId, studentId, 3, timeslot);
+                break;
+            case LATENESS:
+                future = retrieveEventCount(structureId, studentId, 2, timeslot);
+                break;
+            case NO_REASON:
+                future = fetchEventCountFromPresences(structureId, studentId, new ArrayList<>(), true,
+                        false, timeslot);
+                break;
+            case UNREGULARIZED:
+                future = fetchEventCountFromPresences(structureId, studentId, reasonIds(structureId).getList(), false,
+                        false, timeslot);
+                break;
+            case REGULARIZED:
+                future = fetchEventCountFromPresences(structureId, studentId, reasonIds(structureId).getList(), false,
+                        true, timeslot);
+                break;
+            case INCIDENT:
+            case SANCTION:
+            case PUNISHMENT:
+                future = Future.succeededFuture(Collections.emptyList());
+                break;
+            default:
+                future = Future.failedFuture(new RuntimeException("Unrecognized event type"));
+        }
+
+        return future;
+    }
+
+    private Future<List<Stat>> countHandler(Future<JsonArray> requestResult, Timeslot timeslot) {
+        Promise<List<Stat>> promise = Promise.promise();
+        requestResult
+                .onSuccess(result -> {
+                    List<Stat> stats = new ArrayList<>();
+                    for (int i = 0; i < result.size(); i++) {
+                        JsonObject incident = result.getJsonObject(i);
+                        stats.add(setStatFromStartDate(incident, timeslot));
+                    }
+
+                    promise.complete(stats);
+                })
+                .onFailure(promise::fail);
+        return promise.future();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Future<List<Stat>> fetchEventCountFromPresences(String structureId, String studentId, List<Integer> reasonIds,
+                                                            Boolean noReasons, Boolean regularized, Timeslot timeslot) {
+        Promise<List<Stat>> promise = Promise.promise();
+        IndicatorGeneric.fetchEventsFromPresences(structureId, studentId, reasonIds, noReasons, regularized)
+                .onSuccess(result -> {
+                    List<Stat> stats = ((List<JsonObject>) result.getList()).stream()
+                            .flatMap(event -> {
+                                List<WeeklyStat> slotStats = getSplitEventsBySlots(event, timeslot);
+                                Long reasonId = ((List<JsonObject>) event.getJsonArray(Field.EVENTS).getList()).stream()
+                                        .map(evt -> evt.getLong(Field.REASON_ID))
+                                        .filter(Objects::nonNull)
+                                        .findFirst()
+                                        .orElse(null);
+
+                                slotStats.forEach(stat -> stat.setReason(reasonId));
+                                return slotStats.stream();
+                            })
+                            .collect(Collectors.toList());
+                    promise.complete(stats);
+                })
+                .onFailure(promise::fail);
+
+        return promise.future();
+    }
+
+    private Future<List<Stat>> retrieveEventCount(String structureId, String studentId, Integer eventType, Timeslot timeslot) {
+        String select = "event.start_date, event.end_date";
+        return countHandler(IndicatorGeneric.retrieveEventCount(structureId, studentId, eventType, select, null), timeslot);
+    }
+
+    private List<WeeklyStat> getSplitEventsBySlots(JsonObject event, Timeslot timeslot) {
+        List<Slot> slots = TimeslotHelper.getSlotsFromPeriod(event.getString(Field.START_DATE), event.getString(Field.END_DATE), timeslot.getSlots());
+
+
+        if (slots == null || slots.isEmpty()) {
+            String message = String.format("[StatisticsPresences@%s::getSplitEventsBySlots] " +
+                            "Slots not found for event %s",
+                    this.getClass().getSimpleName(), event.getString(Field.ID));
+            log.error(message);
+            return Collections.singletonList(new WeeklyStat().setSlotId(null)
+                    .setStartDate(event.getString(Field.START_DATE))
+                    .setEndDate(event.getString(Field.END_DATE)));
+        }
+        return slots.stream()
+                .map(slot -> createStatFromStartDate(event, slot))
+                .collect(Collectors.toList());
+    }
+
+    private WeeklyStat setStatFromStartDate(JsonObject event, Timeslot timeslot) {
+        Slot slot = getCurrentSlot(event.getString(Field.START_DATE), timeslot.getSlots());
+        if (slot == null) {
+            return new WeeklyStat().setSlotId(null)
+                    .setStartDate(event.getString(Field.START_DATE))
+                    .setEndDate(event.getString(Field.END_DATE));
+        }
+        return createStatFromStartDate(event, slot);
+    }
+
+    private WeeklyStat createStatFromStartDate(JsonObject event, Slot slot) {
+        return new WeeklyStat()
+                .setSlotId(slot.getId())
+                .setStartDate(DateHelper.setTimeToDate(
+                        event.getString(Field.START_DATE), slot.getStartHour(), DateHelper.HOUR_MINUTES, DateHelper.SQL_FORMAT
+                ))
+                .setEndDate(DateHelper.setTimeToDate(
+                        event.getString(Field.START_DATE), slot.getEndHour(), DateHelper.HOUR_MINUTES, DateHelper.SQL_FORMAT
+                ));
+    }
+
+    private Slot getCurrentSlot(String date, List<Slot> slots) {
+        long currentEventStartTime = DateHelper.parseDate(
+                DateHelper.fetchTimeString(date, DateHelper.SQL_FORMAT),
+                DateHelper.HOUR_MINUTES
+        ).getTime();
+
+        return slots
+                .stream()
+                .filter(slot -> DateHelper.parseDate(slot.getStartHour(), DateHelper.HOUR_MINUTES).getTime() - currentEventStartTime >= 0)
+                .min((slotA, slotB) -> {
+                    long dateA = DateHelper.parseDate(slotA.getStartHour(), DateHelper.HOUR_MINUTES).getTime() - currentEventStartTime;
+                    long dateB = DateHelper.parseDate(slotB.getStartHour(), DateHelper.HOUR_MINUTES).getTime() - currentEventStartTime;
+                    return Long.compare(dateA, dateB);
+                }).orElse(null);
+    }
+
+}

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/service/CommonServiceFactory.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/service/CommonServiceFactory.java
@@ -3,6 +3,7 @@ package fr.openent.statistics_presences.service;
 import fr.openent.presences.common.service.*;
 import fr.openent.presences.common.service.impl.*;
 import fr.openent.statistics_presences.service.impl.DefaultStatisticsPresencesService;
+import fr.openent.statistics_presences.service.impl.DefaultStatisticsWeeklyAudiencesService;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
 
@@ -21,6 +22,10 @@ public class CommonServiceFactory {
 
     public StatisticsPresencesService statisticsPresencesService() {
         return new DefaultStatisticsPresencesService(this);
+    }
+
+    public StatisticsWeeklyAudiencesService statisticsWeeklyAudiencesService() {
+        return new DefaultStatisticsWeeklyAudiencesService(this);
     }
 
     public EventBus eventBus() {

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/service/StatisticsWeeklyAudiencesService.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/service/StatisticsWeeklyAudiencesService.java
@@ -1,0 +1,37 @@
+package fr.openent.statistics_presences.service;
+
+import fr.openent.statistics_presences.bean.Register;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+
+import java.util.List;
+
+public interface StatisticsWeeklyAudiencesService {
+    /**
+     * Create statistics weekly audiences
+     *
+     * @param structureId structure identifier
+     * @param registerIds register identifiers to convert
+     * @return Future containing creation the result
+     */
+    Future<JsonObject> create(String structureId, List<Integer> registerIds);
+
+    /**
+     * Create statistics weekly audiences from registers
+     *
+     * @param structureId structure identifier
+     * @param registers registers to convert
+     * @return Future containing creation the result
+     */
+    Future<JsonObject> createFromRegisters(String structureId, List<Register> registers);
+
+    /**
+     * Fire worker that convert registers to statisticsWeeklyAudiences
+     *
+     * @param structureIds list structure identifier
+     * @param startAt start date to retrieve register to convert
+     * @param endAt end date to retrieve register to convert
+     * @return Future JsonObject completing process
+     */
+    Future<JsonObject> processWeeklyAudiencesPrefetch(List<String> structureIds, String startAt, String endAt);
+}

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/service/impl/DefaultStatisticsWeeklyAudiencesService.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/service/impl/DefaultStatisticsWeeklyAudiencesService.java
@@ -1,0 +1,254 @@
+package fr.openent.statistics_presences.service.impl;
+
+
+import com.mongodb.QueryBuilder;
+import fr.openent.presences.common.helper.DateHelper;
+import fr.openent.presences.common.helper.FutureHelper;
+import fr.openent.presences.common.presences.Presences;
+import fr.openent.presences.common.viescolaire.Viescolaire;
+import fr.openent.presences.core.constants.Field;
+import fr.openent.presences.db.DBService;
+import fr.openent.statistics_presences.StatisticsPresences;
+import fr.openent.statistics_presences.bean.Register;
+import fr.openent.statistics_presences.bean.timeslot.Slot;
+import fr.openent.statistics_presences.bean.timeslot.Timeslot;
+import fr.openent.statistics_presences.bean.weekly.WeeklyAudience;
+import fr.openent.statistics_presences.helper.RegisterHelper;
+import fr.openent.statistics_presences.helper.TimeslotHelper;
+import fr.openent.statistics_presences.indicator.ProcessingWeeklyAudiencesManual;
+import fr.openent.statistics_presences.service.CommonServiceFactory;
+import fr.openent.statistics_presences.service.StatisticsWeeklyAudiencesService;
+import fr.wseduc.mongodb.MongoQueryBuilder;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.entcore.common.mongodb.MongoDbResult;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static fr.wseduc.webutils.Utils.handlerToAsyncHandler;
+
+public class DefaultStatisticsWeeklyAudiencesService extends DBService implements StatisticsWeeklyAudiencesService {
+    protected final Logger log = LoggerFactory.getLogger(DefaultStatisticsWeeklyAudiencesService.class);
+    private final CommonServiceFactory commonServiceFactory;
+
+
+    public DefaultStatisticsWeeklyAudiencesService(CommonServiceFactory commonServiceFactory) {
+        this.commonServiceFactory = commonServiceFactory;
+    }
+
+    @Override
+    public Future<JsonObject> create(String structureId, List<Integer> registerIds) {
+        Promise<JsonObject> promise = Promise.promise();
+
+        Presences.getInstance().getRegistersWithGroups(structureId, registerIds, null, null, null)
+                .compose(registerResults -> {
+                    List<Register> registers = RegisterHelper.getRegistersFromArray(registerResults);
+
+                    String resStructureId = structureId;
+                    if (resStructureId == null) {
+                        List<String> structureIds = registers.stream()
+                                .map(Register::getStructureId)
+                                .filter(Objects::nonNull)
+                                .distinct()
+                                .collect(Collectors.toList());
+
+                        if (structureIds.size() != 1) {
+                            String message = String.format("[StatisticsPresences@%s::create] " +
+                                    "Can not save registers from different structures", this.getClass().getSimpleName());
+                            return Future.failedFuture(message);
+                        }
+                        resStructureId = structureIds.get(0);
+                    }
+
+                    return createFromRegisters(resStructureId, RegisterHelper.getRegistersFromArray(registerResults));
+                })
+                .onFailure(promise::fail)
+                .onSuccess(createResults -> promise.complete());
+
+        return promise.future();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Future<JsonObject> createFromRegisters(String structureId, List<Register> registers) {
+        Promise<JsonObject> promise = Promise.promise();
+        List<String> audienceIds = registers.stream()
+                .map(Register::getAudienceId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .collect(Collectors.toList());
+
+        Future<JsonArray> timeslotsFuture = Viescolaire.getInstance().getAudienceTimeslots(structureId, audienceIds);
+        Future<JsonArray> countStudentsFuture = Viescolaire.getInstance().getCountStudentsByAudiences(audienceIds);
+        Future<List<Register>> registersFuture = filterRegisterByUnsavedWeeklyAudiences(registers);
+
+        CompositeFuture.all(timeslotsFuture, countStudentsFuture, registersFuture)
+                .compose(futures -> {
+                    List<Timeslot> timeslots = TimeslotHelper.getTimeslotsFromArray(timeslotsFuture.result());
+                    List<JsonObject> groupCountStudents = countStudentsFuture.result().getList();
+                    List<JsonObject> weeklyAudiences = mapRegistersToMongoWeeklyAudiences(registersFuture.result(), timeslots, groupCountStudents);
+                    return storeValues(new JsonArray(weeklyAudiences));
+                })
+                .onSuccess(res -> promise.complete())
+                .onFailure(error -> {
+                    String message = String.format("[StatisticsPresences@%s::createFromRegisters] " +
+                            "Failed create weekly audiences from registers", this.getClass().getSimpleName());
+                    log.error(String.format("%s. %s", message, error));
+                    promise.fail(message);
+                });
+
+        return promise.future();
+    }
+
+
+    private List<JsonObject> mapRegistersToMongoWeeklyAudiences(List<Register> registers, List<Timeslot> timeslots, List<JsonObject> groupCountStudents) {
+        return registers.stream()
+                .flatMap(register -> {
+                    Timeslot timeslot = timeslots.stream()
+                            .filter(timeslotFilter -> timeslotFilter.getAudienceId().equals(register.getAudienceId()))
+                            .findFirst()
+                            .orElse(null);
+
+                    JsonObject countStudents = groupCountStudents.stream()
+                            .filter(countStudentsFilter -> countStudentsFilter.getString(Field.ID_GROUPE).equals(register.getAudienceId()))
+                            .findFirst()
+                            .orElse(new JsonObject().put(Field.NB, 0));
+
+
+                    return mapRegisterToMongoWeeklyAudiences(register, timeslot, countStudents).stream();
+                })
+                .collect(Collectors.toList());
+    }
+
+    private List<JsonObject> mapRegisterToMongoWeeklyAudiences(Register register, Timeslot timeslot, JsonObject countStudents) {
+        if (timeslot == null) {
+            String message = String.format("[StatisticsPresences@%s::mapRegisterToWeeklyAudiences] " +
+                            "Timeslot not found in structure %s for audience %s",
+                    this.getClass().getSimpleName(), register.getStructureId(), register.getAudienceId());
+            log.error(message);
+            return Collections.emptyList();
+        }
+
+        List<Slot> slots = TimeslotHelper.getSlotsFromPeriod(register.getStartAt(),
+                register.getEndAt(), timeslot.getSlots());
+
+        if (slots == null || slots.isEmpty()) {
+            String message = String.format("[StatisticsPresences@%s::mapRegisterToWeeklyAudiences] " +
+                            "Slots not found in structure %s for register %s",
+                    this.getClass().getSimpleName(), register.getStructureId(), register.getId());
+            log.error(message);
+            return Collections.singletonList(new WeeklyAudience()
+                    .setSlotId(null)
+                    .setStructureId(register.getStructureId())
+                    .setAudienceId(register.getAudienceId())
+                    .setRegisterId(register.getId())
+                    .setStartAt(register.getStartAt())
+                    .setEndAt(register.getEndAt())
+                    .setStudentCount(countStudents.getInteger(Field.NB, 0))
+                    .toJSON());
+        }
+        return slots.stream()
+                .map(slot -> new WeeklyAudience()
+                        .setStructureId(register.getStructureId())
+                        .setAudienceId(register.getAudienceId())
+                        .setRegisterId(register.getId())
+                        .setSlotId(slot.getId())
+                        .setStartAt(DateHelper.setTimeToDate(
+                                register.getStartAt(), slot.getStartHour(), DateHelper.HOUR_MINUTES, DateHelper.SQL_FORMAT
+                        ))
+                        .setEndAt(DateHelper.setTimeToDate(
+                                register.getStartAt(), slot.getEndHour(), DateHelper.HOUR_MINUTES, DateHelper.SQL_FORMAT
+                        ))
+                        .setStudentCount(countStudents.getInteger(Field.NB, 0))
+                        .toJSON())
+                .collect(Collectors.toList());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Future<List<Register>> filterRegisterByUnsavedWeeklyAudiences(List<Register> registers) {
+        Promise<List<Register>> promise = Promise.promise();
+        List<Integer> registerIds = registers.stream().map(Register::getId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .collect(Collectors.toList());
+
+        getWeeklyAudiences(registerIds)
+                .onFailure(err -> {
+                    String message = String.format("[StatisticsPresences@%s::filterRegisterByUnsavedWeeklyAudiences]" +
+                            " failed to retrieve weeklyAudiences.", this.getClass().getSimpleName());
+                    log.error(String.format("%s %s", message, err.getMessage()));
+                    promise.fail(message);
+                })
+                .onSuccess(weeklyAudiences ->
+                        promise.complete(
+                                registers
+                                        .stream()
+                                        .filter(register ->
+                                                ((List<JsonObject>) weeklyAudiences.getList()).stream()
+                                                        .noneMatch(weeklyAudience -> {
+                                                            JsonObject id = weeklyAudience.getJsonObject(Field._ID);
+                                                            return register.getId() == null || register.getAudienceId() == null ||
+                                                                    (register.getId().equals(id.getInteger(Field.REGISTER_ID)) &&
+                                                                            register.getAudienceId().equals(id.getString(Field.AUDIENCE_ID)));
+                                                        }))
+                                        .collect(Collectors.toList())
+                        ));
+        return promise.future();
+    }
+
+    private Future<Void> storeValues(JsonArray weeklyAudiences) {
+        Promise<Void> promise = Promise.promise();
+        if (!weeklyAudiences.isEmpty()) {
+            mongoDb.insert(StatisticsPresences.WEEKLY_AUDIENCES_COLLECTION, weeklyAudiences,
+                    MongoDbResult.validResultHandler(results -> {
+                        if (results.isLeft()) {
+                            String message = String.format("[StatisticsPresences@%s::createFromRegisters] " +
+                                    "Failed to store new values", this.getClass().getSimpleName());
+
+                            log.error(String.format("%s. %s", message, results.left().getValue()));
+                            promise.fail(message);
+                            return;
+                        }
+                        promise.complete();
+                    }));
+        } else promise.complete();
+
+        return promise.future();
+    }
+
+    private Future<JsonArray> getWeeklyAudiences(List<Integer> registerIds) {
+        Promise<JsonArray> promise = Promise.promise();
+        QueryBuilder matcher = QueryBuilder.start(String.format("%s.%s", Field._ID, Field.REGISTER_ID)).in(registerIds);
+        mongoDb.find(StatisticsPresences.WEEKLY_AUDIENCES_COLLECTION, MongoQueryBuilder.build(matcher),
+                MongoDbResult.validResultsHandler(FutureHelper.handlerJsonArray(promise)));
+        return promise.future();
+    }
+
+    @Override
+    public Future<JsonObject> processWeeklyAudiencesPrefetch(List<String> structureIds, String startAt, String endAt) {
+        Promise<JsonObject> promise = Promise.promise();
+        if (structureIds.isEmpty()) {
+            String message = String.format("[StatisticsPresences@%s::processWeeklyAudiencesPrefetch] " +
+                    "No structure(s) identifier given", this.getClass().getSimpleName());
+            promise.fail(message);
+        } else {
+            JsonObject params = new JsonObject()
+                    .put(Field.STRUCTUREIDS, structureIds)
+                    .put(Field.STARTAT, startAt)
+                    .put(Field.ENDAT, endAt);
+
+            commonServiceFactory.eventBus().request(ProcessingWeeklyAudiencesManual.class.getName(),
+                    params, new DeliveryOptions(), handlerToAsyncHandler(res -> promise.complete(res.body())));
+        }
+
+        return promise.future();
+    }
+
+}

--- a/statistics-presences/src/main/resources/i18n/en.json
+++ b/statistics-presences/src/main/resources/i18n/en.json
@@ -6,6 +6,7 @@
   "statistics-presences.to": "au",
   "statistics-presences.indicator.Global": "Globales",
   "statistics-presences.indicator.Monthly": "Mensuelles",
+  "statistics-presences.indicator.Weekly": "Weekly",
   "statistics-presences.indicator.export.csv": "Export CSV",
   "statistics-presences.indicator.export.csv.audiences.only": "Exporter uniquement les classes",
   "statistics-presences.indicator.export.csv.audiences.students": "Exporter classes et élèves",
@@ -49,6 +50,8 @@
   "statistics-presences.events": "événements",
   "statistics-presences.csv.export": "Exporter CSV",
   "statistics-presences.indicator.empty.state": "Aucune statistique trouvée pour votre recherche",
+  "statistics-presences.indicator.empty.filter": "Please select a class or user to view statistics",
   "statistics-presences.cancel": "Annuler",
-  "statistics-presences.validate": "Valider"
+  "statistics-presences.validate": "Valider",
+  "statistics-presences.slots.error": "An error occurred while retrieving statistics"
 }

--- a/statistics-presences/src/main/resources/i18n/fr.json
+++ b/statistics-presences/src/main/resources/i18n/fr.json
@@ -6,6 +6,7 @@
   "statistics-presences.to": "au",
   "statistics-presences.indicator.Global": "Globales",
   "statistics-presences.indicator.Monthly": "Mensuelles",
+  "statistics-presences.indicator.Weekly": "Hebdomadaire",
   "statistics-presences.indicator.export.csv": "Export CSV",
   "statistics-presences.indicator.export.csv.audiences.only": "Exporter uniquement les classes",
   "statistics-presences.indicator.export.csv.audiences.students": "Exporter classes et élèves",
@@ -55,7 +56,9 @@
   "statistics-presences.events": "événements",
   "statistics-presences.csv.export": "Exporter CSV",
   "statistics-presences.indicator.empty.state": "Aucune statistique trouvée pour votre recherche",
+  "statistics-presences.indicator.empty.filter": "Veuillez sélectionner une classe ou un utilisateur pour afficher les statistiques",
   "statistics-presences.month.empty": "Aucune statistique trouvée pour votre recherche",
   "statistics-presences.cancel": "Annuler",
-  "statistics-presences.validate": "Valider"
+  "statistics-presences.validate": "Valider",
+  "statistics-presences.slots.error": "Une erreur est survenue dans la récupération des statistiques"
 }

--- a/statistics-presences/src/main/resources/jsonschema/processWeeklyAudiencesPrefetch.json
+++ b/statistics-presences/src/main/resources/jsonschema/processWeeklyAudiencesPrefetch.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "structureIds": {
+      "type": [
+        "array",
+        "string"
+      ]
+    },
+    "startAt": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "endAt": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "structureIds"
+  ]
+}

--- a/statistics-presences/src/main/resources/public/constants/calendar.ts
+++ b/statistics-presences/src/main/resources/public/constants/calendar.ts
@@ -1,0 +1,4 @@
+/**
+ * Define the height of each slots in calendar
+ */
+export const SLOT_HEIGHT = 47;

--- a/statistics-presences/src/main/resources/public/sass/global/components/_index.scss
+++ b/statistics-presences/src/main/resources/public/sass/global/components/_index.scss
@@ -4,3 +4,4 @@
 @import "monthly-table";
 @import "chart-statistics";
 @import "export-csv-lightbox";
+@import "containers/index";

--- a/statistics-presences/src/main/resources/public/sass/global/components/containers/_calendar.scss
+++ b/statistics-presences/src/main/resources/public/sass/global/components/containers/_calendar.scss
@@ -1,0 +1,66 @@
+$calendar-item-color: rgba(247, 246, 246, 1);
+$calendar-item-border-color: rgba(96, 96, 96, 0.15);
+$calendar-item-border-radius: 5px;
+
+.calendar {
+  &.calendar-statistics {
+    .week-switcher {
+      display: none;
+    }
+    .calendar-current-week {
+      display: none;
+    }
+    .schedule {
+      .days {
+        button {
+
+        }
+        .day {
+          legend {
+            top: -60px;
+            height: 40px;
+
+            div:nth-child(2) {
+              display: none;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  calendar {
+    .schedule {
+      .schedule-item {
+        .statistics-item-container {
+          display: flex;
+          flex-direction: row;
+          width: 100%;
+          height: 100%;
+        }
+
+        .statistics-item {
+          font-size: 11px;
+          display: flex;
+          width: 100%;
+          background-color: $calendar-item-color;
+          border: solid 1px $calendar-item-border-color;
+          border-radius: $calendar-item-border-radius;
+          flex-direction: column;
+          justify-content: center;
+
+          &.important {
+            background-color: $statistics-presences-main;
+            color: $statistics-presences-white;
+          }
+
+          .data {
+            p {
+              font-size: 2em;
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/statistics-presences/src/main/resources/public/sass/global/components/containers/_index.scss
+++ b/statistics-presences/src/main/resources/public/sass/global/components/containers/_index.scss
@@ -1,0 +1,1 @@
+@import "calendar";

--- a/statistics-presences/src/main/resources/public/template/calendar/weekly-statistics-item.html
+++ b/statistics-presences/src/main/resources/public/template/calendar/weekly-statistics-item.html
@@ -1,0 +1,8 @@
+<div class="statistics-item-container">
+    <!-- data course item -->
+    <div class="center-component statistics-item" ng-class="{ important: item.max}">
+        <div class="data">
+            <p class="no-margin">[[item.rate]]%</p>
+        </div>
+    </div>
+</div>

--- a/statistics-presences/src/main/resources/public/template/filter.html
+++ b/statistics-presences/src/main/resources/public/template/filter.html
@@ -29,7 +29,7 @@
         </div>
 
         <!-- Punishment/sanction types -->
-        <div class="row vertical-spacing">
+        <div class="row vertical-spacing" ng-if="!!vm.indicator.filter('PUNISHMENT_SANCTION_TYPES')">
             <h4 class="row">
                 <i18n class="cell">massmailing.filters.punishment.types</i18n>
             </h4>

--- a/statistics-presences/src/main/resources/public/template/indicator/Weekly.html
+++ b/statistics-presences/src/main/resources/public/template/indicator/Weekly.html
@@ -1,0 +1,14 @@
+<div>
+    <div class="calendar calendar-statistics">
+        <div class="calendar-container row">
+            <calendar ng-if="!vm.indicator.disabled"
+                      enable-display-modes="false"
+                      readonly="true"
+                      display-template="calendar/weekly-statistics-item"
+                      items="vm.indicator.values.slots"
+                      slots="vm.indicator.timeslot"
+                      show-quarter-hours="false"
+                      show-next-previous-button="false"></calendar>
+        </div>
+    </div>
+</div>

--- a/statistics-presences/src/main/resources/public/template/main.html
+++ b/statistics-presences/src/main/resources/public/template/main.html
@@ -79,7 +79,7 @@
 
         <div class="right-magnet">
             <!-- export CSV -->
-            <button class="left-spacing-twice no-margin" data-ng-click="vm.openCSVOptions()">
+            <button class="left-spacing-twice no-margin" data-ng-click="vm.openCSVOptions()" data-ng-disabled="vm.isWeekly(vm.indicator)">
                 <i18n>statistics-presences.csv.export</i18n>
             </button>
         </div>
@@ -92,7 +92,7 @@
         </div>
         <!-- display absence rate -->
         <!-- switch stat default/rate absence -->
-        <div ng-if="!vm.canAccessOption(vm.indicator) && vm.setting.event_recovery_method !== 'HOUR'"
+        <div ng-if="vm.isGlobal(vm.indicator) && vm.setting.event_recovery_method !== 'HOUR'"
              class="right-spacing displayRate"
              ng-class="{selected: vm.indicator.rateDisplay}">
             <i class="percent" data-ng-click="vm.indicator.rateDisplay = !vm.indicator.rateDisplay">
@@ -105,7 +105,7 @@
         <display-statistics-mode on-change="vm.onSwitchDisplay()"
                                  indicator="vm.indicator"
                                  ng-show="true"
-                                 ng-if="vm.canAccessOption(vm.indicator)"
+                                 ng-if="vm.isMonthly(vm.indicator)"
                                  class="right-spacing">
         </display-statistics-mode>
         <!-- tagged filter -->
@@ -121,7 +121,7 @@
     <div class="empty-content">
         <div class="five description">
             <span class="red-bar bar"></span>
-            <i18n>statistics-presences.indicator.empty.state</i18n>
+            <span class="text-center">[[vm.indicator.getEmptyMessage()]]</span>
             <span class="yellow-bar bar"></span>
         </div>
         <img data-ng-src="/statistics-presences/public/images/girl-book.svg" class="four" alt="">

--- a/statistics-presences/src/main/resources/public/ts/core/constants/IndicatorType.ts
+++ b/statistics-presences/src/main/resources/public/ts/core/constants/IndicatorType.ts
@@ -1,4 +1,5 @@
 export const INDICATOR_TYPE = {
     global: 'Global',
-    monthly: 'Monthly'
+    monthly: 'Monthly',
+    weekly: 'Weekly'
 };

--- a/statistics-presences/src/main/resources/public/ts/core/constants/roots.ts
+++ b/statistics-presences/src/main/resources/public/ts/core/constants/roots.ts
@@ -1,0 +1,3 @@
+export const ROOTS = {
+    directive: '/statistics-presences/public/ts/directives/',
+};

--- a/statistics-presences/src/main/resources/public/ts/directives/filter-indicator.ts
+++ b/statistics-presences/src/main/resources/public/ts/directives/filter-indicator.ts
@@ -55,6 +55,7 @@ export const filterIndicator = ng.directive('filterIndicator', () => {
                                 type.process(type.selected());
                             });
                             break;
+                        case INDICATOR_TYPE.weekly:
                         case INDICATOR_TYPE.monthly:
                             vm.filters.forEach((type: FilterType) => {
                                 type.select(false);
@@ -85,7 +86,7 @@ export const filterIndicator = ng.directive('filterIndicator', () => {
                         filterType.process(filterType.selected());
                         break;
                     case INDICATOR_TYPE.monthly:
-
+                    case INDICATOR_TYPE.weekly:
                         if (vm.isAbsenceFilter(filterType)) {
                             vm.filters.forEach((type: FilterType) => {
                                 if (!vm.isAbsenceFilter(type)) {

--- a/statistics-presences/src/main/resources/public/ts/filter/filter.ts
+++ b/statistics-presences/src/main/resources/public/ts/filter/filter.ts
@@ -5,7 +5,8 @@ import {PunishmentsUtils} from "@incidents/utilities/punishments";
 export enum Filter {
     FROM = "FROM",
     TO = "TO",
-    HOUR_DETAIL = "HOUR_DETAIL"
+    HOUR_DETAIL = "HOUR_DETAIL",
+    PUNISHMENT_SANCTION_TYPES = "PUNISHMENT_SANCTION_TYPES"
 }
 
 export class FilterValue {

--- a/statistics-presences/src/main/resources/public/ts/indicator/Global.ts
+++ b/statistics-presences/src/main/resources/public/ts/indicator/Global.ts
@@ -29,6 +29,7 @@ export class Global extends Indicator {
         this.enableFilter(Filter.FROM, false);
         this.enableFilter(Filter.TO, false);
         this.enableFilter(Filter.HOUR_DETAIL, false);
+        this.enableFilter(Filter.PUNISHMENT_SANCTION_TYPES, false);
     }
 
     absenceSelected(): boolean {

--- a/statistics-presences/src/main/resources/public/ts/indicator/Indicator.ts
+++ b/statistics-presences/src/main/resources/public/ts/indicator/Indicator.ts
@@ -10,6 +10,7 @@ import {GlobalResponse, IGlobal} from "../model/Global";
 import {IMonthly, IMonthlyGraph} from "../model/Monthly";
 import {IndicatorBody} from "../model/Indicator";
 import {indicatorService} from "../services";
+import {IWeekly, IWeeklyResponse} from "@statistics/model/Weekly";
 
 declare const window: any;
 
@@ -25,10 +26,12 @@ export interface IIndicator {
     cloneFilterTypes();
 
     cloneFilterTypes(): FilterType[];
+
+    getEmptyMessage(): string
 }
 
 export abstract class Indicator implements IIndicator {
-    values: IGlobal | IMonthly;
+    values: IGlobal | IMonthly | IWeekly;
     graphValues: IMonthlyGraph;
     _factoryFilter: FilterTypeFactory;
     _filtersEnabled: Map<Filter, FilterValue>;
@@ -51,7 +54,7 @@ export abstract class Indicator implements IIndicator {
             [Filter.HOUR_DETAIL, this._factoryFilter.getFilterValue(null, null)]
         ]);
         this._from = DateUtils.setFirstTime(new Date());
-        this._to =  DateUtils.setLastTime(new Date());
+        this._to = DateUtils.setLastTime(new Date());
         this._display = DISPLAY_TYPE.TABLE;
         this._isRateDisplay = false;
         this._name = name;
@@ -156,7 +159,11 @@ export abstract class Indicator implements IIndicator {
 
     abstract isEmpty();
 
-    async fetchIndicator(start: Date, end: Date, users: string[], audiences: string[]): Promise<GlobalResponse | IMonthly> {
+    getEmptyMessage(): string {
+        return idiom.translate('statistics-presences.indicator.empty.state');
+    }
+
+    async fetchIndicator(start: Date, end: Date, users: string[], audiences: string[]): Promise<GlobalResponse | IMonthly | IWeeklyResponse> {
         const body = this.prepareIndicator(start, end, users, audiences);
         return indicatorService.fetchIndicator(window.structure.id, this.name(), this._page, body);
     }

--- a/statistics-presences/src/main/resources/public/ts/indicator/Monthly.ts
+++ b/statistics-presences/src/main/resources/public/ts/indicator/Monthly.ts
@@ -30,6 +30,7 @@ export class Monthly extends Indicator {
         ]);
 
         this.enableFilter(Filter.HOUR_DETAIL, false);
+        this.enableFilter(Filter.PUNISHMENT_SANCTION_TYPES, false);
     }
 
     absenceSelected(): boolean {

--- a/statistics-presences/src/main/resources/public/ts/indicator/Weekly.ts
+++ b/statistics-presences/src/main/resources/public/ts/indicator/Weekly.ts
@@ -1,0 +1,147 @@
+import {Indicator} from './index';
+import {INDICATOR_TYPE} from "../core/constants/IndicatorType";
+import {FILTER_TYPE} from '../filter';
+import {IPunishmentType} from '@incidents/models/PunishmentType';
+import {IStructureSlot, ITimeSlot, Reason, Student} from '@presences/models';
+import {IWeekly, IWeeklyResponse, WeeklyStatistics, WeeklyStatisticsResponse} from "@statistics/model/Weekly";
+import {DateUtils} from "@common/utils";
+import {DISPLAY_TYPE} from "../core/constants/DisplayMode";
+import {IndicatorFactory} from '../indicator';
+import {AxiosError} from "axios";
+import {idiom, idiom as lang, model, moment, toasts} from "entcore";
+import {ViescolaireService} from "@common/services";
+import {timeslotClasseService} from "@common/services/TimeslotClasseService";
+
+declare let window: any;
+
+export class Weekly extends Indicator {
+    audienceFilter: string;
+    userFilter: string;
+    disabled: boolean;
+    timeslot: ITimeSlot[];
+
+    constructor(reasons: Reason[], punishmentTypes: IPunishmentType[]) {
+        super(INDICATOR_TYPE.weekly, reasons, punishmentTypes);
+        this.resetValues();
+        this.setFilterTypes([
+            this._factoryFilter.getFilter(FILTER_TYPE.NO_REASON, null),
+            this._factoryFilter.getFilter(FILTER_TYPE.UNREGULARIZED, (value: boolean) => this._factoryFilter.changeUnProvingReasons(value)),
+            this._factoryFilter.getFilter(FILTER_TYPE.REGULARIZED, (value: boolean) => this._factoryFilter.changeProvingReasons(value)),
+            this._factoryFilter.getFilter(FILTER_TYPE.LATENESS, null),
+            this._factoryFilter.getFilter(FILTER_TYPE.DEPARTURE, null)
+        ]);
+        this.values = {slots: []};
+        this.timeslot = [];
+        model.calendar.setDate(moment());
+    }
+
+    isEmpty(): boolean {
+        return (this.values as IWeekly).slots === null || (this.values as IWeekly).slots.length == 0 ||
+            (this.audienceFilter == null && this.userFilter == null);
+    }
+
+    resetDates(): void {
+        this._from = DateUtils.setFirstTime(new Date());
+        this._to = DateUtils.setLastTime(new Date());
+    }
+
+    resetDisplayMode(): void {
+        this._display = DISPLAY_TYPE.TABLE;
+    }
+
+    resetValues(): void {
+        this.values = {slots: []};
+    }
+
+    async search(start: Date, end: Date, users: string[], audiences: string[]): Promise<void> {
+        await new Promise((resolve, reject) => {
+            if (audiences.length == 0 && users.length == 0) {
+                this.values = {slots: []};
+                resolve();
+                return;
+            }
+            super.fetchIndicator(start, end, users, audiences)
+                .then((res: IWeeklyResponse) => {
+                    this._mapResults(res)
+                    this.values = {slots: this._mapResults(res)}
+                    resolve();
+                })
+                .catch((error: AxiosError) => {
+                    reject(error);
+                });
+        });
+    }
+
+    private _mapResults(res: IWeeklyResponse): Array<WeeklyStatistics> {
+           return res.data.map((week: WeeklyStatisticsResponse) => {
+                const slot = this.timeslot.find((slot: ITimeSlot) => slot._id == week.slot_id);
+                if (!!slot && !!slot.startHour && !!slot.endHour) {
+                    return {
+                        dayOfWeek: week.dayOfWeek,
+                        slot_id: slot._id,
+                        endMoment: moment()
+                            .isoWeekday(week.dayOfWeek)
+                            .set('hour', Number(slot.endHour.split(":")[0]))
+                            .set('minute', Number(slot.endHour.split(":")[1]))
+                            .set('second', 0)
+                            .set('millisecond', 0),
+                        startMoment: moment()
+                            .isoWeekday(week.dayOfWeek)
+                            .set('hour', Number(slot.startHour.split(":")[0]))
+                            .set('minute', Number(slot.startHour.split(":")[1]))
+                            .set('second', 0)
+                            .set('millisecond', 0),
+                        is_periodic: false,
+                        locked: true,
+                        rate: week.rate,
+                        max: week.max
+                    } as WeeklyStatistics;
+                }
+            });
+    }
+
+    public async initTimeslot(users: string[], audiences: string[]): Promise<void> {
+        try {
+            this.setUserAndAudienceFilter(users, audiences)
+
+            let structure_slots: IStructureSlot;
+            if (!this.audienceFilter && !this.userFilter) {
+                structure_slots = await ViescolaireService.getSlotProfile(window.structure.id);
+            } else {
+                let audience: string = this.audienceFilter ? this.audienceFilter : await this.getAudienceFromUserFilter();
+                structure_slots = await timeslotClasseService.getAudienceTimeslot(audience);
+            }
+            this.timeslot = structure_slots.slots;
+            model.calendar.setTimeslots(this.timeslot);
+        } catch (err) {
+            this.disabled = true;
+            toasts.warning("statistics-presences.slots.error");
+            console.error(err, err.stack);
+        }
+    }
+
+    public setUserAndAudienceFilter(users: string[], audiences: string[]): void {
+        this.userFilter = (!!users.length && !audiences.length) ? users[0] : null;
+        this.audienceFilter = (!!audiences.length) ? audiences[0] : null;
+    }
+
+
+    private async getAudienceFromUserFilter(): Promise<any> {
+        return new Promise(async (resolve, reject) => {
+            let students: Array<Student> = await ViescolaireService.getStudent(window.structure.id, this.userFilter);
+            if (students.length == 0) {
+                reject(lang.translate("statistics-presences.slots.error"));
+            } else {
+                resolve(students[0].idClasse);
+            }
+        });
+    }
+
+    getEmptyMessage(): string {
+        return !this.audienceFilter && !this.userFilter ?
+            idiom.translate('statistics-presences.indicator.empty.filter') : super.getEmptyMessage();
+    }
+
+}
+
+IndicatorFactory.register(Weekly);

--- a/statistics-presences/src/main/resources/public/ts/indicator/index.ts
+++ b/statistics-presences/src/main/resources/public/ts/indicator/index.ts
@@ -6,3 +6,4 @@ declare const require: any;
 // Require all indicators. Needed by webpack
 require('./Global');
 require('./Monthly');
+require('./Weekly');

--- a/statistics-presences/src/main/resources/public/ts/model/Weekly.ts
+++ b/statistics-presences/src/main/resources/public/ts/model/Weekly.ts
@@ -1,0 +1,34 @@
+import {Moment} from "moment";
+
+export type WeeklyStatisticsResponse = {
+    dayOfWeek: number,
+    slot_id: string,
+    total_group_occurrences: any,
+    total_students_expected: WeeklyStats,
+    total_events: number,
+    rate: number,
+    max: boolean
+}
+
+export type WeeklyStats = {
+    [monthLabel: string]: number;
+}
+
+export interface IWeeklyResponse {
+    data: Array<WeeklyStatisticsResponse>;
+}
+
+export interface IWeekly {
+    slots: Array<WeeklyStatistics>;
+}
+
+export interface WeeklyStatistics {
+    dayOfWeek: number,
+    slot_id: string,
+    startMoment: Moment;
+    endMoment: Moment;
+    is_periodic: boolean;
+    locked: true;
+    rate: number;
+    max: boolean
+}

--- a/statistics-presences/src/main/resources/public/ts/services/indicator.service.ts
+++ b/statistics-presences/src/main/resources/public/ts/services/indicator.service.ts
@@ -1,17 +1,18 @@
-import {ng} from 'entcore'
+import {ng, moment} from 'entcore'
 import {GlobalResponse} from "@statistics/model/Global";
 import {IMonthly, IMonthlyGraph} from "@statistics/model/Monthly";
 import http, {AxiosResponse} from "axios";
 import {IndicatorBody} from "../model/Indicator";
+import {IWeekly, IWeeklyResponse, WeeklyStatistics} from "@statistics/model/Weekly";
 
 export interface IndicatorService {
-    fetchIndicator(structureId: string, indicatorName: string, page: number, body: IndicatorBody): Promise<GlobalResponse | IMonthly>;
+    fetchIndicator(structureId: string, indicatorName: string, page: number, body: IndicatorBody): Promise<GlobalResponse | IMonthly | IWeeklyResponse>;
 
     fetchGraphIndicator(structureId: string, indicatorName: string, body: IndicatorBody): Promise<IMonthlyGraph>;
 }
 
 export const indicatorService: IndicatorService = {
-    fetchIndicator: async (structure: string, name: string, page: number, body: IndicatorBody): Promise<GlobalResponse | IMonthly> => {
+    fetchIndicator: async (structure: string, name: string, page: number, body: IndicatorBody): Promise<GlobalResponse | IMonthly | IWeeklyResponse> => {
         return http.post(`/statistics-presences/structures/${structure}/indicators/${name}?page=${page}`, body)
             .then((res: AxiosResponse) => res.data);
     },

--- a/statistics-presences/src/test/java/fr/openent/statistics_presences/indicator/impl/WeeklyTest.java
+++ b/statistics-presences/src/test/java/fr/openent/statistics_presences/indicator/impl/WeeklyTest.java
@@ -1,0 +1,190 @@
+package fr.openent.statistics_presences.indicator.impl;
+
+import fr.openent.presences.db.DB;
+import fr.openent.presences.db.DBService;
+import fr.openent.statistics_presences.bean.weekly.WeeklySearch;
+import fr.openent.statistics_presences.model.StatisticsFilter;
+import fr.wseduc.mongodb.MongoDb;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.reflect.Whitebox;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+
+@RunWith(VertxUnitRunner.class)
+public class WeeklyTest extends DBService {
+
+    MongoDb mongoDb = Mockito.mock(MongoDb.class);
+    private Weekly weekly;
+    private WeeklySearch search;
+
+    private static final String STRUCTURE_ID = "111";
+    private static final List<String> AUDIENCE_IDS = Collections.singletonList("222");
+    private static final String STUDENT_ID = "333";
+    private static final List<Integer> REASON_IDS = Arrays.asList(12, 13);
+    private static final String START = "2021-06-01 08:00:00";
+    private static final String END = "2021-06-30 23:59:59";
+    private static final String NO_REASON = "NO_REASON";
+    private static final String UNREGULARIZED = "UNREGULARIZED";
+
+
+    @Before
+    public void setUp(TestContext context) {
+        DB.getInstance().init(null, null, mongoDb);
+
+        /* Indicator to test */
+        this.weekly = new Weekly(Vertx.vertx(), "Weekly");
+    }
+
+    @Test
+    public void testStudentsBySlotsPipeline(TestContext ctx) throws Exception {
+        JsonObject filter = new JsonObject()
+                .put(StatisticsFilter.StatisticsFilterField.START, START)
+                .put(StatisticsFilter.StatisticsFilterField.END, END)
+                .put(StatisticsFilter.StatisticsFilterField.AUDIENCES, AUDIENCE_IDS)
+                .put(StatisticsFilter.StatisticsFilterField.TYPES, Arrays.asList(NO_REASON, UNREGULARIZED))
+                .put(StatisticsFilter.StatisticsFilterField.REASONS, REASON_IDS)
+                .put(StatisticsFilter.StatisticsFilterField.PUNISHMENT_TYPES, Collections.emptyList());
+
+        search = new WeeklySearch(new StatisticsFilter(STRUCTURE_ID, filter));
+
+        JsonArray expected = expectedStudentsBySlotsPipeline().getJsonArray("pipeline");
+
+        Mockito.doAnswer(invocation -> {
+            String query = invocation.getArgument(0);
+            ctx.assertEquals(new JsonObject(query).getJsonArray("pipeline", new JsonArray()), expected);
+            return null;
+        }).when(mongoDb).command(Mockito.anyString(), Mockito.any(Handler.class));
+
+        Whitebox.invokeMethod(weekly, "retrieveStatistics", search.countEventTypedBySlotsCommand());
+
+    }
+
+    @Test
+    public void testCountEventTypedBySlotsPipelineFromStudent(TestContext ctx) throws Exception {
+        JsonObject filter = new JsonObject()
+                .put(StatisticsFilter.StatisticsFilterField.START, START)
+                .put(StatisticsFilter.StatisticsFilterField.END, END)
+                .put(StatisticsFilter.StatisticsFilterField.AUDIENCES, AUDIENCE_IDS)
+                .put(StatisticsFilter.StatisticsFilterField.TYPES, Arrays.asList(NO_REASON, UNREGULARIZED))
+                .put(StatisticsFilter.StatisticsFilterField.REASONS, REASON_IDS)
+                .put(StatisticsFilter.StatisticsFilterField.PUNISHMENT_TYPES, Collections.emptyList());
+
+        search = new WeeklySearch(new StatisticsFilter(STRUCTURE_ID, filter));
+        search.filter().setUserId(STUDENT_ID);
+
+        JsonArray expected = expectedCountEventTypedBySlotsPipelineFromStudent().getJsonArray("pipeline");
+
+        Mockito.doAnswer(invocation -> {
+            String query = invocation.getArgument(0);
+            ctx.assertEquals(new JsonObject(query).getJsonArray("pipeline", new JsonArray()), expected);
+            return null;
+        }).when(mongoDb).command(Mockito.anyString(), Mockito.any(Handler.class));
+
+        Whitebox.invokeMethod(weekly, "retrieveStatistics", search.countStudentsBySlotsCommand());
+    }
+
+    @Test
+    public void testCountEventTypedBySlotsPipelineFromAudience(TestContext ctx) throws Exception {
+        JsonObject filter = new JsonObject()
+                .put(StatisticsFilter.StatisticsFilterField.START, START)
+                .put(StatisticsFilter.StatisticsFilterField.END, END)
+                .put(StatisticsFilter.StatisticsFilterField.AUDIENCES, AUDIENCE_IDS)
+                .put(StatisticsFilter.StatisticsFilterField.TYPES, Arrays.asList(NO_REASON, UNREGULARIZED))
+                .put(StatisticsFilter.StatisticsFilterField.REASONS, REASON_IDS)
+                .put(StatisticsFilter.StatisticsFilterField.PUNISHMENT_TYPES, Collections.emptyList());
+
+        search = new WeeklySearch(new StatisticsFilter(STRUCTURE_ID, filter));
+
+        JsonArray expected = expectedCountEventTypedBySlotsPipelineFromAudience().getJsonArray("pipeline");
+
+        Mockito.doAnswer(invocation -> {
+            String query = invocation.getArgument(0);
+            ctx.assertEquals(new JsonObject(query).getJsonArray("pipeline", new JsonArray()), expected);
+            return null;
+        }).when(mongoDb).command(Mockito.anyString(), Mockito.any(Handler.class));
+
+        Whitebox.invokeMethod(weekly, "retrieveStatistics", search.countStudentsBySlotsCommand());
+    }
+
+    @Test
+    public void testRates(TestContext ctx) throws Exception {
+        double testClassicRates = Whitebox.invokeMethod(weekly, "getEventRates", 3, 1);
+        ctx.assertEquals(testClassicRates, 33.33);
+
+        double testNoMoreThanUndredRates = Whitebox.invokeMethod(weekly, "getEventRates", 1, 3);
+        ctx.assertEquals(testNoMoreThanUndredRates, 100.0);
+
+        double testAbsolute = Whitebox.invokeMethod(weekly, "getEventRates", 4, -1);
+        ctx.assertEquals(testAbsolute, 25.0);
+
+        double testNullParam = Whitebox.invokeMethod(weekly, "getEventRates", 4, null);
+        ctx.assertEquals(testNullParam, 0.0);
+
+        double testNaN = Whitebox.invokeMethod(weekly, "getEventRates", 0, 1);
+        ctx.assertEquals(testNaN, 0.0);
+
+    }
+
+    private JsonObject expectedStudentsBySlotsPipeline() {
+        return new JsonObject("{" +
+                "\"pipeline\": [{\"$match\": {" +
+                "\"structure\": \"111\"," +
+                "\"indicator\": \"fr.openent.statistics_presences.indicator.impl.Weekly\"," +
+                "\"start_date\": {\"$lt\": \"2021-06-30 23:59:59\"}," +
+                "\"end_date\": {\"$gt\": \"2021-06-01 08:00:00\"}," +
+                "\"audiences\": {\"$in\": [\"222\"]}," +
+                "\"$or\": [{\"type\": \"NO_REASON\"}, {\"type\":\"UNREGULARIZED\",\"reason\":{\"$in\":[12, 13]}}]" +
+                "}}, {\"$addFields\": {" +
+                "\"dayOfWeek\": {\"$isoDayOfWeek\": {\"$dateFromString\": {\"dateString\": \"$start_date\"}}}" +
+                "}}, {\"$group\": {" +
+                "\"_id\": {\"slot_id\": \"$slot_id\",\"dayOfWeek\": \"$dayOfWeek\"}," +
+                "\"count\": {\"$sum\": 1}" +
+                "}}, {\"$project\": {" +
+                "\"_id\": 0," +
+                "\"slot_id\": \"$_id.slot_id\"," +
+                "\"dayOfWeek\": \"$_id.dayOfWeek\"," +
+                "\"count\": {\"$sum\": \"$count\"}" +
+                "}}]" +
+                "}");
+    }
+
+    private JsonObject expectedCountEventTypedBySlotsPipelineFromStudent() {
+        return new JsonObject("{" +
+                "\"pipeline\": [{\"$match\": {" +
+                "\"structure_id\": \"111\"," +
+                "\"_id.start_at\": {\"$lt\": \"2021-06-30 23:59:59\"}," +
+                "\"_id.end_at\": {\"$gt\": \"2021-06-01 08:00:00\"}," +
+                "\"_id.audience_id\": {\"$in\": [\"222\"]}" +
+                "}}, {\"$addFields\": {\"dayOfWeek\": {\"$isoDayOfWeek\": {\"$dateFromString\": {\"dateString\": \"$_id.start_at\"}}}" +
+                "}}, {\"$group\": {\"_id\": {\"slot_id\": \"$slot_id\",\"dayOfWeek\": \"$dayOfWeek\"},\"count\": {\"$sum\": 1}" +
+                "}}, {\"$project\": { \"_id\": 0,\"slot_id\": \"$_id.slot_id\",\"dayOfWeek\": \"$_id.dayOfWeek\",\"count\": {\"$sum\": \"$count\"}" +
+                "}}]" +
+                "}");
+    }
+
+    private JsonObject expectedCountEventTypedBySlotsPipelineFromAudience() {
+        return new JsonObject("{" +
+                "\"pipeline\": [{\"$match\": {" +
+                "\"structure_id\": \"111\"," +
+                "\"_id.start_at\": {\"$lt\": \"2021-06-30 23:59:59\"}," +
+                "\"_id.end_at\": {\"$gt\": \"2021-06-01 08:00:00\"}," +
+                "\"_id.audience_id\": {\"$in\": [\"222\"]}" +
+                "}}, {\"$addFields\": {\"dayOfWeek\": {\"$isoDayOfWeek\": {\"$dateFromString\": {\"dateString\": \"$_id.start_at\"}}}" +
+                "}}, {\"$group\": {\"_id\": {\"slot_id\": \"$slot_id\",\"dayOfWeek\": \"$dayOfWeek\"},\"count\": {\"$sum\": \"$student_count\"}" +
+                "}}, {\"$project\": { \"_id\": 0,\"slot_id\": \"$_id.slot_id\",\"dayOfWeek\": \"$_id.dayOfWeek\",\"count\": {\"$sum\": \"$count\"}" +
+                "}}]" +
+                "}");
+    }
+}

--- a/statistics-presences/src/test/java/fr/openent/statistics_presences/service/impl/DefaultStatisticsWeeklyAudiencesServiceTest.java
+++ b/statistics-presences/src/test/java/fr/openent/statistics_presences/service/impl/DefaultStatisticsWeeklyAudiencesServiceTest.java
@@ -1,0 +1,117 @@
+package fr.openent.statistics_presences.service.impl;
+
+import fr.openent.presences.core.constants.Field;
+import fr.openent.presences.db.DBService;
+import fr.openent.statistics_presences.bean.Register;
+import fr.openent.statistics_presences.bean.timeslot.Slot;
+import fr.openent.statistics_presences.bean.timeslot.Timeslot;
+import fr.openent.statistics_presences.service.CommonServiceFactory;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.reflect.Whitebox;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+
+@RunWith(VertxUnitRunner.class)
+public class DefaultStatisticsWeeklyAudiencesServiceTest extends DBService {
+    private DefaultStatisticsWeeklyAudiencesService weeklyAudienceService;
+
+    private static final String STRUCTURE_ID = "111";
+    private static final Integer REGISTER_ID = 444;
+    private static final String AUDIENCE_ID ="333";
+    private static final Integer STATE_ID = 3;
+    private static final Integer STUDENT_COUNT = 29;
+
+    @Before
+    public void setUp(TestContext context) {
+        CommonServiceFactory commonServiceFactory = new CommonServiceFactory(Vertx.vertx());
+
+        /* Indicator to test */
+        this.weeklyAudienceService = new DefaultStatisticsWeeklyAudiencesService(commonServiceFactory);
+    }
+
+    @Test
+    public void testMapSimpleRegisterToWeeklyAudience(TestContext ctx) throws Exception {
+        List<JsonObject> expected = expectedMapSimpleRegisterToWeeklyAudience();
+
+        Register register = getRegister();
+        register.setStartAt("2022-03-08T08:55:00");
+        register.setEndAt("2022-03-08T09:50:00");
+
+        List<JsonObject> result =  Whitebox.invokeMethod(weeklyAudienceService, "mapRegistersToMongoWeeklyAudiences",
+                Collections.singletonList(register), Collections.singletonList(getTimeslot()), Collections.singletonList(getGroupCountStudents()));
+
+        ctx.assertEquals(result, expected);
+    }
+
+    @Test
+    public void testMapSplittableRegisterToWeeklyAudience(TestContext ctx) throws Exception {
+        List<JsonObject> expected = expectedMapSplittableRegisterToWeeklyAudience();
+
+        Register register = getRegister();
+        register.setStartAt("2022-03-08T08:55:00");
+        register.setEndAt("2022-03-08T10:30:00");
+
+        List<JsonObject> result =  Whitebox.invokeMethod(weeklyAudienceService, "mapRegistersToMongoWeeklyAudiences",
+                Collections.singletonList(register), Collections.singletonList(getTimeslot()), Collections.singletonList(getGroupCountStudents()));
+
+        ctx.assertEquals(result, expected);
+    }
+
+    private Timeslot getTimeslot() {
+        Timeslot timeslot = new Timeslot(new JsonObject("{\"_id\":\"222\",\"name\":\"slots\",\"schoolId\":\"111\"," +
+                "\"created\":{\"$date\":1637318354978},\"modified\":{\"$date\":1637319121341}," +
+                "\"owner\":{\"userId\":\"555\",\"displayName\":\"test\"}," +
+                "\"audienceId\":\"333\"}"));
+
+
+        return timeslot.setSlots(
+                Arrays.asList(
+                        new Slot(new JsonObject("{\"name\":\"M1\",\"startHour\":\"08:00\",\"endHour\":\"08:55\",\"id\":\"2221\"}")),
+                        new Slot(new JsonObject("{\"name\":\"M2\",\"startHour\":\"08:55\",\"endHour\":\"09:50\",\"id\":\"2222\"}")),
+                        new Slot(new JsonObject("{\"name\":\"M3\",\"startHour\":\"10:05\",\"endHour\":\"11:00\",\"id\":\"2223\"}")),
+                        new Slot(new JsonObject("{\"name\":\"M4\",\"startHour\":\"11:00\",\"endHour\":\"11:55\",\"id\":\"2224\"}"))
+                )
+        );
+    }
+
+    private Register getRegister() {
+        return new Register(
+                new JsonObject()
+                        .put(Field.ID, REGISTER_ID)
+                        .put(Field.GROUP_ID, AUDIENCE_ID)
+                        .put(Field.STATE_ID, STATE_ID)
+                        .put(Field.STRUCTURE_ID, STRUCTURE_ID)
+        );
+    }
+
+    private JsonObject getGroupCountStudents() {
+        return new JsonObject()
+                .put(Field.ID_GROUPE, AUDIENCE_ID)
+                .put(Field.NB, STUDENT_COUNT);
+    }
+
+
+    private List<JsonObject> expectedMapSimpleRegisterToWeeklyAudience() {
+        return Collections.singletonList(new JsonObject("{" +
+                "\"_id\": {\"register_id\": 444, \"audience_id\":\"333\", \"start_at\":\"2022-03-08T08:55:00\", \"end_at\":\"2022-03-08T09:50:00\"}," +
+                "\"structure_id\": \"111\", \"slot_id\":\"2222\", \"student_count\":29}"));
+    }
+
+    private List<JsonObject> expectedMapSplittableRegisterToWeeklyAudience() {
+        return Arrays.asList(new JsonObject("{" +
+                "\"_id\": {\"register_id\": 444, \"audience_id\":\"333\", \"start_at\":\"2022-03-08T08:55:00\", \"end_at\":\"2022-03-08T09:50:00\"}," +
+                "\"structure_id\": \"111\", \"slot_id\":\"2222\", \"student_count\":29}"),
+                new JsonObject("{" +
+                        "\"_id\": {\"register_id\": 444, \"audience_id\":\"333\", \"start_at\":\"2022-03-08T10:05:00\", \"end_at\":\"2022-03-08T11:00:00\"}," +
+                        "\"structure_id\": \"111\", \"slot_id\":\"2223\", \"student_count\":29}"));
+    }
+}


### PR DESCRIPTION
[Jira - MA-747](https://entsupport.gdapublic.fr/browse/MA-747)

Ajout de la vue statistiques hebdomadaire:
 - nouvelle collection MongoDB: presences.statistics_weekly_audiences => permet a chaque remplissage/validation d'appel de stocker le nombre d'étudiant sur le créneau de l'appel
 - sur la vue des statistiques hebdo, on calcul le nombre d'évènement sur le nombre d'élèves attendues par récurrence créneaux (sur x semaines).