### PR TITLE
fix(sql): #MA-926 add security to SQL querries in Settings Service

### DIFF
--- a/common/src/main/java/fr/openent/presences/core/constants/Field.java
+++ b/common/src/main/java/fr/openent/presences/core/constants/Field.java
@@ -293,6 +293,7 @@ public class Field {
     public static final String HIDDEN = "hidden";
     public static final String ABSENCE_COMPILANCE = "absence_compliance";
     public static final String REASON_TYPE_ID = "reason_type_id";
+    public static final String INITIALIZED = "initialized";
 
     private Field() {
         throw new IllegalStateException("Utility class");

--- a/common/src/main/java/fr/openent/presences/enums/SettingsFieldEnum.java
+++ b/common/src/main/java/fr/openent/presences/enums/SettingsFieldEnum.java
@@ -1,0 +1,26 @@
+package fr.openent.presences.enums;
+
+import java.util.Arrays;
+
+public enum SettingsFieldEnum {
+    ALERT_ABSENCE_THRESHOLD("alert_absence_threshold"),
+    ALERT_LATENESS_THRESHOLD("alert_lateness_threshold"),
+    ALERT_INCIDENT_THRESHOLD("alert_incident_threshold"),
+    ALERT_FORGOTTEN_NOTEBOOK_THRESHOLD("alert_forgotten_notebook_threshold"),
+    EVENT_RECOVERY_METHOD("event_recovery_method"),
+    INITIALIZED("initialized");
+
+    private final String value;
+
+    SettingsFieldEnum(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+    public static String getSettingsField(String field) {
+        SettingsFieldEnum settingsFieldValue = Arrays.stream(SettingsFieldEnum.values()).filter(settingsFieldEnum -> settingsFieldEnum.getValue().equals(field)).findFirst().orElse(null);
+        return settingsFieldValue == null ? null : settingsFieldValue.getValue();
+    }
+}


### PR DESCRIPTION
Vérification des champs du json fournit par l'utilisateur. On vérifie qu'ils appartiennent bien a une enum de valeur autorisé