### PR TITLE
fix(presence): #MA-930 fix event list filter

### DIFF
--- a/presences/src/main/resources/public/ts/controllers/events.ts
+++ b/presences/src/main/resources/public/ts/controllers/events.ts
@@ -1004,7 +1004,8 @@ export const eventsController = ng.controller('EventsController', ['$scope', '$r
             (vm.filter.justifiedRegularized && vm.filter.justifiedNotRegularized) ? null : vm.filter.justifiedRegularized;
 
             vm.events.eventType = vm.eventType.toString();
-            vm.events.listReasonIds = (vm.filter.justifiedRegularized || vm.filter.justifiedNotRegularized) ? vm.eventReasonsId.toString() : "";
+            //If neither absences nor lateness are selected, the list of reasons is empty
+            vm.events.listReasonIds = (vm.filter.justifiedRegularized || vm.filter.justifiedNotRegularized || vm.filter.late) ? vm.eventReasonsId.toString() : "";
             vm.events.noReason = vm.filter.noReasons;
             vm.events.noReasonLateness = vm.filter.noReasonsLateness;
             vm.events.followed = vm.filter.followed;


### PR DESCRIPTION
## Describe your changes
The list of reasons was empty if the absence filter was not activated. Except with the lateness patterns, you must not empty the list if the lateness filter is selected

## Checklist tests
Test case one lateness without pattern, two lateness with differ patterns, one abs without pattern, two abs with differ patterns

## Issue ticket number and link
https://entsupport.gdapublic.fr/browse/MA-930

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequences regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequence feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

