### PR TITLE
fix(statistics): #MA-931 set default noLatenessReason to false at csv

### DIFF
--- a/common/src/main/java/fr/openent/statistics_presences/model/StatisticsFilter.java
+++ b/common/src/main/java/fr/openent/statistics_presences/model/StatisticsFilter.java
@@ -63,6 +63,7 @@ public class StatisticsFilter {
             this.punishmentTypes.addAll(request.params().getAll(StatisticsFilterField.PUNISHMENT_TYPES).stream().map(Integer::parseInt).collect(Collectors.toList()));
             this.sanctionTypes.addAll(request.params().getAll(StatisticsFilterField.SANCTION_TYPES).stream().map(Integer::parseInt).collect(Collectors.toList()));
             this.exportOption = request.getParam(StatisticsFilterField.EXPORT_OPTION);
+            this.noLatenessReason = Boolean.parseBoolean(request.getParam(StatisticsFilterField.NOLATENESSREASON));
             this.from = request.params().contains(StatisticsFilterField.FROM) ? Integer.parseInt(request.getParam(StatisticsFilterField.FROM)) : null;
             this.to = request.params().contains(StatisticsFilterField.TO) ? Integer.parseInt(request.getParam(StatisticsFilterField.TO)) : null;
             this.hourDetail = request.params().contains(StatisticsFilterField.HOUR_DETAILS) && Boolean.parseBoolean(request.getParam(StatisticsFilterField.HOUR_DETAILS));

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/global/GlobalSearch.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/global/GlobalSearch.java
@@ -504,12 +504,12 @@ public class GlobalSearch {
                         break;
                     case LATENESS:
                         List<Integer> list = this.filter().reasons();
-                        if (this.filter().getNoLatenessReason()) {
+                        if (Boolean.TRUE.equals(this.filter().getNoLatenessReason())) {
                             list.add(null);
                         }
                         JsonObject inFilterLatenessReasons = new JsonObject()
                                 .put("$in", list);
-                        filterType.put(Field.REASON, inFilterLatenessReasons );
+                        filterType.put(Field.REASON, inFilterLatenessReasons);
                         break;
                     default:
                         break;

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/monthly/MonthlySearch.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/monthly/MonthlySearch.java
@@ -224,7 +224,7 @@ public class MonthlySearch {
                     break;
                 case LATENESS:
                     List<Integer> list = this.filter().reasons();
-                    if (this.filter().getNoLatenessReason()) {
+                    if (Boolean.TRUE.equals(this.filter().getNoLatenessReason())) {
                         list.add(null);
                     }
                     JsonObject inFilterLatenessReasons = new JsonObject()

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/weekly/WeeklySearch.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/weekly/WeeklySearch.java
@@ -96,7 +96,7 @@ public class WeeklySearch {
                     break;
                 case LATENESS:
                     List<Integer> list = this.filter().reasons();
-                    if (this.filter().getNoLatenessReason()) {
+                    if (Boolean.TRUE.equals(this.filter().getNoLatenessReason())) {
                         list.add(null);
                     }
                     filterType.and(Field.REASON).in(list);

--- a/statistics-presences/src/test/java/fr/openent/statistics_presences/bean/global/GlobalSearchTest.java
+++ b/statistics-presences/src/test/java/fr/openent/statistics_presences/bean/global/GlobalSearchTest.java
@@ -1,0 +1,50 @@
+package fr.openent.statistics_presences.bean.global;
+
+import fr.openent.statistics_presences.model.StatisticsFilter;
+import fr.openent.statistics_presences.utils.EventType;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.reflect.Whitebox;
+
+import java.util.Arrays;
+import java.util.List;
+
+
+@RunWith(VertxUnitRunner.class)
+public class GlobalSearchTest {
+    private GlobalSearch search;
+
+    private static final String STRUCTURE_ID = "111";
+    private static final List<Integer> PUNISHMENT_TYPE_IDS = Arrays.asList(11, 12);
+    private static final List<Integer> SANCTION_TYPE_IDS = Arrays.asList(21, 22);
+    private static final List<String> TYPES = Arrays.asList(EventType.UNREGULARIZED.name(), EventType.REGULARIZED.name(),
+            EventType.SANCTION.name(), EventType.PUNISHMENT.name(), EventType.LATENESS.name());
+
+
+    @Test
+    public void testFilterTypeWithNullNOLATENESSREASON(TestContext ctx) throws Exception {
+        JsonObject filter = new JsonObject()
+                .put(StatisticsFilter.StatisticsFilterField.TYPES, TYPES)
+                .putNull(StatisticsFilter.StatisticsFilterField.NOLATENESSREASON)
+                .put(StatisticsFilter.StatisticsFilterField.REASONS, new JsonArray(Arrays.asList(1, 2)))
+                .put(StatisticsFilter.StatisticsFilterField.SANCTION_TYPES, SANCTION_TYPE_IDS)
+                .put(StatisticsFilter.StatisticsFilterField.PUNISHMENT_TYPES, PUNISHMENT_TYPE_IDS);
+
+        search = new GlobalSearch(new StatisticsFilter(STRUCTURE_ID, filter));
+
+        JsonArray expected = new JsonArray()
+                .add(new JsonObject("{\"type\":\"UNREGULARIZED\",\"reason\":{\"$in\":[1,2]}}"))
+                .add(new JsonObject("{\"type\":\"REGULARIZED\",\"reason\":{\"$in\":[1,2]}}"))
+                .add(new JsonObject("{\"type\":\"SANCTION\",\"punishment_type\":{\"$in\":[21,22]}}"))
+                .add(new JsonObject("{\"type\":\"PUNISHMENT\",\"punishment_type\":{\"$in\":[11,12]}}"))
+                .add(new JsonObject("{\"type\":\"LATENESS\",\"reason\":{\"$in\":[1,2]}}"));
+
+        JsonArray result = Whitebox.invokeMethod(search, "filterType", TYPES, false);
+
+        ctx.assertEquals(expected, result);
+    }
+}


### PR DESCRIPTION
## Describe your changes
set default value noLatenessReason to false:
This parameter is Boolean typed and so can have null value => "if(noLatenessReason)" was creating a null pointer.

## Checklist tests
- Go to global statistics view and try an CSV export.
- Go to monthly statistics view and try an CSV export. 

## Issue ticket number and link
[Jira - MA-931](https://entsupport.gdapublic.fr/browse/MA-931)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [x] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

