### PR TITLE
fix(events/absences): #MA-944 fix reason and internal/halfBoarder fil…

### DIFF
--- a/presences/src/main/java/fr/openent/presences/service/impl/DefaultAbsenceService.java
+++ b/presences/src/main/java/fr/openent/presences/service/impl/DefaultAbsenceService.java
@@ -120,7 +120,7 @@ public class DefaultAbsenceService extends DBService implements AbsenceService {
                     return userService.getStudents(structureId, filteredStudentIds, halfBoarder, internal);
                 })
                 .compose(students -> getWithPaginate(structureId, teacherId, students.getList(), startAt, endAt, regularized,
-                        noReason, followed, reasonIds, page))
+                        noReason, followed, halfBoarder, internal, reasonIds, page))
                 .onFailure(err -> {
                     String message = String.format("[Presences@%s::getWithPaginate] Failed to get absences ",
                             this.getClass().getSimpleName());
@@ -156,7 +156,8 @@ public class DefaultAbsenceService extends DBService implements AbsenceService {
     @SuppressWarnings("unchecked")
     private Future<JsonObject> getWithPaginate(String structureId, String teacherId, List<JsonObject> students,
                                                String startAt, String endAt, Boolean regularized, Boolean noReason,
-                                               Boolean followed, List<Integer> reasonIds, Integer page) {
+                                               Boolean followed, Boolean halfBoarder, Boolean internal,
+                                               List<Integer> reasonIds, Integer page) {
         Promise<JsonObject> promise = Promise.promise();
 
         List<String> filterStudentIds = students.stream()
@@ -164,7 +165,8 @@ public class DefaultAbsenceService extends DBService implements AbsenceService {
                 .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
-        boolean canRetrieveAbsences = teacherId == null || !students.isEmpty();
+        boolean canRetrieveAbsences = (teacherId == null && !Boolean.TRUE.equals(halfBoarder) && !Boolean.TRUE.equals(internal))
+                || !students.isEmpty();
 
         Future<JsonArray> absencesFuture = !canRetrieveAbsences ? Future.succeededFuture(new JsonArray()) :
                 retrieve(structureId, filterStudentIds, startAt, endAt, regularized,

--- a/presences/src/main/resources/public/ts/controllers/events.ts
+++ b/presences/src/main/resources/public/ts/controllers/events.ts
@@ -85,12 +85,10 @@ class Controller implements ng.IController, IViewModel {
         });
 
         this.$scope.$on(EVENTS_DATE.ABSENCES_REQUEST, () => {
-            console.log ("onrequest");
             this.$scope.$broadcast(EVENTS_DATE.ABSENCES_SEND, this.absenceListDates);
         });
 
         this.$scope.$on(EVENTS_DATE.EVENT_LIST_REQUEST, () => {
-            console.log ("onrequest");
             this.$scope.$broadcast(EVENTS_DATE.EVENT_LIST_SEND, this.eventListDates);
         });
     }

--- a/presences/src/main/resources/public/ts/directives/events-filter-form/events-filter-form.html
+++ b/presences/src/main/resources/public/ts/directives/events-filter-form/events-filter-form.html
@@ -166,18 +166,14 @@
             </h4>
             <div class="chips cell overflow-y">
                 <label class="chip" ng-class="{ selected: vm.formFilter.allAbsenceReasons &&
-                               (!vm.formFilter.noReasons ||
-                               (vm.formFilter.noReasons &&
-                               (vm.formFilter.notRegularized || vm.formFilter.regularized)))}"
+                (vm.formFilter.notRegularized || vm.formFilter.regularized)}"
                        data-ng-click="vm.switchAllAbsenceReasons()">
                     <i18n>presences.all.none</i18n>
                 </label>
                 <label class="chip"
                        ng-repeat="reason in vm.getAbsencesReasons() track by $index"
                        ng-class="{ selected: reason.isSelected &&
-                               (!vm.formFilter.noReasons ||
-                               (vm.formFilter.noReasons &&
-                               (vm.formFilter.notRegularized || vm.formFilter.regularized)))}"
+                               (vm.formFilter.notRegularized || vm.formFilter.regularized)}"
                        ng-click="vm.switchReason(reason)">
                             <span ng-show="[[reason.id]] !== 0 && !reason.hidden"
                                   ng-disabled="vm.formFilter.noReasons &&


### PR DESCRIPTION
## Describe your changes

- Fix a boolean that was always false in planned absences, that was blocking reasons recovery.
- For internal/halfboarder filters, we retrieve students that correspond to these states, and we filter absences with these students. The fix allow to not execute absences request and to return empty array if we have no students in these case.

## Checklist tests

- On planned absence list, when your editing filters, try to play with reasons list and check if the filter is well applied.
- Try to filter on Internal only (admitting we have no internal absence for these day) and see that the list is empty

## Issue ticket number and link
[Jira - MA-944](https://entsupport.gdapublic.fr/browse/MA-944)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

