### PR TITLE
fix(pdf): #MA-941 fix recovery of absences in pdf export

### DIFF
--- a/presences/src/main/java/fr/openent/presences/controller/events/EventController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/events/EventController.java
@@ -178,6 +178,7 @@ public class EventController extends ControllerHelper {
             String teacherId = (WorkflowHelper.hasRight(userInfos, WorkflowActions.READ_EVENT_RESTRICTED.toString())
                     && "Teacher".equals(userInfos.getType())) ?
                     userInfos.getUserId() : null;
+            Boolean canSeeAllStudent = teacherId != null;
 
             this.groupService.getGroupsAndClassesFromTeacherId(teacherId, structureId)
                     .onFailure(fail -> renderError(request, JsonObject.mapFrom(fail.getMessage())))
@@ -204,7 +205,7 @@ public class EventController extends ControllerHelper {
                                 } else if (ExportType.PDF.type().equals(type)) {
                                     String domain = Renders.getHost(request);
                                     String local = I18n.acceptLanguage(request);
-                                    exportEventService.getPdfData(domain, local, structureId, startDate, endDate, eventType, reasonIds,
+                                    exportEventService.getPdfData(canSeeAllStudent, domain, local, structureId, startDate, endDate, eventType, reasonIds,
                                                     noReason, userId, userIdFromClasses, regularized)
                                             .compose(this::processPdfEvent)
                                             .onSuccess(res -> request.response()

--- a/presences/src/main/java/fr/openent/presences/service/EventService.java
+++ b/presences/src/main/java/fr/openent/presences/service/EventService.java
@@ -190,12 +190,12 @@ public interface EventService {
                             String startDate, String endDate, boolean noReasons, String recoveryMethodUsed, String limit, String offset,
                             Boolean regularized, Handler<Either<String, JsonArray>> handler);
 
-    Future<JsonArray> getEventsByStudent(Integer eventType, List<String> students, String structure, Boolean justified,
+    Future<JsonArray> getEventsByStudent(Boolean canSeeAllStudent, Integer eventType, List<String> students, String structure, Boolean justified,
                                          List<Integer> reasonsId, Boolean massmailed, Boolean compliance, String startDate, String endDate,
                                          boolean noReasons, String recoveryMethodUsed, String limit, String offset,
                                          Boolean regularized);
 
-    void getEventsByStudent(Integer eventType, List<String> students, String structure, Boolean justified,
+    void getEventsByStudent(Boolean canSeeAllStudent, Integer eventType, List<String> students, String structure, Boolean justified,
                             List<Integer> reasonsId, Boolean massmailed, Boolean compliance, String startDate, String endDate,
                             boolean noReasons, String recoveryMethodUsed, String limit, String offset,
                             Boolean regularized, Handler<Either<String, JsonArray>> handler);

--- a/presences/src/main/java/fr/openent/presences/service/ExportEventService.java
+++ b/presences/src/main/java/fr/openent/presences/service/ExportEventService.java
@@ -56,6 +56,7 @@ public interface ExportEventService {
     /**
      * Get events. Will after export this into csv (or PDF)
      *
+     * @param canSeeAllStudent  true if we have access to all student
      * @param domain            domain request sent
      * @param local             accepted langage
      * @param structureId       structure identifier
@@ -72,7 +73,7 @@ public interface ExportEventService {
      * event type -> {@link List} of {@link fr.openent.presences.model.Event.EventByStudent} as JsonObject
      * ... event type...
      */
-    Future<JsonObject> getPdfData(String domain, String local, String structureId, String startDate, String endDate,
+    Future<JsonObject> getPdfData(Boolean canSeeAllStudent, String domain, String local, String structureId, String startDate, String endDate,
                                   List<String> eventType, List<String> listReasonIds, Boolean noReason, List<String> userId,
                                   JsonArray userIdFromClasses, Boolean regularized);
 

--- a/presences/src/main/java/fr/openent/presences/service/impl/DefaultEventService.java
+++ b/presences/src/main/java/fr/openent/presences/service/impl/DefaultEventService.java
@@ -1289,12 +1289,12 @@ public class DefaultEventService extends DBService implements EventService {
     }
 
     @Override
-    public Future<JsonArray> getEventsByStudent(Integer eventType, List<String> students, String structure, Boolean justified,
+    public Future<JsonArray> getEventsByStudent(Boolean canSeeAllStudent, Integer eventType, List<String> students, String structure, Boolean justified,
                                                 List<Integer> reasonsId, Boolean massmailed, Boolean compliance, String startDate, String endDate,
                                                 boolean noReasons, String recoveryMethodUsed, String limit, String offset,
                                                 Boolean regularized) {
         Promise<JsonArray> promise = Promise.promise();
-        this.getEventsByStudent(eventType, students, structure, justified, reasonsId, massmailed, compliance, startDate, endDate, noReasons,
+        this.getEventsByStudent(canSeeAllStudent, eventType, students, structure, justified, reasonsId, massmailed, compliance, startDate, endDate, noReasons,
                 recoveryMethodUsed, limit, offset, regularized, event -> {
                     if (event.isLeft()) {
                         String message = String.format("[Presences@%s::getEventsByStudent] an error has occurred while fetching " +
@@ -1309,7 +1309,7 @@ public class DefaultEventService extends DBService implements EventService {
     }
 
     @Override
-    public void getEventsByStudent(Integer eventType, List<String> students, String structure, Boolean justified,
+    public void getEventsByStudent(Boolean canSeeAllStudent, Integer eventType, List<String> students, String structure, Boolean justified,
                                    List<Integer> reasonsId, Boolean massmailed, Boolean compliance, String startDate, String endDate,
                                    boolean noReasons, String recoveryMethodUsed, String limit, String offset,
                                    Boolean regularized, Handler<Either<String, JsonArray>> handler) {
@@ -1385,7 +1385,10 @@ public class DefaultEventService extends DBService implements EventService {
                                 if (res.isLeft()) {
                                     queryHandler.handle(new Either.Left<>(res.left().getValue()));
                                 } else {
-                                    queryHandler.handle(new Either.Right<>((students == null || students.isEmpty()) ?
+                                    //If we do not have permission to see the information of all the students
+                                    // and the list of our students is empty
+                                    // then we do not return any data
+                                    queryHandler.handle(new Either.Right<>(!Boolean.TRUE.equals(canSeeAllStudent) && (students == null || students.isEmpty()) ?
                                             new JsonArray() : res.right().getValue()));
                                 }
                             }));
@@ -1410,7 +1413,7 @@ public class DefaultEventService extends DBService implements EventService {
     public void getEventsByStudent(Integer eventType, List<String> students, String structure, Boolean justified, List<Integer> reasonsId,
                                    Boolean massmailed, Boolean compliance, String startDate, String endDate, boolean noReasons,
                                    String recoveryMethodUsed, Boolean regularized, Handler<Either<String, JsonArray>> handler) {
-        this.getEventsByStudent(eventType, students, structure, justified, reasonsId, massmailed, compliance, startDate,
+        this.getEventsByStudent(null, eventType, students, structure, justified, reasonsId, massmailed, compliance, startDate,
                 endDate, noReasons, recoveryMethodUsed, null, null, regularized, handler);
     }
 
@@ -1419,7 +1422,7 @@ public class DefaultEventService extends DBService implements EventService {
                                    List<Integer> reasonsId, Boolean massmailed, String startDate, String endDate,
                                    boolean noReasons, String recoveryMethodUsed, String limit, String offset,
                                    Boolean regularized, Handler<Either<String, JsonArray>> handler) {
-        this.getEventsByStudent(eventType, students, structure, justified, reasonsId, massmailed, null, startDate,
+        this.getEventsByStudent(null, eventType, students, structure, justified, reasonsId, massmailed, null, startDate,
                 endDate, noReasons, recoveryMethodUsed, null, null, regularized, handler);
     }
 

--- a/presences/src/main/java/fr/openent/presences/service/impl/DefaultExportEventService.java
+++ b/presences/src/main/java/fr/openent/presences/service/impl/DefaultExportEventService.java
@@ -125,7 +125,7 @@ public class DefaultExportEventService extends DBService implements ExportEventS
 
     @Override
     @SuppressWarnings("unchecked")
-    public Future<JsonObject> getPdfData(String domain, String local, String structureId, String startDate, String endDate,
+    public Future<JsonObject> getPdfData(Boolean canSeeAllStudent, String domain, String local, String structureId, String startDate, String endDate,
                                          List<String> eventType, List<String> listReasonIds, Boolean noReason, List<String> userId,
                                          JsonArray userIdFromClasses, Boolean regularized) {
         Promise<JsonObject> promise = Promise.promise();
@@ -151,7 +151,7 @@ public class DefaultExportEventService extends DBService implements ExportEventS
                             .setEndOfHalfDayTimeSlot(slotsSettingsFuture.result().getString(Field.END_OF_HALF_DAY));
                     List<Reason> reasons = ReasonHelper.getReasonListFromJsonArray(reasonFuture.result(), Reason.MANDATORY_ATTRIBUTE);
 
-                    processEvents(settings, structureId, startDate, endDate, eventType, listReasonIds, noReason, studentIdList)
+                    processEvents(canSeeAllStudent, settings, structureId, startDate, endDate, eventType, listReasonIds, noReason, studentIdList)
                             .compose(eventByStudent -> formatEventsDataPdf(startDate, endDate, domain, local, settings, reasons, eventByStudent, eventType))
                             .onSuccess(promise::complete)
                             .onFailure(err -> {
@@ -185,7 +185,7 @@ public class DefaultExportEventService extends DBService implements ExportEventS
      * @return {@link Future<List>} of {@link EventByStudent}
      */
     @SuppressWarnings("unchecked")
-    private Future<List<EventByStudent>> processEvents(Settings setting, String structureId, String startDate, String endDate,
+    private Future<List<EventByStudent>> processEvents(Boolean canSeeAllStudent, Settings setting, String structureId, String startDate, String endDate,
                                                        List<String> eventType, List<String> listReasonIds, Boolean noReason,
                                                        JsonArray userIdFromClasses) {
         Promise<List<EventByStudent>> promise = Promise.promise();
@@ -198,7 +198,7 @@ public class DefaultExportEventService extends DBService implements ExportEventS
 
         for (Integer type : eventsTypes) {
             current = current.compose(v -> {
-                Future<JsonArray> next = this.eventService.getEventsByStudent(type, userIdFromClasses.getList(), structureId,
+                Future<JsonArray> next = this.eventService.getEventsByStudent(canSeeAllStudent, type, userIdFromClasses.getList(), structureId,
                         null, reasonIds, null, null, startDate, endDate, noReason,
                         setting.recoveryMethod(), null, null, null);
                 eventsTypeResult.add(next);


### PR DESCRIPTION
## Describe your changes
When setting up 1D rights, it was decided that if you have the presences.event.read.restricted right and you are a teacher, then you only get our students. Conversely, if you don't have this right or you are an admin then you don't get a student because you necessarily have access. The problem occurs later with a condition that verifies the presence of a student, if we don't have one, we don't retrieve the data (See com).

## Checklist tests
Export absences from the list of events.

## Issue ticket number and link
https://entsupport.gdapublic.fr/browse/MA-942

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

