### PR TITLE
fix(event): #MA-947 fix lateness without reason no show in scroll

### DIFF
--- a/presences/src/main/resources/public/ts/services/EventService.ts
+++ b/presences/src/main/resources/public/ts/services/EventService.ts
@@ -55,7 +55,7 @@ export const eventService: EventService = {
             const startTime: string = eventRequest.startTime ? `&startTime=${eventRequest.startTime}` : '';
             const endTime: string = eventRequest.endTime ? `&endTime=${eventRequest.endTime}` : '';
             const noReason: string = eventRequest.noReason ? `&noReason=${eventRequest.noReason}` : '';
-            const noReasonLateness: string = eventRequest.noReasonLateness ? `&noReason=${eventRequest.noReasonLateness}` : '';
+            const noReasonLateness: string = eventRequest.noReasonLateness ? `&noReasonLateness=${eventRequest.noReasonLateness}` : '';
             const eventType: string = eventRequest.eventType ? `&eventType=${eventRequest.eventType}` : '';
             const listReasonIds: string = eventRequest.listReasonIds ? `&reasonIds=${eventRequest.listReasonIds}` : '';
             const userId: string = eventRequest.userId && eventRequest.userId.length > 0 ? `&userId=${eventRequest.userId}` : '';
@@ -80,8 +80,8 @@ export const eventService: EventService = {
             const page: string = eventRequest.page ? `&page=${eventRequest.page}` : '';
 
 
-            const urlParams: string = `${structureId}${startDate}${endDate}${startTime}${endTime}${noReason}${noReasonLateness}
-            ${eventType}${listReasonIds}${userId}${userIds}${classes}${classesIds}${regularized}${followed}${page}`;
+            const urlParams: string = `${structureId}${startDate}${endDate}${startTime}${endTime}${noReason}${noReasonLateness}` +
+            `${eventType}${listReasonIds}${userId}${userIds}${classes}${classesIds}${regularized}${followed}${page}`;
 
             const {data}: AxiosResponse = await http.get(`/presences/events${urlParams}`);
 

--- a/presences/src/main/resources/public/ts/services/__tests__/event.service.test.ts
+++ b/presences/src/main/resources/public/ts/services/__tests__/event.service.test.ts
@@ -1,0 +1,245 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import {EventRequest, eventService} from "@presences/services";
+import {ActionBody, IEventBody, IStudentEventRequest} from "@presences/models";
+import {ExportType} from "@common/core/enum/export-type.enum";
+
+describe('EventService', () => {
+    it('check get methode in EventService', done => {
+        const mock = new MockAdapter(axios);
+        const eventRequest : EventRequest = {
+            classes: "classes1,classes2",
+            classesIds: ["classesId1", "classesId2"],
+            endDate: "2000-02-01",
+            endTime: "endTime",
+            eventType: "4,5",
+            followed: true,
+            listReasonIds: "1,2,3",
+            noReason: true,
+            noReasonLateness: true,
+            notFollowed: true,
+            page: 7,
+            regularized: true,
+            startDate: "2000-01-02",
+            startTime: "startTime",
+            structureId: "structureId",
+            userId: "userId",
+            userIds: ["userId1", "userId2"]
+        }
+        const data = {all: [], page_count: 3};
+        const result = {all: [], events: [], pageCount: 3};
+        mock.onGet(`/presences/events?structureId=${eventRequest.structureId}&startDate=${eventRequest.startDate}&endDate=${eventRequest.endDate}` +
+            `&startTime=${eventRequest.startTime}&endTime=${eventRequest.endTime}&noReason=${eventRequest.noReason}&noReasonLateness=${eventRequest.noReasonLateness}` +
+            `&eventType=${eventRequest.eventType}&reasonIds=${eventRequest.listReasonIds}&userId=${eventRequest.userId}&userId=${eventRequest.userIds[0]}` +
+            `&userId=${eventRequest.userIds[1]}&classes=${eventRequest.classes}&classes=${eventRequest.classesIds[0]}&classes=${eventRequest.classesIds[1]}` +
+            `&regularized=${eventRequest.regularized}&page=${eventRequest.page}`)
+            .reply(200, data);
+
+        eventService.get(eventRequest).then(response => {
+            expect(response).toEqual(result);
+            done();
+        });
+    });
+
+    it('check get methode in EventService', done => {
+        const mock = new MockAdapter(axios);
+        const eventRequest : EventRequest = {
+            classes: "classes1,classes2",
+            classesIds: ["classesId1", "classesId2"],
+            endDate: "2000-02-01",
+            endTime: "endTime",
+            eventType: "4,5",
+            followed: true,
+            listReasonIds: "",
+            noReason: true,
+            noReasonLateness: false,
+            notFollowed: false,
+            page: 7,
+            regularized: false,
+            startDate: "2000-01-02",
+            startTime: "startTime",
+            structureId: "structureId",
+            userId: "userId",
+            userIds: ["userId1", "userId2"]
+        }
+        const data = {all: [], page_count: 3};
+        const result = {all: [], events: [], pageCount: 3};
+        mock.onGet(`/presences/events?structureId=${eventRequest.structureId}&startDate=${eventRequest.startDate}&endDate=${eventRequest.endDate}` +
+            `&startTime=${eventRequest.startTime}&endTime=${eventRequest.endTime}&noReason=${eventRequest.noReason}` +
+            `&eventType=${eventRequest.eventType}&userId=${eventRequest.userId}&userId=${eventRequest.userIds[0]}` +
+            `&userId=${eventRequest.userIds[1]}&classes=${eventRequest.classes}&classes=${eventRequest.classesIds[0]}&classes=${eventRequest.classesIds[1]}` +
+            `&regularized=${eventRequest.regularized}&followed=${!eventRequest.notFollowed}&page=${eventRequest.page}`)
+            .reply(200, data);
+
+        eventService.get(eventRequest).then(response => {
+            expect(response).toEqual(result);
+            done();
+        });
+    });
+
+    it('check getEventActions methode in EventService', done => {
+        const mock = new MockAdapter(axios);
+
+        const data = {response: true};
+        const eventId = 3;
+        mock.onGet(`/presences/events/${eventId}/actions`)
+            .reply(200, data);
+
+        eventService.getEventActions(eventId).then(response => {
+            expect(response).toEqual(data);
+            done();
+        });
+    });
+
+    it('check createAction methode in EventService', done => {
+        const mock = new MockAdapter(axios);
+
+        const data = {response: true};
+        const actionBody : ActionBody = {actionId: 0, comment: "", eventId: [3], owner: ""};
+        mock.onPost(`/presences/events/actions`, actionBody)
+            .reply(200, data);
+
+        eventService.createAction(actionBody).then(response => {
+            expect(response.data).toEqual(data);
+            done();
+        });
+    });
+
+    it('check getStudentEvent methode in EventService', done => {
+        const mock = new MockAdapter(axios);
+
+        const data = {response: true};
+        let studentEventRequest : IStudentEventRequest = {
+            end_at: "end_at",
+            limit: 4,
+            offset: 5,
+            start_at: "start_at",
+            structure_id: "structure_id",
+            student_id: "student_id",
+            type: ["1","3"]
+        };
+        mock.onGet(`/presences/students/student_id/events?structure_id=${studentEventRequest.structure_id}` +
+            `&start_at=${studentEventRequest.start_at}&end_at=${studentEventRequest.end_at}&type=${studentEventRequest.type[0]}` +
+            `&type=${studentEventRequest.type[1]}&limit=${studentEventRequest.limit}&offset=${studentEventRequest.offset}`)
+            .reply(200, data);
+
+        eventService.getStudentEvent(studentEventRequest).then(response => {
+            expect(response).toEqual(data);
+            done();
+        });
+
+        studentEventRequest = {
+            end_at: "end_at",
+            limit: undefined,
+            offset: undefined,
+            start_at: "start_at",
+            structure_id: "structure_id",
+            student_id: "student_id",
+            type: ["1","3"]
+        };
+
+        mock.onGet(`/presences/students/student_id/events?structure_id=${studentEventRequest.structure_id}` +
+            `&start_at=${studentEventRequest.start_at}&end_at=${studentEventRequest.end_at}&type=${studentEventRequest.type[0]}` +
+            `&type=${studentEventRequest.type[1]}`)
+            .reply(200, data);
+
+        eventService.getStudentEvent(studentEventRequest).then(response => {
+            expect(response).toEqual(data);
+            done();
+        });
+    });
+
+    it('check export methode in EventService', done => {
+        const actionBody : ActionBody = {actionId: 0, comment: "", eventId: undefined, owner: ""};
+        const eventRequest : EventRequest = {
+            classes: "classes1,classes2",
+            classesIds: ["classesId1", "classesId2"],
+            endDate: "2000-02-01",
+            endTime: "endTime",
+            eventType: "4,5",
+            followed: true,
+            listReasonIds: "1,2,3",
+            noReason: true,
+            noReasonLateness: true,
+            notFollowed: true,
+            page: 7,
+            regularized: true,
+            startDate: "2000-01-02",
+            startTime: "startTime",
+            structureId: "structureId",
+            userId: "userId",
+            userIds: ["userId1", "userId2"]
+        }
+        const exportType: ExportType = 'CSV';
+        const res: string = eventService.export(eventRequest, exportType);
+        expect(res).toEqual(`/presences/events/export?type=${exportType}&structureId=${eventRequest.structureId}&startDate=${eventRequest.startDate}&endDate=${eventRequest.endDate}&noReason=${eventRequest.noReason}&eventType=${eventRequest.eventType}&reasonIds=${eventRequest.listReasonIds}&userId=${eventRequest.userId}&classes=${eventRequest.classes}&regularized=${eventRequest.regularized}`)
+        done();
+    });
+
+    it('check getAbsentsCounts methode in EventService', done => {
+        const mock = new MockAdapter(axios);
+
+        const data = {response: true};
+        //Must find a way to mock currentdate
+        const startDate: string = "startDate";
+        const endDate: string = "endDate";
+
+        mock.onGet(`/presences/events/absences/summary&startAt=${startDate}&endAt=${endDate}`)
+            .reply(200, data);
+
+        eventService.getAbsentsCounts(undefined, startDate, endDate).then(response => {
+            expect(response).toEqual(data);
+            done();
+        });
+    });
+
+    it('check createLatenessEvent methode in EventService', done => {
+        const mock = new MockAdapter(axios);
+
+        const data = {response: true};
+        //Must find a way to mock currentdate
+        const structureId: string = "structureId";
+        const eventBody: IEventBody = {end_date: "", reason_id: 0, register_id: 0, start_date: "", student_id: ""};
+
+        mock.onPost(`/presences/events/${structureId}/lateness`, eventBody)
+            .reply(200, data);
+
+        eventService.createLatenessEvent(eventBody, structureId).then(response => {
+            expect(response.data).toEqual(data);
+            done();
+        });
+    });
+
+    it('check updateEvent methode in EventService', done => {
+        const mock = new MockAdapter(axios);
+
+        const data = {response: true};
+        //Must find a way to mock currentdate
+        const eventId = 3;
+        const eventBody: IEventBody = {end_date: "", reason_id: 0, register_id: 0, start_date: "", student_id: ""};
+
+        mock.onPut(`/presences/events/${eventId}`, eventBody)
+            .reply(200, data);
+
+        eventService.updateEvent(eventId, eventBody).then(response => {
+            expect(response.data).toEqual(data);
+            done();
+        });
+    });
+
+    it('check deleteEvent methode in EventService', done => {
+        const mock = new MockAdapter(axios);
+
+        const data = {response: true};
+        //Must find a way to mock currentdate
+        const eventId = 3;
+
+        mock.onDelete(`/presences/events/${eventId}`)
+            .reply(200, data);
+
+        eventService.deleteEvent(eventId).then(response => {
+            expect(response.data).toEqual(data);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
## Describe your changes
When you scroll in the list of events, you call the API to get the following events. The problem is that the value of the filter was not used for delays without a reason.

## Checklist tests
Have a lateness without cause as well as an absence without reason and more than 20 events more recent than that of the lateness and the absence

## Issue ticket number and link
https://entsupport.gdapublic.fr/browse/MA-947

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

