### PR TITLE
fix(event-list): #MA-951 stop selecting reason ids from preferences if noReason filter only

### DIFF
--- a/presences/src/main/resources/public/ts/directives/events-filter-form/events-filter-form.ts
+++ b/presences/src/main/resources/public/ts/directives/events-filter-form/events-filter-form.ts
@@ -143,7 +143,8 @@ class Controller implements ng.IController, IViewModel {
             if (formFilterPref[window.structure.id] !== undefined && formFilterPref[window.structure.id].regularized !== undefined) {
                 formFilterPref = formFilterPref ? formFilterPref[window.structure.id] : null;
                 this.formFilter = formFilterPref ? formFilterPref : JSON.parse(JSON.stringify(this.filter));
-                this.updateReasonsFromIds();
+                let hasOnlyNoReason: boolean = this.formFilter.noReasons && !this.formFilter.regularized && !this.formFilter.notRegularized;
+                this.updateReasonsFromIds(hasOnlyNoReason ? REASON_TYPE_ID.LATENESS : null);
             } else {
                 this.resetFilter();
             }
@@ -198,10 +199,11 @@ class Controller implements ng.IController, IViewModel {
         this.updateReasonsFromIds();
     }
 
-    updateReasonsFromIds(): void {
+    updateReasonsFromIds(reasonTypeId?: number): void {
         if (this.reasons && this.formFilter.reasonIds !== undefined) {
             this.reasons.forEach((reason: Reason) => {
-                if (this.formFilter.reasonIds.find((rId: number) => rId === reason.id) !== undefined) {
+                if (this.formFilter.reasonIds.find((rId: number) => rId === reason.id &&
+                    ((reasonTypeId && reason.reason_type_id === reasonTypeId) || !reasonTypeId) !== undefined)) {
                     reason.isSelected = true;
                 }
             });


### PR DESCRIPTION
## Describe your changes

- If `noReason` filter is selected, absences reasons will not be selected even if saved in preferences

## Checklist tests

- check if reasons are loading properly on form init
- checl if reasons are not selected if noReason filter is the only absence filter selected

## Issue ticket number and link

https://entsupport.gdapublic.fr/browse/MA-951

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

