### PR TITLE
feat(event): #MA-950 add filter for lateness and followed abs in export

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ subprojects {
         testCompile "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
         testCompile "org.mockito:mockito-core:$mockitoVersion"
         testCompile "org.powermock:powermock-core:$powerMockVersion"
+        testCompile "org.powermock:powermock-api-mockito2:$powerMockVersion"
+        testCompile "org.powermock:powermock-module-junit4:$powerMockVersion"
+        testCompile "org.powermock:powermock-module-testng:$powerMockVersion"
         compile "fr.wseduc:vertx-cron-timer:$vertxCronTimer"
         testCompile "io.vertx:testtools:$toolsVersion"
     }

--- a/presences/src/main/java/fr/openent/presences/controller/EventBusController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/EventBusController.java
@@ -74,7 +74,6 @@ public class EventBusController extends ControllerHelper {
                 break;
             case "get-events-by-student":
                 eventType = body.getInteger("eventType");
-                justified = body.getBoolean("justified");
                 students = body.getJsonArray("students", new JsonArray()).getList();
                 structure = body.getString("structure");
                 reasonsId = body.getJsonArray("reasonsId", new JsonArray()).getList();
@@ -85,7 +84,7 @@ public class EventBusController extends ControllerHelper {
                 noReasons = body.getBoolean("noReasons");
                 recoveryMethod = body.getString("recoveryMethod");
                 regularized = body.getBoolean("regularized");
-                this.eventService.getEventsByStudent(eventType, students, structure, justified, reasonsId, massmailed, compliance, startDate, endDate, noReasons, recoveryMethod, regularized, BusResponseHandler.busArrayHandler(message));
+                this.eventService.getEventsByStudent(eventType, students, structure, reasonsId, massmailed, compliance, startDate, endDate, noReasons, recoveryMethod, regularized, BusResponseHandler.busArrayHandler(message));
                 break;
             case "get-absences":
                 students = body.getJsonArray("studentIds", new JsonArray()).getList();

--- a/presences/src/main/java/fr/openent/presences/controller/MementoController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/MementoController.java
@@ -88,19 +88,19 @@ public class MementoController extends ControllerHelper {
                     Future<JsonArray> future = Future.future();
                     switch (type) {
                         case UNREGULARIZED:
-                            eventService.getEventsByStudent(1, Collections.singletonList(student), structure, null, reasonIds, null, start, end, false, null, false, FutureHelper.handlerJsonArray(future));
+                            eventService.getEventsByStudent(1, Collections.singletonList(student), structure, reasonIds, null, start, end, false, null, false, FutureHelper.handlerJsonArray(future));
                             break;
                         case REGULARIZED:
-                            eventService.getEventsByStudent(1, Collections.singletonList(student), structure, null, reasonIds, null, start, end, false, null, true, FutureHelper.handlerJsonArray(future));
+                            eventService.getEventsByStudent(1, Collections.singletonList(student), structure, reasonIds, null, start, end, false, null, true, FutureHelper.handlerJsonArray(future));
                             break;
                         case NO_REASON:
-                            eventService.getEventsByStudent(1, Collections.singletonList(student), structure, null, new ArrayList<>(), null, start, end, true, null, false, FutureHelper.handlerJsonArray(future));
+                            eventService.getEventsByStudent(1, Collections.singletonList(student), structure, new ArrayList<>(), null, start, end, true, null, false, FutureHelper.handlerJsonArray(future));
                             break;
                         case LATENESS:
-                            eventService.getEventsByStudent(2, Collections.singletonList(student), structure, null, new ArrayList<>(), null, start, end, true, null, null, FutureHelper.handlerJsonArray(future));
+                            eventService.getEventsByStudent(2, Collections.singletonList(student), structure, new ArrayList<>(), null, start, end, true, null, null, FutureHelper.handlerJsonArray(future));
                             break;
                         case DEPARTURE:
-                            eventService.getEventsByStudent(3, Collections.singletonList(student), structure, null, new ArrayList<>(), null, start, end, true, null, null, FutureHelper.handlerJsonArray(future));
+                            eventService.getEventsByStudent(3, Collections.singletonList(student), structure, new ArrayList<>(), null, start, end, true, null, null, FutureHelper.handlerJsonArray(future));
                             break;
                         default:
                             //There is no default case

--- a/presences/src/main/java/fr/openent/presences/controller/events/EventController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/events/EventController.java
@@ -165,6 +165,7 @@ public class EventController extends ControllerHelper {
         List<String> eventType = request.getParam(Field.EVENTTYPE) != null ? Arrays.asList(request.getParam(Field.EVENTTYPE).split("\\s*,\\s*")) : null;
         List<String> reasonIds = request.getParam(Field.REASONIDS) != null ? Arrays.asList(request.getParam(Field.REASONIDS).split("\\s*,\\s*")) : null;
         Boolean noReason = request.params().contains(Field.NOREASON) && Boolean.parseBoolean(request.getParam(Field.NOREASON));
+        Boolean noReasonLateness = request.params().contains(Field.NOREASONLATENESS) && Boolean.parseBoolean(request.getParam(Field.NOREASONLATENESS));
         List<String> userId = request.getParam(Field.USERID) != null ? Arrays.asList(request.getParam(Field.USERID).split("\\s*,\\s*")) : new ArrayList<>();
         List<String> classes = request.getParam(Field.CLASSES) != null ?
                 Arrays.asList(request.getParam(Field.CLASSES).split("\\s*,\\s*")) : new ArrayList<>();
@@ -200,13 +201,13 @@ public class EventController extends ControllerHelper {
                             } else {
                                 JsonArray userIdFromClasses = userResponse.right().getValue();
                                 if (ExportType.CSV.type().equals(type)) {
-                                    exportEventService.getCsvData(structureId, startDate, endDate, eventType, reasonIds, noReason, userId, userIdFromClasses,
+                                    exportEventService.getCsvData(structureId, startDate, endDate, eventType, reasonIds, noReason, noReasonLateness, userId, userIdFromClasses,
                                             classes, restrictedClasses, regularized, followed, event -> processCsvEvent(request, event));
                                 } else if (ExportType.PDF.type().equals(type)) {
                                     String domain = Renders.getHost(request);
                                     String local = I18n.acceptLanguage(request);
                                     exportEventService.getPdfData(canSeeAllStudent, domain, local, structureId, startDate, endDate, eventType, reasonIds,
-                                                    noReason, userId, userIdFromClasses, regularized)
+                                                    noReason, noReasonLateness, userId, userIdFromClasses, regularized, followed)
                                             .compose(this::processPdfEvent)
                                             .onSuccess(res -> request.response()
                                                     .putHeader("Content-type", "application/pdf; charset=utf-8")

--- a/presences/src/main/java/fr/openent/presences/helper/RegisterPresenceHelper.java
+++ b/presences/src/main/java/fr/openent/presences/helper/RegisterPresenceHelper.java
@@ -128,7 +128,7 @@ public class RegisterPresenceHelper {
                 filterDates(startDate, endDate, params) +
                 filterTimes(startTime, endTime, params) +
                 EventQueryHelper.filterStudentIds(registerUsers, params) +
-                EventQueryHelper.filterReasons(reasonIds, noAbsenceReason, noLatenessReason,regularized, typeIds, params) +
+                EventQueryHelper.filterReasons(reasonIds, noAbsenceReason, noLatenessReason,regularized, followed, typeIds, params) +
                 EventQueryHelper.filterFollowed(followed, params) +
                 filterTypes(typeIds, params) +
                 " GROUP BY student_id; ";

--- a/presences/src/main/java/fr/openent/presences/service/EventService.java
+++ b/presences/src/main/java/fr/openent/presences/service/EventService.java
@@ -29,7 +29,7 @@ public interface EventService {
      */
 
     void getEvents(String structureId, String startDate, String endDate,
-                   List<String> eventType, List<String> listReasonIds, Boolean noReason, List<String> userId, JsonArray userIdFromClasses,
+                   List<String> eventType, List<String> listReasonIds, Boolean noReason, Boolean noReasonLateness, List<String> userId, JsonArray userIdFromClasses,
                    Boolean regularized, Boolean followed, Integer page, Handler<Either<String, JsonArray>> handler);
 
     void get(String structureId, String startDate, String endDate, String startTime, String endTime,
@@ -186,21 +186,21 @@ public interface EventService {
      * @param offset             corresponding to the offset data rows wanted (optional).
      * @param handler            Function handler returning data
      */
-    void getEventsByStudent(Integer eventType, List<String> students, String structure, Boolean justified, List<Integer> reasonsId, Boolean massmailed,
+    void getEventsByStudent(Integer eventType, List<String> students, String structure, List<Integer> reasonsId, Boolean massmailed,
                             String startDate, String endDate, boolean noReasons, String recoveryMethodUsed, String limit, String offset,
                             Boolean regularized, Handler<Either<String, JsonArray>> handler);
 
-    Future<JsonArray> getEventsByStudent(Boolean canSeeAllStudent, Integer eventType, List<String> students, String structure, Boolean justified,
+    Future<JsonArray> getEventsByStudent(Boolean canSeeAllStudent, Integer eventType, List<String> students, String structure,
                                          List<Integer> reasonsId, Boolean massmailed, Boolean compliance, String startDate, String endDate,
-                                         boolean noReasons, String recoveryMethodUsed, String limit, String offset,
-                                         Boolean regularized);
+                                         boolean noReasons, boolean noReasonsLateness, String recoveryMethodUsed, String limit, String offset,
+                                         Boolean regularized, Boolean followed);
 
-    void getEventsByStudent(Boolean canSeeAllStudent, Integer eventType, List<String> students, String structure, Boolean justified,
+    void getEventsByStudent(Boolean canSeeAllStudent, Integer eventType, List<String> students, String structure,
                             List<Integer> reasonsId, Boolean massmailed, Boolean compliance, String startDate, String endDate,
-                            boolean noReasons, String recoveryMethodUsed, String limit, String offset,
-                            Boolean regularized, Handler<Either<String, JsonArray>> handler);
+                            boolean noReasons, Boolean noReasonsLateness, String recoveryMethodUsed, String limit, String offset,
+                            Boolean regularized, Boolean followed, Handler<Either<String, JsonArray>> handler);
 
-    void getEventsByStudent(Integer eventType, List<String> students, String structure, Boolean justified, List<Integer> reasonsId,
+    void getEventsByStudent(Integer eventType, List<String> students, String structure, List<Integer> reasonsId,
                             Boolean massmailed, String startDate, String endDate, boolean noReasons, String recoveryMethodUsed,
                             Boolean regularized, Handler<Either<String, JsonArray>> handler);
 
@@ -210,7 +210,6 @@ public interface EventService {
      * @param eventType          Event Type list
      * @param students           Student list. Contains every students identifiers
      * @param structure          Structure identifier
-     * @param justified          Justified events or not ? Can be null if justified event needs to be excluded
      * @param massmailed         Massmailed ? Use by massmailing module. When null, column is excluded
      * @param compliance         compliance ? Using this filter will remove absence whose compliance is TRUE if included
      * @param startDate          Range start date
@@ -220,7 +219,7 @@ public interface EventService {
      * @param recoveryMethodUsed method used to recover events, can be null if method in settings is wanted.
      * @param handler            Function handler returning data
      */
-    void getEventsByStudent(Integer eventType, List<String> students, String structure, Boolean justified, List<Integer> reasonsId,
+    void getEventsByStudent(Integer eventType, List<String> students, String structure, List<Integer> reasonsId,
                             Boolean massmailed, Boolean compliance, String startDate, String endDate, boolean noReasons,
                             String recoveryMethodUsed, Boolean regularized, Handler<Either<String, JsonArray>> handler);
 

--- a/presences/src/main/java/fr/openent/presences/service/ExportEventService.java
+++ b/presences/src/main/java/fr/openent/presences/service/ExportEventService.java
@@ -30,7 +30,7 @@ public interface ExportEventService {
      * @param handler           Function handler returning data
      */
     void getCsvData(String structureId, String startDate, String endDate, List<String> eventType, List<String> listReasonIds,
-                    Boolean noReason, List<String> userId, JsonArray userIdFromClasses, List<String> classes,
+                    Boolean noReason, Boolean noReasonLateness, List<String> userId, JsonArray userIdFromClasses, List<String> classes,
                     List<String> restrictedClasses, Boolean regularized, Boolean followed, Handler<AsyncResult<List<Event>>> handler);
 
     /**
@@ -50,7 +50,7 @@ public interface ExportEventService {
      * @return list of {@link Event}
      */
     Future<List<Event>> getCsvData(String structureId, String startDate, String endDate, List<String> eventType, List<String> listReasonIds,
-                                   Boolean noReason, List<String> userId, JsonArray userIdFromClasses, List<String> classes,
+                                   Boolean noReason, Boolean noReasonLateness, List<String> userId, JsonArray userIdFromClasses, List<String> classes,
                                    Boolean regularized, Boolean followed);
 
     /**
@@ -74,7 +74,7 @@ public interface ExportEventService {
      * ... event type...
      */
     Future<JsonObject> getPdfData(Boolean canSeeAllStudent, String domain, String local, String structureId, String startDate, String endDate,
-                                  List<String> eventType, List<String> listReasonIds, Boolean noReason, List<String> userId,
-                                  JsonArray userIdFromClasses, Boolean regularized);
+                                  List<String> eventType, List<String> listReasonIds, Boolean noReason, Boolean noReasonLateness, List<String> userId,
+                                  JsonArray userIdFromClasses, Boolean regularized, Boolean followed);
 
 }

--- a/presences/src/main/java/fr/openent/presences/service/impl/DefaultArchiveService.java
+++ b/presences/src/main/java/fr/openent/presences/service/impl/DefaultArchiveService.java
@@ -249,7 +249,7 @@ public class DefaultArchiveService extends DBService implements ArchiveService {
         Promise<JsonObject> promise = Promise.promise();
         String start = splittedDateSchoolYear.getString(Field.START_DATE);
         String end = splittedDateSchoolYear.getString(Field.END_DATE);
-        exportEventService.getCsvData(structure.getString(Field.ID), start, end, eventType, reasonIds, true, new ArrayList<>(),
+        exportEventService.getCsvData(structure.getString(Field.ID), start, end, eventType, reasonIds, true, true, new ArrayList<>(),
                 new JsonArray(), null, null, null)
                 .compose(events -> writeCSV(events, start, end, exportProcess, domain, locale))
                 .onSuccess(res -> promise.complete(exportProcess))

--- a/presences/src/main/java/fr/openent/presences/service/impl/DefaultEventStudentService.java
+++ b/presences/src/main/java/fr/openent/presences/service/impl/DefaultEventStudentService.java
@@ -292,28 +292,28 @@ public class DefaultEventStudentService implements EventStudentService {
         Promise<JsonArray> promise = Promise.promise();
         switch (type) {
             case NO_REASON:
-                eventService.getEventsByStudent(1, studentIds, structureId, null,
+                eventService.getEventsByStudent(1, studentIds, structureId,
                         new ArrayList<>(), null, start, end, true, HOUR, false,
                         FutureHelper.handlerJsonArray(promise));
                 break;
             case UNREGULARIZED:
-                eventService.getEventsByStudent(1, studentIds, structureId, null,
+                eventService.getEventsByStudent(1, studentIds, structureId,
                         reasonsIds, null, start, end, false, HOUR, false,
                         FutureHelper.handlerJsonArray(promise));
                 break;
             case REGULARIZED:
-                eventService.getEventsByStudent(1, studentIds, structureId, null,
+                eventService.getEventsByStudent(1, studentIds, structureId,
                         reasonsIds, null, start, end, false, HOUR, true,
                         FutureHelper.handlerJsonArray(promise));
                 break;
             case LATENESS:
                 eventService.getEventsByStudent(2, studentIds, structureId,
-                        null, new ArrayList<>(), null, start, end, true, null,
+                        new ArrayList<>(), null, start, end, true, null,
                         limit, offset, null, FutureHelper.handlerJsonArray(promise));
                 break;
             case DEPARTURE:
                 eventService.getEventsByStudent(3, studentIds, structureId,
-                        null, new ArrayList<>(), null, start, end, true, null,
+                        new ArrayList<>(), null, start, end, true, null,
                         limit, offset, null, FutureHelper.handlerJsonArray(promise));
                 break;
             default:

--- a/presences/src/main/resources/public/ts/controllers/event-list.ts
+++ b/presences/src/main/resources/public/ts/controllers/event-list.ts
@@ -834,9 +834,12 @@ export const eventListController = ng.controller('EventListController', ['$scope
                 startTime: vm.events.startTime,
                 endTime: vm.events.endTime,
                 noReason: vm.events.noReason,
+                noReasonLateness: vm.events.noReasonLateness,
                 eventType: vm.events.eventType,
                 listReasonIds: vm.events.listReasonIds,
                 regularized: vm.events.regularized,
+                followed: vm.events.followed,
+                notFollowed: vm.events.notFollowed,
                 userId: vm.events.userId,
                 classes: vm.events.classes,
             };

--- a/presences/src/main/resources/public/ts/services/EventService.ts
+++ b/presences/src/main/resources/public/ts/services/EventService.ts
@@ -148,14 +148,17 @@ export const eventService: EventService = {
         const startDate: string = `&startDate=${DateUtils.format(eventRequest.startDate, dateFormat)}`;
         const endDate: string = `&endDate=${DateUtils.format(eventRequest.endDate, dateFormat)}`;
         const noReason: string = eventRequest.noReason ? `&noReason=${eventRequest.noReason}` : "";
+        const noReasonLateness: string = eventRequest.noReasonLateness ? `&noReasonLateness=${eventRequest.noReasonLateness}` : "";
         const eventType: string = `&eventType=${eventRequest.eventType}`;
         const listReasonIds: string = eventRequest.listReasonIds ? `&reasonIds=${eventRequest.listReasonIds}` : "";
         const userId: string = eventRequest.userId.length === 0 ? "" : `&userId=${eventRequest.userId}`;
         const classes: string = eventRequest.classes.length === 0 ? "" : `&classes=${eventRequest.classes}`;
         const regularized: string = (eventRequest.regularized != null) ? `&regularized=${(eventRequest.regularized)}` : "";
+        const followed: string = (eventRequest.followed != null || eventRequest.notFollowed != null)
+        && (eventRequest.followed === !eventRequest.notFollowed) ? `&followed=${eventRequest.followed}` : '';
         const basedUrl: string = `${url}${type}${structureId}`;
 
-        return `${basedUrl}${startDate}${endDate}${noReason}${eventType}${listReasonIds}${userId}${classes}${regularized}`;
+        return `${basedUrl}${startDate}${endDate}${noReason}${noReasonLateness}${eventType}${listReasonIds}${userId}${classes}${regularized}${followed}`;
     },
 
 

--- a/presences/src/main/resources/public/ts/services/__tests__/event.service.test.ts
+++ b/presences/src/main/resources/public/ts/services/__tests__/event.service.test.ts
@@ -172,7 +172,7 @@ describe('EventService', () => {
         }
         const exportType: ExportType = 'CSV';
         const res: string = eventService.export(eventRequest, exportType);
-        expect(res).toEqual(`/presences/events/export?type=${exportType}&structureId=${eventRequest.structureId}&startDate=${eventRequest.startDate}&endDate=${eventRequest.endDate}&noReason=${eventRequest.noReason}&eventType=${eventRequest.eventType}&reasonIds=${eventRequest.listReasonIds}&userId=${eventRequest.userId}&classes=${eventRequest.classes}&regularized=${eventRequest.regularized}`)
+        expect(res).toEqual(`/presences/events/export?type=${exportType}&structureId=${eventRequest.structureId}&startDate=${eventRequest.startDate}&endDate=${eventRequest.endDate}&noReason=${eventRequest.noReason}&noReasonLateness=${eventRequest.noReasonLateness}&eventType=${eventRequest.eventType}&reasonIds=${eventRequest.listReasonIds}&userId=${eventRequest.userId}&classes=${eventRequest.classes}&regularized=${eventRequest.regularized}`)
         done();
     });
 

--- a/presences/src/test/java/fr/openent/presences/service/impl/DefaultEventServiceTest.java
+++ b/presences/src/test/java/fr/openent/presences/service/impl/DefaultEventServiceTest.java
@@ -3,8 +3,8 @@ package fr.openent.presences.service.impl;
 import fr.openent.presences.Presences;
 import fr.openent.presences.db.DB;
 import fr.openent.presences.db.DBService;
+import fr.openent.presences.helper.EventQueryHelper;
 import fr.openent.presences.service.CommonPresencesServiceFactory;
-import fr.openent.presences.service.EventService;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
@@ -17,23 +17,31 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
+import org.powermock.reflect.Whitebox;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-@RunWith(VertxUnitRunner.class)
+@RunWith(PowerMockRunner.class)
+@PowerMockRunnerDelegate(VertxUnitRunner.class)
+@PrepareForTest({DefaultEventService.class, EventQueryHelper.class})
 public class DefaultEventServiceTest extends DBService {
 
     Sql sql = Mockito.mock(Sql.class);
 
-    private EventService eventService;
+    private DefaultEventService eventService;
 
     @Before
     public void setUp() {
         DB.getInstance().init(null, sql, null);
         CommonPresencesServiceFactory commonPresencesServiceFactory = new CommonPresencesServiceFactory(Vertx.vertx(), null, new JsonObject());
-        this.eventService = new DefaultEventService(commonPresencesServiceFactory);
+        this.eventService = PowerMockito.spy(new DefaultEventService(commonPresencesServiceFactory));
     }
 
     @Test
@@ -67,5 +75,60 @@ public class DefaultEventServiceTest extends DBService {
         }).when(sql).prepared(Mockito.anyString(), Mockito.any(JsonArray.class), Mockito.any(Handler.class));
         eventService.getEventsBetweenDates(startDate, endDate, users, eventType, structureId);
 
+    }
+
+    @Test
+    public void testSetParamsForQueryEvents(TestContext ctx) throws Exception {
+        PowerMockito.spy(EventQueryHelper.class);
+        List<String> listReasonIds = Arrays.asList("reason1", "reason2");
+        List<String> userId = Arrays.asList("user1", "user2", "user3");
+        Boolean regularized = true;
+        Boolean followed = true;
+        Boolean noReason = true;
+        Boolean noReasonLateness = true;
+        JsonArray userIdFromClasses = new JsonArray(Arrays.asList(new JsonObject().put("studentId","studentId1"), new JsonObject().put("studentId", "studentId2")));
+        List<String> typeIds = Arrays.asList("1", "2", "3");
+        JsonArray params = new JsonArray();
+
+        PowerMockito.doReturn(" AND (paramsStudent)").when(EventQueryHelper.class, "filterStudentIds", Mockito.any(), Mockito.any());
+        PowerMockito.doReturn(" AND (paramsReason)").when(EventQueryHelper.class, "filterReasons", Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+
+        String expectedQuery = " AND ( (paramsStudent) AND (paramsReason))";
+        JsonArray expectedParams = new JsonArray(Arrays.asList());
+
+        String res = Whitebox.invokeMethod(eventService, "setParamsForQueryEvents", listReasonIds, userId, regularized, followed, noReason, noReasonLateness, userIdFromClasses, typeIds, params);
+        ctx.assertEquals(expectedQuery, res);
+        ctx.assertEquals(expectedParams, params);
+        ctx.assertEquals(res.length() - res.replace("?","").length(), params.size());
+
+        PowerMockito.doReturn("").when(EventQueryHelper.class, "filterReasons", Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+
+        expectedQuery = " AND ( (paramsStudent))";
+        expectedParams = new JsonArray(Arrays.asList());
+
+        res = Whitebox.invokeMethod(eventService, "setParamsForQueryEvents", listReasonIds, userId, regularized, followed, noReason, noReasonLateness, userIdFromClasses, typeIds, params);
+        ctx.assertEquals(expectedQuery, res);
+        ctx.assertEquals(expectedParams, params);
+        ctx.assertEquals(res.length() - res.replace("?","").length(), params.size());
+
+        PowerMockito.doReturn("").when(EventQueryHelper.class, "filterStudentIds", Mockito.any(), Mockito.any());
+
+        expectedQuery = "";
+        expectedParams = new JsonArray(Arrays.asList());
+
+        res = Whitebox.invokeMethod(eventService, "setParamsForQueryEvents", listReasonIds, userId, regularized, followed, noReason, noReasonLateness, userIdFromClasses, typeIds, params);
+        ctx.assertEquals(expectedQuery, res);
+        ctx.assertEquals(expectedParams, params);
+        ctx.assertEquals(res.length() - res.replace("?","").length(), params.size());
+
+        PowerMockito.doReturn(" AND (paramsReason)").when(EventQueryHelper.class, "filterReasons", Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+
+        expectedQuery = " AND (paramsReason)";
+        expectedParams = new JsonArray(Arrays.asList());
+
+        res = Whitebox.invokeMethod(eventService, "setParamsForQueryEvents", listReasonIds, userId, regularized, followed, noReason, noReasonLateness, userIdFromClasses, typeIds, params);
+        ctx.assertEquals(expectedQuery, res);
+        ctx.assertEquals(expectedParams, params);
+        ctx.assertEquals(res.length() - res.replace("?","").length(), params.size());
     }
 }

--- a/presences/src/test/java/fr/openent/presences/service/impl/EventServiceTest.java
+++ b/presences/src/test/java/fr/openent/presences/service/impl/EventServiceTest.java
@@ -36,6 +36,8 @@ public class EventServiceTest extends DBService {
         Mockito.doAnswer((Answer<Void>) invocation -> {
             JsonArray params = invocation.getArgument(1);
 
+
+
             ctx.assertEquals(params, new JsonArray()
                     .add(Field.STRUCTURE_ID)
                     .add(Field.EVENT_TYPE)
@@ -44,8 +46,7 @@ public class EventServiceTest extends DBService {
                     .add(Field.END_TIME)
                     .add(Field.START_TIME)
                     .add(true)
-                    .add(Field.REASON_ID)
-                    .add(Field.REASON_ID)
+                    .add(Field.EVENT_TYPE)
                     .add(0)
                     .add(20));
 
@@ -61,59 +62,58 @@ public class EventServiceTest extends DBService {
     public void testGetEventQuery(TestContext ctx) throws Exception {
         List<String> students = new ArrayList<>();
         List<Integer> reasonsId = new ArrayList<>();
-        JsonObject res = Whitebox.invokeMethod(eventService, "getEventQuery",0, students, "structure", true,
+        JsonObject res = Whitebox.invokeMethod(eventService, "getEventQuery",0, students, "structure",
                 reasonsId, true, true, "startDate", "endDate", false, "InvalidRecoveryMethod", "startTime", "endTime",
                 "limit", "offset", true, true);
 
-        ctx.assertEquals(res.toString(), "{\"query\":\"SELECT event.student_id, event.start_date, event.end_date," +
-                " event.type_id, 'HOUR' as recovery_method, json_agg(json_build_object('id', event.id, 'start_date'," +
-                " event.start_date, 'end_date', event.end_date, 'comment', event.comment, 'counsellor_input', event.counsellor_input," +
-                " 'student_id', event.student_id, 'register_id', event.register_id, 'type_id', event.type_id, 'reason_id'," +
-                " event.reason_id, 'owner', event.owner, 'created', event.created, 'counsellor_regularisation'," +
-                " event.counsellor_regularisation, 'followed', event.followed, 'massmailed', event.massmailed, 'reason'," +
-                " json_build_object('id', reason.id, 'absence_compliance', reason.absence_compliance))) as events FROM" +
-                " null.event LEFT JOIN presences.reason ON (reason.id = event.reason_id) INNER JOIN presences.register ON" +
-                " (register.id = event.register_id) WHERE event.start_date >= ? AND event.end_date<= ? AND register.structure_id" +
-                " = ? AND type_id = ? AND (reason.absence_compliance IS true OR reason.absence_compliance IS NULL)  AND massmailed" +
-                " = ?  AND counsellor_regularisation = ? GROUP BY event.start_date, event.student_id, event.end_date, event.type_id" +
-                "  LIMIT ?  OFFSET ? \",\"params\":[\"startDate 00:00:00\",\"endDate 23:59:59\",\"structure\",0,true,true,\"limit\",\"offset\"]}");
+        ctx.assertEquals(res.toString(), "{\"query\":\"SELECT event.student_id, event.start_date, event.end_date, event.type_id," +
+                " 'HOUR' as recovery_method, json_agg(json_build_object('id', event.id, 'start_date', event.start_date, 'end_date', event.end_date," +
+                " 'comment', event.comment, 'counsellor_input', event.counsellor_input, 'student_id', event.student_id, 'register_id'," +
+                " event.register_id, 'type_id', event.type_id, 'reason_id', event.reason_id, 'owner', event.owner, 'created', event.created," +
+                " 'counsellor_regularisation', event.counsellor_regularisation, 'followed', event.followed, 'massmailed', event.massmailed," +
+                " 'reason', json_build_object('id', reason.id, 'absence_compliance', reason.absence_compliance))) as events FROM" +
+                " null.event LEFT JOIN presences.reason ON (reason.id = event.reason_id) INNER JOIN presences.register ON (register.id" +
+                " = event.register_id) WHERE event.start_date >= ? AND event.end_date<= ? AND register.structure_id = ? AND type_id =" +
+                " ? AND (reason.absence_compliance IS true OR reason.absence_compliance IS NULL)  AND ((type_id IN (?) AND type_id NOT" +
+                " IN (1,2))) AND massmailed = ?  GROUP BY event.start_date, event.student_id, event.end_date, event.type_id  LIMIT ?" +
+                "  OFFSET ? \",\"params\":[\"startDate 00:00:00\",\"endDate 23:59:59\",\"structure\",0,\"0\",true,\"limit\",\"offset\"]}");
 
-        res = Whitebox.invokeMethod(eventService, "getEventQuery",0, students, "structure", true,
+        res = Whitebox.invokeMethod(eventService, "getEventQuery",0, students, "structure",
                 reasonsId, true, true, "startDate", "endDate", false, EventRecoveryMethodEnum.HOUR.getValue(), "startTime", "endTime",
                 "limit", "offset", true, true);
 
-        ctx.assertEquals(res.toString(), "{\"query\":\"SELECT event.student_id, event.start_date, event.end_date," +
-                " event.type_id, 'HOUR' as recovery_method, json_agg(json_build_object('id', event.id, 'start_date'," +
-                " event.start_date, 'end_date', event.end_date, 'comment', event.comment, 'counsellor_input', event.counsellor_input," +
-                " 'student_id', event.student_id, 'register_id', event.register_id, 'type_id', event.type_id, 'reason_id'," +
-                " event.reason_id, 'owner', event.owner, 'created', event.created, 'counsellor_regularisation'," +
-                " event.counsellor_regularisation, 'followed', event.followed, 'massmailed', event.massmailed, 'reason'," +
-                " json_build_object('id', reason.id, 'absence_compliance', reason.absence_compliance))) as events FROM" +
-                " null.event LEFT JOIN presences.reason ON (reason.id = event.reason_id) INNER JOIN presences.register ON" +
-                " (register.id = event.register_id) WHERE event.start_date >= ? AND event.end_date<= ? AND register.structure_id" +
-                " = ? AND type_id = ? AND (reason.absence_compliance IS true OR reason.absence_compliance IS NULL)  AND massmailed" +
-                " = ?  AND counsellor_regularisation = ? GROUP BY event.start_date, event.student_id, event.end_date, event.type_id" +
-                "  LIMIT ?  OFFSET ? \",\"params\":[\"startDate 00:00:00\",\"endDate 23:59:59\",\"structure\",0,true,true,\"limit\",\"offset\"]}");
+        ctx.assertEquals(res.toString(), "{\"query\":\"SELECT event.student_id, event.start_date, event.end_date, event.type_id," +
+                " 'HOUR' as recovery_method, json_agg(json_build_object('id', event.id, 'start_date', event.start_date, 'end_date'," +
+                " event.end_date, 'comment', event.comment, 'counsellor_input', event.counsellor_input, 'student_id', event.student_id," +
+                " 'register_id', event.register_id, 'type_id', event.type_id, 'reason_id', event.reason_id, 'owner', event.owner," +
+                " 'created', event.created, 'counsellor_regularisation', event.counsellor_regularisation, 'followed', event.followed," +
+                " 'massmailed', event.massmailed, 'reason', json_build_object('id', reason.id, 'absence_compliance', reason.absence_compliance)))" +
+                " as events FROM null.event LEFT JOIN presences.reason ON (reason.id = event.reason_id) INNER JOIN presences.register" +
+                " ON (register.id = event.register_id) WHERE event.start_date >= ? AND event.end_date<= ? AND register.structure_id =" +
+                " ? AND type_id = ? AND (reason.absence_compliance IS true OR reason.absence_compliance IS NULL)  AND ((type_id IN (?)" +
+                " AND type_id NOT IN (1,2))) AND massmailed = ?  GROUP BY event.start_date, event.student_id, event.end_date," +
+                " event.type_id  LIMIT ?  OFFSET ? \",\"params\":[\"startDate 00:00:00\",\"endDate 23:59:59\",\"structure\",0,\"0\"," +
+                "true,\"limit\",\"offset\"]}");
 
-        res = Whitebox.invokeMethod(eventService, "getEventQuery",0, students, "structure", true,
+        res = Whitebox.invokeMethod(eventService, "getEventQuery",0, students, "structure",
                 reasonsId, true, true, "startDate", "endDate", false, EventRecoveryMethodEnum.HALF_DAY.getValue(), "startTime", "endTime",
                 "limit", "offset", true, true);
 
         ctx.assertEquals(res.toString(), "{\"query\":\"SELECT event.student_id, event.start_date::date, event.end_date::date," +
                 " event.type_id, 'HALF_DAY' as recovery_method, json_agg(json_build_object('id', event.id, 'start_date', event.start_date," +
                 " 'end_date', event.end_date, 'comment', event.comment, 'counsellor_input', event.counsellor_input, 'student_id'," +
-                " event.student_id, 'register_id', event.register_id, 'type_id', event.type_id, 'reason_id', event.reason_id," +
-                " 'owner', event.owner, 'created', event.created, 'counsellor_regularisation', event.counsellor_regularisation," +
-                " 'followed', event.followed, 'massmailed', event.massmailed, 'reason', json_build_object('id', reason.id," +
-                " 'absence_compliance', reason.absence_compliance))) as events FROM null.event LEFT JOIN presences.reason ON" +
-                " (reason.id = event.reason_id) INNER JOIN presences.register ON (register.id = event.register_id) WHERE" +
-                " event.start_date::date >= ? AND event.end_date::date<= ? AND register.structure_id = ? AND type_id = ? AND" +
-                " (reason.absence_compliance IS true OR reason.absence_compliance IS NULL)  AND event.start_date::time > ? AND" +
-                " event.start_date::time < ? AND massmailed = ?  AND counsellor_regularisation = ? GROUP BY event.start_date::date," +
-                " event.student_id, event.end_date::date, event.type_id  LIMIT ?  OFFSET ?" +
-                " \",\"params\":[\"startDate 00:00:00\",\"endDate 23:59:59\",\"structure\",0,\"startTime\",\"endTime\",true,true,\"limit\",\"offset\"]}");
+                " event.student_id, 'register_id', event.register_id, 'type_id', event.type_id, 'reason_id', event.reason_id, 'owner'," +
+                " event.owner, 'created', event.created, 'counsellor_regularisation', event.counsellor_regularisation, 'followed'," +
+                " event.followed, 'massmailed', event.massmailed, 'reason', json_build_object('id', reason.id, 'absence_compliance'," +
+                " reason.absence_compliance))) as events FROM null.event LEFT JOIN presences.reason ON (reason.id = event.reason_id)" +
+                " INNER JOIN presences.register ON (register.id = event.register_id) WHERE event.start_date::date >= ? AND event.end_date::date<=" +
+                " ? AND register.structure_id = ? AND type_id = ? AND (reason.absence_compliance IS true OR reason.absence_compliance" +
+                " IS NULL)  AND event.start_date::time > ? AND event.start_date::time < ? AND ((type_id IN (?) AND type_id NOT IN" +
+                " (1,2))) AND massmailed = ?  GROUP BY event.start_date::date, event.student_id, event.end_date::date, event.type_id" +
+                "  LIMIT ?  OFFSET ? \",\"params\":[\"startDate 00:00:00\",\"endDate 23:59:59\",\"structure\",0,\"startTime\",\"endTime\"" +
+                ",\"0\",true,\"limit\",\"offset\"]}");
 
-        res = Whitebox.invokeMethod(eventService, "getEventQuery",0, students, "structure", true,
+        res = Whitebox.invokeMethod(eventService, "getEventQuery",0, students, "structure",
                 reasonsId, true, true, "startDate", "endDate", false, EventRecoveryMethodEnum.DAY.getValue(), "startTime", "endTime",
                 "limit", "offset", true, true);
 
@@ -123,11 +123,11 @@ public class EventServiceTest extends DBService {
                 " event.student_id, 'register_id', event.register_id, 'type_id', event.type_id, 'reason_id', event.reason_id," +
                 " 'owner', event.owner, 'created', event.created, 'counsellor_regularisation', event.counsellor_regularisation," +
                 " 'followed', event.followed, 'massmailed', event.massmailed, 'reason', json_build_object('id', reason.id," +
-                " 'absence_compliance', reason.absence_compliance))) as events FROM null.event LEFT JOIN presences.reason ON" +
-                " (reason.id = event.reason_id) INNER JOIN presences.register ON (register.id = event.register_id) WHERE" +
-                " event.start_date::date >= ? AND event.end_date::date<= ? AND register.structure_id = ? AND type_id = ? AND" +
-                " (reason.absence_compliance IS true OR reason.absence_compliance IS NULL)  AND massmailed = ?  AND" +
-                " counsellor_regularisation = ? GROUP BY event.start_date::date, event.student_id, event.end_date::date, event.type_id" +
-                "  LIMIT ?  OFFSET ? \",\"params\":[\"startDate 00:00:00\",\"endDate 23:59:59\",\"structure\",0,true,true,\"limit\",\"offset\"]}");
+                " 'absence_compliance', reason.absence_compliance))) as events FROM null.event LEFT JOIN presences.reason ON (reason.id" +
+                " = event.reason_id) INNER JOIN presences.register ON (register.id = event.register_id) WHERE event.start_date::date" +
+                " >= ? AND event.end_date::date<= ? AND register.structure_id = ? AND type_id = ? AND (reason.absence_compliance IS" +
+                " true OR reason.absence_compliance IS NULL)  AND ((type_id IN (?) AND type_id NOT IN (1,2))) AND massmailed = ?" +
+                "  GROUP BY event.start_date::date, event.student_id, event.end_date::date, event.type_id  LIMIT ?  OFFSET ? \"," +
+                "\"params\":[\"startDate 00:00:00\",\"endDate 23:59:59\",\"structure\",0,\"0\",true,\"limit\",\"offset\"]}");
     }
 }


### PR DESCRIPTION
## Describe your changes
The csv and pdf exports did not correctly filter the events. I had to add the filter on delays without a reason for the csv and the pdf, as well as the filters for absence followed and regularize.

Added PowerMockito for testing.

Doc: https://entconf.gdapublic.fr/display/MP/Event#Event-ExportCSV/PDF

## Checklist tests
Go to the list of events and filter it, export CSV and PDF.

## Issue ticket number and link
https://entsupport.gdapublic.fr/browse/MA-950

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [x] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been added to this project (must specify in **Description**)

