### PR TITLE
fix(registry): #MA-936 fix that monday is not consider as excluded fo…

### DIFF
--- a/presences/src/main/java/fr/openent/presences/helper/CalendarHelper.java
+++ b/presences/src/main/java/fr/openent/presences/helper/CalendarHelper.java
@@ -30,6 +30,10 @@ public class CalendarHelper {
     public static final int SATURDAY_OF_WEEK = 6;
     public static final int SUNDAY_OF_WEEK = 7;
 
+    private CalendarHelper() {
+        throw new IllegalStateException("Utility class");
+    }
+
     public static HashMap<String, Map<String, Course>> hashCourses(List<Course> courses, List<Slot> slots,
                                                                    List<String> subjects) {
         HashMap<String, Map<String, Course>> courseList = new HashMap<>();
@@ -336,7 +340,7 @@ public class CalendarHelper {
                 JsonObject exclusion = exclusionsDate.getJsonObject(i);
                 String startDate = exclusion.getString("start_date");
                 String endDate = exclusion.getString("end_date");
-                if (DateHelper.isAfterOrEquals(date, startDate) && DateHelper.isBeforeOrEquals(date, endDate)) {
+                if (DateHelper.isAfterOrEquals(date, startDate) && DateHelper.isBefore(date, endDate)) {
                     return true;
                 }
             }

--- a/presences/src/test/java/fr/openent/presences/helper/CalendarHelperTest.java
+++ b/presences/src/test/java/fr/openent/presences/helper/CalendarHelperTest.java
@@ -1,0 +1,39 @@
+package fr.openent.presences.helper;
+
+import fr.openent.presences.common.helper.DateHelper;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.reflect.Whitebox;
+
+
+@RunWith(VertxUnitRunner.class)
+public class CalendarHelperTest {
+
+    @Test
+    public void testSetExcludeDay_is_false_when_endDate_is_not_included(TestContext ctx) throws Exception {
+        String date = "2022-05-30T00:00:00";
+        JsonArray exclusionDay = new JsonArray()
+                .add(new JsonObject()
+                        .put("start_date", "2022-05-26T00:00:00")
+                        .put("end_date", "2022-05-30T00:00:00"));
+
+        boolean res = Whitebox.invokeMethod(CalendarHelper.class, "isMatchWithExclusionsDate", exclusionDay, date);
+        ctx.assertFalse(res);
+    }
+
+    @Test
+    public void testSetExcludeDay_is_true_when_endDate_is_included(TestContext ctx) throws Exception {
+        String date = "2022-05-30T00:00:00";
+        JsonArray exclusionDay = new JsonArray()
+                .add(new JsonObject()
+                        .put("start_date", "2022-05-26T00:00:00")
+                        .put("end_date", "2022-05-30T23:59:59"));
+
+        boolean res = Whitebox.invokeMethod(CalendarHelper.class, "isMatchWithExclusionsDate", exclusionDay, date);
+        ctx.assertTrue(res);
+    }
+}


### PR DESCRIPTION
## Describe your changes
To fix excluded end day, i taste if date is before end excluded period day.
Before, we also checked if these dates were equal, so "2022-05-30T00:00:00" date was equal to "2022-05-30T00:00:00" excluded day and so this date was consider excluded.

## Checklist tests
In NG2, with compte.admin:
- go to presence => dashboard => search 3eme1 on registry => select Mai - 2022 => and see that "9 mai" date is no more consider as excluded.

## Issue ticket number and link
[Jira - MA-936](https://entsupport.gdapublic.fr/browse/MA-936)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [x] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

