### PR TITLE
fix(common): #MA-954 fix NoStackTraceThrowable in FutureHelper

### DIFF
--- a/common/src/main/java/fr/openent/presences/common/helper/FutureHelper.java
+++ b/common/src/main/java/fr/openent/presences/common/helper/FutureHelper.java
@@ -103,13 +103,13 @@ public class FutureHelper {
     public static void busArrayHandler(Future<JsonArray> future, Message<JsonObject> message) {
         future
                 .onSuccess(result -> message.reply((new JsonObject()).put(Field.STATUS, Field.OK).put(Field.RESULT, result)))
-                .onFailure(error -> message.reply((new JsonObject()).put(Field.STATUS, Field.ERROR).put(Field.MESSAGE, error)));
+                .onFailure(error -> message.reply((new JsonObject()).put(Field.STATUS, Field.ERROR).put(Field.MESSAGE, error.getMessage())));
     }
 
     public static void busObjectHandler(Future<JsonObject> future, Message<JsonObject> message) {
         future
                 .onSuccess(result -> message.reply((new JsonObject()).put(Field.STATUS, Field.OK).put(Field.RESULT, result)))
-                .onFailure(error -> message.reply((new JsonObject()).put(Field.STATUS, Field.ERROR).put(Field.MESSAGE, error)));
+                .onFailure(error -> message.reply((new JsonObject()).put(Field.STATUS, Field.ERROR).put(Field.MESSAGE, error.getMessage())));
     }
 
     public static void handleObjectResult(JsonObject messageBody, Promise<JsonObject> promise) {


### PR DESCRIPTION
## Describe your changes
A Not StackTrace Throwable error was thrown in the FutureHelper.java

```
java.lang.IllegalStateException: Illegal type in JsonObject: class io.vertx.core.impl.NoStackTraceThrowable
	at io.vertx.core.json.JsonObject.checkAndCopy(JsonObject.java:1100)
	at io.vertx.core.json.JsonObject.put(JsonObject.java:730)
	at fr.openent.presences.common.helper.FutureHelper.lambda$busObjectHandler$10(FutureHelper.java:112)
```

## Checklist tests
Nothing

## Issue ticket number and link
https://entsupport.gdapublic.fr/browse/MA-954

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

