### PR TITLE
fix(register): #MA-955 fix to long name when create event

### DIFF
--- a/presences/src/main/java/fr/openent/presences/constants/EventStores.java
+++ b/presences/src/main/java/fr/openent/presences/constants/EventStores.java
@@ -10,5 +10,5 @@ public class EventStores {
     public static final String ACCESS = "ACCESS";
 
     // CREATE EVENT TO STORE REGISTER VALIDATION
-    public static final String VALIDATE_REGISTER = "VALIDATE_REGISTER";
+    public static final String VALID_REGISTER = "VALID_REGISTER";
 }

--- a/presences/src/main/java/fr/openent/presences/controller/RegisterController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/RegisterController.java
@@ -124,7 +124,7 @@ public class RegisterController extends ControllerHelper {
                     }
                 });
                 if (RegisterStatus.DONE.getStatus().equals(state)) {
-                    eventStore.createAndStoreEvent(EventStores.VALIDATE_REGISTER, request);
+                    eventStore.createAndStoreEvent(EventStores.VALID_REGISTER, request);
                 }
             } catch (ClassCastException | NumberFormatException e) {
                 log.error("[Presences@RegisterController::updateStatus] Failed to parse register identifier", e);


### PR DESCRIPTION
## Describe your changes
After validating the call, the API request is saved in the EventStore. Each query is stored with a name. This name cannot move 16 characters.

## Checklist tests
Validate a call, no error appears in the logs.

## Issue ticket number and link
https://entsupport.gdapublic.fr/browse/MA-955

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

