### PR TITLE
fix(event): #MA-958 fix consistency concerns between total and number info displayed

### DIFF
--- a/common/src/main/java/fr/openent/presences/common/helper/EventsHelper.java
+++ b/common/src/main/java/fr/openent/presences/common/helper/EventsHelper.java
@@ -41,14 +41,19 @@ public class EventsHelper {
             JsonObject latestEvent = getLatestEvent(groupEvents);
 
             // we set new Event start date with the earliest events start_date and end date with the latest events end_date
-            if (earliestEvent != null && latestEvent != null)
-                newEvents.add(setGroupedEvent(groupEvents, earliestEvent.getString("start_date"), latestEvent.getString("end_date")));
+            if (earliestEvent != null && latestEvent != null) {
+                groupEvents.stream()
+                        .collect(Collectors.groupingBy(el -> el.getString(Field.STUDENT_ID)))
+                        .forEach((s, studentEvents) -> newEvents.add(
+                                setGroupedEvent(studentEvents, earliestEvent.getString(Field.START_DATE), latestEvent.getString(Field.END_DATE))
+                        ));
+            }
         });
 
         // return events sorted by date desc
         return new JsonArray(
                 newEvents.stream().sorted((JsonObject eventA, JsonObject eventB) ->
-                        DateHelper.isDateBeforeOrEqual(eventB.getString("start_date"), eventA.getString("start_date")) ? -1 : 1
+                        DateHelper.isDateBeforeOrEqual(eventB.getString(Field.START_DATE), eventA.getString(Field.START_DATE)) ? -1 : 1
                 ).collect(Collectors.toList())
         );
     }

--- a/presences/src/main/java/fr/openent/presences/service/impl/DefaultEventService.java
+++ b/presences/src/main/java/fr/openent/presences/service/impl/DefaultEventService.java
@@ -1371,7 +1371,7 @@ public class DefaultEventService extends DBService implements EventService {
                                    boolean noReasons, String recoveryMethodUsed, String limit, String offset,
                                    Boolean regularized, Handler<Either<String, JsonArray>> handler) {
         this.getEventsByStudent(null, eventType, students, structure, reasonsId, massmailed, null, startDate,
-                endDate, noReasons, null, recoveryMethodUsed, null, null, regularized, null, handler);
+                endDate, noReasons, null, recoveryMethodUsed, limit, offset, regularized, null, handler);
     }
 
 


### PR DESCRIPTION
## Describe your changes
When there are 2 absences with different students, the absences are merged if they are in the same morning/day (depending on the school life setting). It should not be merged if they are different students.

## Checklist tests
Have a parent account with 2 children, these 2 children must have an absence on the same day (see with Guillaume Roux and Manon Lacommare).

## Issue ticket number and link
https://entsupport.gdapublic.fr/browse/MA-958

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

