### PR TITLE
feat(alert): #MA-968 init data to set up excluded alerts rules

### DIFF
--- a/incidents/src/main/resources/sql/020-MA-968-make-alerts-configurable.sql
+++ b/incidents/src/main/resources/sql/020-MA-968-make-alerts-configurable.sql
@@ -1,0 +1,2 @@
+-- Add column for incidents params
+ALTER TABLE incidents.seriousness ADD COLUMN exclude_alert_seriousness boolean NOT NULL DEFAULT FALSE;

--- a/presences/src/main/resources/sql/046-MA-968-make-alerts-configurable.sql
+++ b/presences/src/main/resources/sql/046-MA-968-make-alerts-configurable.sql
@@ -1,0 +1,35 @@
+-- Add column for viesco params, used in trigger
+ALTER TABLE presences.settings ADD COLUMN exclude_alert_absence_no_reason boolean NOT NULL DEFAULT FALSE,
+                               ADD COLUMN exclude_alert_lateness_no_reason boolean NOT NULL DEFAULT FALSE,
+                               ADD COLUMN exclude_alert_forgotten_notebook boolean NOT NULL DEFAULT FALSE;
+
+-- Table used as constant
+CREATE TABLE presences.reason_alert_exclude_rules_type(
+    id bigserial,
+    rule_type varchar(36) UNIQUE,
+    CONSTRAINT reason_alert_exclude_rules_type_pkey PRIMARY KEY(id)
+);
+-- Add some constant
+INSERT INTO presences.reason_alert_exclude_rules_type(id, rule_type) VALUES (1, 'REGULARIZED'),(2, 'UNREGULARIZED'),(3, 'LATENESS');
+
+-- Add new table for exclude reason
+CREATE TABLE presences.reason_alert
+(
+    structure_id character varying(36),
+    reason_id    bigint REFERENCES presences.reason(id),
+    reason_alert_exclude_rules_type_id bigserial REFERENCES presences.reason_alert_exclude_rules_type(id),
+    created_at timestamp without time zone NOT NULL DEFAULT now(),
+    deleted_at timestamp without time zone,
+    CONSTRAINT uniq_reason_alert UNIQUE (structure_id, reason_id, reason_alert_exclude_rules_type_id)
+);
+
+-- By default, all the reasons already created must be excluded, whether they are regularized or not.
+do $$
+    declare
+        reason presences.reason;
+    begin
+        FOR reason IN SELECT * FROM presences.reason WHERE reason_type_id = 1 LOOP
+            INSERT INTO presences.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) VALUES (reason.structure_id, reason.id, 1);
+            INSERT INTO presences.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) VALUES (reason.structure_id, reason.id, 2);
+        end loop;
+    end$$;

--- a/presences/src/main/resources/sql/scriptSQLReverse/046-MA-968-make-alerts-configurable-reverse.sql
+++ b/presences/src/main/resources/sql/scriptSQLReverse/046-MA-968-make-alerts-configurable-reverse.sql
@@ -1,0 +1,7 @@
+ALTER TABLE presences.settings DROP COLUMN exclude_alert_absence_no_reason,
+                               DROP COLUMN exclude_alert_lateness_no_reason,
+                               DROP COLUMN exclude_alert_forgotten_notebook;
+ALTER TABLE incidents.seriousness DROP COLUMN exclude_alert_seriousness;
+
+DROP TABLE presences.reason_alert;
+DROP TABLE presences.reason_alert_exclude_rules_type;


### PR DESCRIPTION
## Describe your changes
Party 1/3 of the ticket [MA-662](https://entsupport.gdapublic.fr/browse/MA-662)

Edit table for the MA-662.
MA-662 makes alerts configurable.

The tests are provided in the PR #140 

Doc: https://entconf.gdapublic.fr/pages/viewpage.action?pageId=96436457

The files in the "SQLReverseScript" folder is used in case of a problem in production. They must allow to restore the database to the state before the ticket. They will be deleted in the PR of the MA-770 ticket.

## Checklist tests
Nothing. Just execute this file after MA-662 complete 
https://github.com/OPEN-ENT-NG/presences/pull/140/files#diff-849bfe6ffcfd3d258ea47768804e674f38c73d03c0da7520bebbcbef54fbccd2

## Issue ticket number and link
[MA-968](https://entsupport.gdapublic.fr/browse/MA-968)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

