### PR TITLE
feat(alert): #MA-967 add of the count of alerts per line

### DIFF
--- a/presences/src/main/resources/sql/044-MA-967-count-alert-by-line.sql
+++ b/presences/src/main/resources/sql/044-MA-967-count-alert-by-line.sql
@@ -1,0 +1,17 @@
+-- Delete old data due to the modification of the table
+TRUNCATE TABLE presences.alerts;
+TRUNCATE TABLE presences.alert_history;
+
+-- Override unique CONSTRAINT
+ALTER TABLE presences.alerts ADD COLUMN event_id bigint NOT NULL,
+                             DROP CONSTRAINT uniq_alert,
+                             ADD CONSTRAINT uniq_alert UNIQUE (event_id, structure_id, student_id, type),
+                             -- Delete column no longer used
+                             DROP COLUMN exceed_date,
+                             DROP COLUMN modified,
+                             -- Column used in trigger
+                             ADD COLUMN delete_at timestamp without time zone;
+
+ALTER TABLE presences.alert_history DROP COLUMN exceed_date,
+                                    DROP COLUMN modified,
+                                    ADD COLUMN delete_at timestamp without time zone NOT NULL;

--- a/presences/src/main/resources/sql/scriptSQLReverse/044-MA-967-count-alert-by-line-reverse.sql
+++ b/presences/src/main/resources/sql/scriptSQLReverse/044-MA-967-count-alert-by-line-reverse.sql
@@ -1,0 +1,13 @@
+-- Delete old data due to the modification of the table
+TRUNCATE TABLE presences.alerts;
+TRUNCATE TABLE presences.alert_history;
+
+ALTER TABLE presences.alerts DROP CONSTRAINT uniq_alert,
+                             ADD CONSTRAINT uniq_alert UNIQUE (structure_id, student_id, type),
+                             DROP COLUMN event_id,
+                             ADD COLUMN exceed_date timestamp without time zone,
+                             ADD COLUMN modified timestamp without time zone,
+                             DROP COLUMN delete_at;
+ALTER TABLE presences.alert_history ADD COLUMN exceed_date timestamp without time zone,
+                                    ADD COLUMN modified timestamp without time zone,
+                                    DROP COLUMN delete_at;


### PR DESCRIPTION
## Describe your changes
Party 1/3 of the ticket [MA-770](https://entsupport.gdapublic.fr/browse/MA-770)

Preparation of the "alert" and "alert_history" tables for the MA-770.
MA-770 aims to make alerts resettable by dates.

The tests are provided in the PR #140 

Doc: https://entconf.gdapublic.fr/pages/viewpage.action?pageId=96436457

The files in the "SQLReverseScript" folder is used in case of a problem in production. They must allow to restore the database to the state before the ticket. They will be deleted in the PR of the MA-770 ticket.

## Checklist tests
Nothing. Just execute this file after MA-662 complete 
https://github.com/OPEN-ENT-NG/presences/pull/140/files#diff-849bfe6ffcfd3d258ea47768804e674f38c73d03c0da7520bebbcbef54fbccd2

## Issue ticket number and link
[MA-967](https://entsupport.gdapublic.fr/browse/MA-967)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

