### PR TITLE
feat(alert): #MA-966 edit trigger/function for alert configurable

### DIFF
--- a/incidents/src/main/resources/sql/021-MA-966-function-make-alerts-configurable.sql
+++ b/incidents/src/main/resources/sql/021-MA-966-function-make-alerts-configurable.sql
@@ -1,0 +1,25 @@
+-- Return true if incident is exclude to create alert
+CREATE or replace FUNCTION incidents.incident_exclude_alert(incident incidents.incident) RETURNS BOOLEAN AS
+$BODY$
+DECLARE
+    eventExclude boolean;
+BEGIN
+    SELECT exclude_alert_seriousness FROM incidents.seriousness as s WHERE s.id = incident.seriousness_id INTO eventExclude;
+    RETURN eventExclude;
+END
+$BODY$
+    LANGUAGE plpgsql;
+
+-- Return true if incident of the protagonist is exclude to create alert
+CREATE or replace FUNCTION incidents.incident_protagonist_exclude_alert(protagonist incidents.protagonist, structureId varchar) RETURNS BOOLEAN AS
+$BODY$
+DECLARE
+    eventExclude boolean;
+BEGIN
+    SELECT exclude_alert_seriousness FROM incidents.seriousness as s INNER JOIN incidents.incident i on s.id = i.seriousness_id
+    WHERE protagonist.incident_id = i.id AND s.structure_id = structureId LIMIT 1 INTO eventExclude;
+
+    RETURN eventExclude;
+END
+$BODY$
+    LANGUAGE plpgsql;

--- a/incidents/src/main/resources/sql/022-MA-966-create-trigger-make-alerts-configurable.sql
+++ b/incidents/src/main/resources/sql/022-MA-966-create-trigger-make-alerts-configurable.sql
@@ -1,0 +1,25 @@
+-- Drop old trigger and function
+DROP TRIGGER increment_incident_alert ON incidents.protagonist;
+DROP FUNCTION incidents.increment_incident_alert();
+
+-- Because an incident may be in relationship with many protagonists, we trigger alert on protagonist insert
+CREATE FUNCTION incidents.add_incident_alert() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+    structureId character varying;
+BEGIN
+    -- Select the structure associate with the new protagonist
+    SELECT structure_id FROM incidents.incident WHERE id = NEW.incident_id INTO structureId;
+
+    IF incidents.incident_protagonist_exclude_alert(NEW, structureId) IS FALSE THEN -- If we have no exclude condition
+        -- Create alert
+        EXECUTE presences.create_alert(NEW.incident_id, 'INCIDENT', NEW.user_id, structureId);
+    END IF;
+
+    RETURN NEW;
+END
+$BODY$
+    LANGUAGE plpgsql;
+
+-- Because an incident may be in relationship with many protagonists, we trigger alert on protagonist insert
+CREATE TRIGGER add_incident_alert AFTER INSERT ON incidents.protagonist FOR EACH ROW EXECUTE PROCEDURE incidents.add_incident_alert();

--- a/incidents/src/main/resources/sql/023-MA-966-delete-trigger-make-alerts-configurable.sql
+++ b/incidents/src/main/resources/sql/023-MA-966-delete-trigger-make-alerts-configurable.sql
@@ -1,0 +1,37 @@
+-- Drop old trigger and function
+DROP TRIGGER decrement_incident_alert ON incidents.protagonist;
+DROP FUNCTION incidents.decrement_incident_alert();
+
+-- Delete alert for each protagonist of the incident if the event having one
+CREATE OR REPLACE FUNCTION incidents.delete_incident(incidentId bigint) RETURNS void AS
+$BODY$
+DECLARE
+    incident incidents.incident;
+    protagonist incidents.protagonist;
+BEGIN
+    SELECT * FROM incidents.incident WHERE id = incidentId INTO incident;
+    FOR protagonist IN SELECT * FROM incidents.protagonist WHERE incident_id = incidentId
+        -- Before deleting incident, for each protagonist
+        LOOP
+            -- Delete alert for each protagonist
+            EXECUTE presences.delete_alert(incidentId, 'INCIDENT', protagonist.user_id, incident.structure_id);
+    END LOOP;
+    DELETE FROM incidents.incident WHERE id = incidentId;
+END;
+$BODY$
+    LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION incidents.remove_incident_alert() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+    incident incidents.incident;
+BEGIN
+    SELECT * FROM incidents.incident WHERE id = OLD.incident_id LIMIT 1 INTO incident;
+    EXECUTE presences.delete_alert(OLD.incident_id, 'INCIDENT', OLD.user_id, incident.structure_id);
+    RETURN OLD;
+END;
+$BODY$
+    LANGUAGE plpgsql;
+
+CREATE TRIGGER remove_incident_alert before DELETE ON incidents.protagonist
+    FOR EACH ROW EXECUTE PROCEDURE incidents.remove_incident_alert();

--- a/incidents/src/main/resources/sql/024-MA-966-update-trigger-make-alerts-configurable.sql
+++ b/incidents/src/main/resources/sql/024-MA-966-update-trigger-make-alerts-configurable.sql
@@ -1,0 +1,29 @@
+-- Manages whether to create or delete an alert following the modification of an incident
+CREATE FUNCTION incidents.update_incident_alert() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+    newEventExclude boolean;
+    oldAlertId bigint = NULL;
+    protagonist incidents.protagonist;
+BEGIN
+    -- Check if the new event must be exclude
+    SELECT incidents.incident_exclude_alert(NEW) INTO newEventExclude;
+
+    -- For each protagonist
+    FOR protagonist IN SELECT * FROM incidents.protagonist WHERE incident_id = OLD.id
+        LOOP
+            -- Check if the old protagonist have alert
+            SELECT event_id FROM presences.alerts WHERE event_id = OLD.id AND type = 'INCIDENT' AND student_id = protagonist.user_id AND structure_id = OLD.structure_id INTO oldAlertId;
+            IF oldAlertId IS NOT NULL AND newEventExclude THEN -- If we have previously a alert and now the seriousness is exclude we must delete alert
+                EXECUTE presences.delete_alert(OLD.id, 'INCIDENT', protagonist.user_id, NEW.structure_id);
+            ELSIF oldAlertId IS NULL AND NOT newEventExclude THEN -- If we have not previously a alert and now the seriousness is not exclude we must create alert
+                EXECUTE presences.create_alert(NEW.id, 'INCIDENT', protagonist.user_id, NEW.structure_id);
+            END IF;
+    END LOOP;
+    RETURN NEW;
+END
+$BODY$
+    LANGUAGE plpgsql;
+
+CREATE TRIGGER update_incident_alert BEFORE UPDATE OF seriousness_id ON incidents.incident
+    FOR EACH ROW EXECUTE PROCEDURE incidents.update_incident_alert();

--- a/presences/src/main/resources/sql/047-MA-966-function-make-alerts-configurable.sql
+++ b/presences/src/main/resources/sql/047-MA-966-function-make-alerts-configurable.sql
@@ -1,0 +1,125 @@
+-- Return true if absence event is exclude to create alert
+CREATE OR REPLACE FUNCTION presences.absence_exclude_alert(event presences.event, structureId varchar) RETURNS BOOLEAN AS
+$BODY$
+DECLARE
+    alertRulesTypeId bigint;
+    noReasonAbsenceExclude boolean;
+BEGIN
+    SELECT reason_alert_exclude_rules_type_id FROM presences.reason_alert WHERE structure_id = structureId
+                                                          AND reason_id = event.reason_id
+                                                          AND deleted_at IS NULL
+                                                          AND ((event.counsellor_regularisation AND reason_alert_exclude_rules_type_id = 1)
+                                                                   OR (NOT event.counsellor_regularisation AND reason_alert_exclude_rules_type_id = 2))
+                                                        LIMIT 1 INTO alertRulesTypeId;
+    SELECT exclude_alert_absence_no_reason FROM presences.settings WHERE structure_id = structureId INTO noReasonAbsenceExclude;
+
+    RETURN ((event.reason_id IS NULL AND noReasonAbsenceExclude) OR
+            (alertRulesTypeId IS NOT NULL AND event.reason_id IS NOT NULL));
+END
+$BODY$
+    LANGUAGE plpgsql;
+
+-- Return true if lateness event is exclude to create alert
+CREATE or replace FUNCTION presences.lateness_exclude_alert(event presences.event, structureId varchar) RETURNS BOOLEAN AS
+$BODY$
+DECLARE
+    alertRulesTypeId bigint;
+    noReasonLatenessExclude boolean;
+BEGIN
+    SELECT reason_alert_exclude_rules_type_id FROM presences.reason_alert WHERE structure_id = structureId
+                                                                            AND reason_id = event.reason_id
+                                                                            AND deleted_at IS NULL
+                                                                            AND reason_alert_exclude_rules_type_id = 3 LIMIT 1 INTO alertRulesTypeId;
+    SELECT exclude_alert_lateness_no_reason FROM presences.settings WHERE structure_id = structureId INTO noReasonLatenessExclude;
+
+    RETURN (alertRulesTypeId IS NOT NULL AND event.reason_id IS NOT NULL) OR (event.reason_id IS NULL AND noReasonLatenessExclude);
+END
+$BODY$
+    LANGUAGE plpgsql;
+
+-- Return true if notebook is exclude to create alert
+CREATE or replace FUNCTION presences.notebook_exclude_alert(structure_identifier varchar) RETURNS BOOLEAN AS
+$BODY$
+DECLARE
+    eventExclude boolean;
+BEGIN
+    SELECT exclude_alert_forgotten_notebook FROM presences.settings WHERE structure_id = structure_identifier INTO eventExclude; -- Check if we exclude forgotten notebook
+
+    RETURN eventExclude;
+END
+$BODY$
+    LANGUAGE plpgsql;
+
+DROP FUNCTION presences.get_id_absence_event_siblings_in_same_day(presences.event, time, time, boolean);
+-- Return the id of the absence event siblings of the event in params, included in the provided time.
+-- If no event is found then we return null.
+-- absenceEvent     The event with absence type of which we must find the siblings
+-- startTime        Siblings must be after start time
+-- endTime          Siblings must be before end time
+-- structureId      Structure id of the absenceEvent
+-- needAlert        If true, the siblings must be have an associated alert. If false, the siblings must be have no associated alert.
+CREATE FUNCTION presences.get_id_absence_event_siblings_in_same_day(absenceEvent presences.event, startTime time, endTime time, structureId varchar, needAlert boolean) RETURNS bigint AS
+$BODY$
+DECLARE
+    eventId bigint;
+    noReasonAbsenceExclude boolean;
+BEGIN
+    SELECT exclude_alert_absence_no_reason FROM presences.settings WHERE structure_id = structureId INTO noReasonAbsenceExclude;
+    SELECT event.id
+    FROM presences.event
+             INNER JOIN presences.register ON (register.id = event.register_id)
+             LEFT JOIN presences.alerts as a ON (a.event_id = event.id)
+    WHERE event.start_date::date = absenceEvent.start_date::date
+      AND event.start_date::time >= startTime
+      AND event.start_date::time <= endTime
+      AND event.student_id = absenceEvent.student_id
+      AND type_id = 1
+      -- Check if event is exclude
+      AND ((event.reason_id IS NULL AND NOT noReasonAbsenceExclude) OR
+          (event.reason_id IS NOT NULL AND NOT exists(
+               SELECT * FROM presences.reason_alert as r WHERE r.structure_id = structureId
+                                                       AND r.reason_id = event.reason_id
+                                                       AND deleted_at IS NULL
+                                                       AND ((event.counsellor_regularisation AND r.reason_alert_exclude_rules_type_id = 1) OR (event.counsellor_regularisation AND r.reason_alert_exclude_rules_type_id = 2))
+               )))
+      AND event.id != absenceEvent.id
+      AND ((needAlert AND a.event_id IS NOT NULL) OR (NOT needAlert AND a.event_id IS NULL))
+    LIMIT 1 -- Only take one
+    INTO eventId;
+    RETURN eventId;
+END
+$BODY$
+    LANGUAGE plpgsql;
+
+-- Return the id of the absence event siblings of the event in params.
+-- If no event is found then we return null.
+-- absenceEvent     The event with absence type of which we must find the siblings
+-- structureId      The structure of the event
+-- needAlert        If true, the siblings must be have an associated alert. If false, the siblings must be have no associated alert.
+CREATE or replace FUNCTION presences.get_id_absence_event_siblings(event presences.event, structureId varchar, needAlert boolean) RETURNS bigint AS
+$BODY$
+DECLARE
+    recoveryMethod character varying;
+    absenceOtherId bigint = NULL;
+    endOfHalfDay time without time zone;
+BEGIN
+    SELECT event_recovery_method FROM presences.settings WHERE structure_id = structureId INTO recoveryMethod; -- Get recovery method
+    CASE recoveryMethod
+        WHEN 'HALF_DAY' THEN
+            -- First retrieve half day hour
+            SELECT time_slots.end_of_half_day FROM viesco.time_slots WHERE id_structure = structureId INTO endOfHalfDay;
+            if event.start_date::time < endOfHalfDay THEN -- If we are in morning
+                SELECT presences.get_id_absence_event_siblings_in_same_day(event, '00:00:00'::time, endOfHalfDay, structureId, needAlert) INTO absenceOtherId;
+            ELSE -- If we are afternoon
+                SELECT presences.get_id_absence_event_siblings_in_same_day(event, endOfHalfDay,'23:59:59'::time, structureId, needAlert) INTO absenceOtherId;
+            END IF;
+        WHEN 'DAY' THEN
+            -- Check if student already have absence for the day based on provided structure identifier
+            SELECT presences.get_id_absence_event_siblings_in_same_day(event, '00:00:00'::time, '23:59:59'::time, structureId, needAlert) INTO absenceOtherId;
+        -- 'HOUR' is a classic case. No other absence can be on the same date.
+        ELSE
+        END CASE;
+    RETURN absenceOtherId;
+END;
+$BODY$
+    LANGUAGE plpgsql;

--- a/presences/src/main/resources/sql/048-MA-966-create-trigger-make-alerts-configurable.sql
+++ b/presences/src/main/resources/sql/048-MA-966-create-trigger-make-alerts-configurable.sql
@@ -1,0 +1,83 @@
+-- Drop old function
+DROP FUNCTION presences.create_alert(varchar, varchar, varchar);
+-- Create a new function that create an alert for given student.
+CREATE OR REPLACE FUNCTION presences.create_alert(eventId bigint, alertType varchar, studentId varchar, structureId varchar) RETURNS void AS
+$BODY$
+DECLARE
+    alertExist boolean;
+BEGIN
+    -- Check if we have already a alert
+    SELECT exists(SELECT * FROM presences.alerts
+                           WHERE event_id = eventId AND type = alertType AND student_id = studentId AND structure_id = structureId)
+    INTO alertExist;
+
+    -- If not we create one
+    IF alertExist IS FALSE THEN
+        INSERT INTO presences.alerts(event_id, type, student_id, structure_id) VALUES (eventId, alertType, studentId, structureId);
+    END IF;
+    RETURN;
+END;
+$BODY$
+    LANGUAGE plpgsql;
+
+-- Drop old trigger and function
+DROP TRIGGER increment_event_alert_after_unjustifying ON presences.event;
+DROP TRIGGER increment_event_alert ON presences.event;
+DROP FUNCTION presences.increment_event_alert();
+
+-- Use for each insert in presences.event
+CREATE or replace FUNCTION presences.add_event_alert() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+    structureId character varying;
+    existingAbsenceWithAlert bigint = NULL;
+BEGIN
+    -- Select the structure associate with the new event
+    SELECT structure_id FROM presences.register WHERE id = NEW.register_id INTO structureId;
+    CASE NEW.type_id
+        WHEN 1 THEN -- Absence creation
+            SELECT presences.get_id_absence_event_siblings(NEW, structureId, true) INTO existingAbsenceWithAlert;
+            -- If we don't have have other absence with alert and the event is not exclude
+            IF existingAbsenceWithAlert IS NULL AND NOT presences.absence_exclude_alert(NEW, structureId) THEN
+                -- Create alert
+                EXECUTE presences.create_alert(NEW.id, 'ABSENCE', NEW.student_id, structureId);
+            END IF;
+        WHEN 2 THEN -- Lateness creation
+            IF NOT presences.lateness_exclude_alert(NEW, structureId) THEN -- If we have no exclude condition
+                -- Create alert
+                EXECUTE presences.create_alert(NEW.id, 'LATENESS', NEW.student_id, structureId);
+            END IF;
+        END CASE;
+    RETURN NEW;
+END
+$BODY$
+    LANGUAGE plpgsql;
+
+-- For each creation of a event we need to create a alert
+CREATE TRIGGER add_event_alert BEFORE INSERT ON presences.event
+    FOR EACH ROW EXECUTE PROCEDURE presences.add_event_alert();
+
+-- Drop old trigger and function
+DROP TRIGGER increment_notebook_alert ON presences.forgotten_notebook;
+DROP FUNCTION presences.increment_notebook_alert();
+
+CREATE FUNCTION presences.add_notebook_alert() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+    structureId character varying;
+BEGIN
+    -- Select the structure associate with the new event
+    SELECT structure_id FROM presences.forgotten_notebook WHERE id = NEW.id INTO structureId;
+
+    IF presences.notebook_exclude_alert(structureId) IS FALSE THEN -- If we have no exclude condition
+        -- Create alert
+        EXECUTE presences.create_alert(NEW.id, 'FORGOTTEN_NOTEBOOK', NEW.student_id, structureId);
+    END IF;
+    RETURN NEW;
+END
+$BODY$
+    LANGUAGE plpgsql;
+
+-- For each creation of a forgotten notebook we need to create a alert
+CREATE TRIGGER add_notebook_alert AFTER INSERT ON presences.forgotten_notebook
+    FOR EACH ROW EXECUTE PROCEDURE presences.add_notebook_alert();

--- a/presences/src/main/resources/sql/049-MA-966-delete-trigger-make-alerts-configurable.sql
+++ b/presences/src/main/resources/sql/049-MA-966-delete-trigger-make-alerts-configurable.sql
@@ -1,0 +1,69 @@
+CREATE FUNCTION presences.delete_alert(eventId bigint, alertType varchar, studentId varchar, structureId varchar) RETURNS void AS
+$BODY$
+BEGIN
+    DELETE FROM presences.alerts WHERE event_id = eventId AND type = alertType AND student_id = studentId AND structure_id = structureId;
+    RETURN;
+END;
+$BODY$
+    LANGUAGE plpgsql;
+
+-- Drop old trigger and function
+DROP TRIGGER decrement_event_alert ON presences.event;
+DROP TRIGGER decrement_event_alert_after_justifying ON presences.event;
+DROP FUNCTION presences.decrement_event_alert();
+
+-- Delete alert if the event having one
+CREATE FUNCTION presences.remove_event_alert() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+    structureId character varying;
+    eventIdNeedAlert bigint;
+BEGIN
+    CASE OLD.type_id
+        WHEN 1 THEN -- Absence creation
+            -- Retrieve event structure identifier based on new event register identifier
+            SELECT structure_id FROM presences.register WHERE id = OLD.register_id INTO structureId;
+
+            SELECT presences.get_id_absence_event_siblings(OLD, structureId, false) INTO eventIdNeedAlert;
+            EXECUTE presences.delete_alert(OLD.id, 'ABSENCE', OLD.student_id, structureId);
+            IF eventIdNeedAlert IS NOT NULL THEN -- If we have other absence in the same time with no alert, we need a alert for this absence
+                EXECUTE presences.create_alert(eventIdNeedAlert, 'ABSENCE', OLD.student_id, structureId);
+            END IF;
+        WHEN 2 THEN -- Lateness creation
+            EXECUTE presences.delete_alert(OLD.id, 'LATENESS', OLD.student_id, structureId);
+        END CASE;
+        RETURN OLD;
+    END
+    $BODY$
+    LANGUAGE plpgsql;
+-- For each delete we need to delete associated alert
+CREATE TRIGGER remove_event_alert AFTER DELETE ON presences.event
+    FOR EACH ROW EXECUTE PROCEDURE presences.remove_event_alert();
+
+-- Delete old trigger and function
+DROP TRIGGER decrement_notebook_alert ON presences.forgotten_notebook;
+DROP FUNCTION presences.decrement_notebook_alert();
+-- Delete alert if the forgotten notebook having one
+CREATE FUNCTION presences.remove_notebook_alert() RETURNS TRIGGER AS
+$BODY$
+BEGIN
+    EXECUTE presences.delete_alert(OLD.id, 'FORGOTTEN_NOTEBOOK', OLD.student_id, OLD.structure_id);
+    RETURN OLD;
+END
+$BODY$
+    LANGUAGE plpgsql;
+-- For each delete we need to delete associated alert
+CREATE TRIGGER remove_notebook_alert AFTER DELETE ON presences.forgotten_notebook
+    FOR EACH ROW EXECUTE PROCEDURE presences.remove_notebook_alert();
+
+-- We need to delete associate reason_alert before deleting reason because of primary key
+CREATE FUNCTION presences.remove_associate_reason_alert() RETURNS TRIGGER AS
+$BODY$
+BEGIN
+    DELETE FROM presences.reason_alert WHERE structure_id = OLD.structure_id AND reason_id = OLD.id;
+    RETURN OLD;
+END
+$BODY$
+    LANGUAGE plpgsql;
+CREATE TRIGGER remove_associate_reason_alert_before_delete_reason BEFORE DELETE ON presences.reason
+    FOR EACH ROW EXECUTE PROCEDURE presences.remove_associate_reason_alert();

--- a/presences/src/main/resources/sql/050-MA-966-update-trigger-make-alerts-configurable.sql
+++ b/presences/src/main/resources/sql/050-MA-966-update-trigger-make-alerts-configurable.sql
@@ -1,0 +1,67 @@
+-- Manages whether to create or delete an alert following the modification of an absence event
+CREATE OR REPLACE FUNCTION presences.update_absence_alert() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+    isNewEventExclude boolean;
+    structureId character varying;
+    oldAlertID bigint;
+    eventIdToReplace bigint;
+BEGIN
+    -- Select the structure associate with the new event
+    SELECT structure_id FROM presences.register WHERE id = NEW.register_id LIMIT 1 INTO structureId;
+
+    -- Check if the new event must be exclude
+    SELECT presences.absence_exclude_alert(NEW, structureId) INTO isNewEventExclude;
+    -- Check if the old data have alert
+    SELECT event_id FROM presences.alerts WHERE event_id = OLD.id AND type = 'ABSENCE' AND student_id = OLD.student_id AND structure_id = structureId INTO oldAlertID;
+
+    IF oldAlertID IS NOT NULL AND isNewEventExclude THEN -- If we have previously a alert and now the event is exclude we must delete alert
+        SELECT presences.get_id_absence_event_siblings(OLD, structureId, false) INTO eventIdToReplace;
+        EXECUTE presences.delete_alert(OLD.id, 'ABSENCE', OLD.student_id, structureId);
+        IF eventIdToReplace IS NOT NULL THEN -- If we have a no other absence in the same time with no alert, we need to create a alert for other absence
+            EXECUTE presences.create_alert(eventIdToReplace, 'ABSENCE', NEW.student_id, structureId);
+        END IF;
+    ELSIF oldAlertID IS NULL AND NOT isNewEventExclude THEN -- If we have not previously a alert and now the event is not exclude we must create alert
+        SELECT presences.get_id_absence_event_siblings(OLD, structureId, true) INTO eventIdToReplace;
+        IF eventIdToReplace IS NULL THEN -- If we have a other absence in the same time with alert, we DONT need create a alert
+            EXECUTE presences.create_alert(NEW.id, 'ABSENCE', NEW.student_id, structureId);
+        END IF;
+    END IF;
+    RETURN NEW;
+END
+$BODY$
+    LANGUAGE plpgsql;
+-- For each update we need to update associated alert
+CREATE TRIGGER update_absence_alert BEFORE UPDATE OF reason_id, start_date, end_date, counsellor_regularisation ON presences.event
+    FOR EACH ROW WHEN (NEW.type_id = 1) EXECUTE PROCEDURE presences.update_absence_alert();
+
+-- Manages whether to create or delete an alert following the modification of an lateness event
+CREATE FUNCTION presences.update_lateness_alert() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+    newEventExclude boolean;
+    structureId character varying;
+    oldAlertId bigint;
+BEGIN
+    -- Select the structure associate with the new event
+    SELECT structure_id FROM presences.register WHERE id = NEW.register_id LIMIT 1 INTO structureId;
+
+    -- Check if the new event must be exclude
+    SELECT presences.lateness_exclude_alert(NEW, structureId) INTO newEventExclude;
+    -- Check if the old data have alert
+    SELECT event_id FROM presences.alerts WHERE event_id = OLD.id AND type = 'LATENESS' AND student_id = OLD.student_id AND structure_id = structureId INTO oldAlertId;
+
+
+    IF oldAlertId IS NOT NULL AND newEventExclude THEN -- If we have previously a alert and now the event is exclude we must delete alert
+        EXECUTE presences.delete_alert(OLD.id, 'LATENESS', OLD.student_id, structureId);
+    ELSIF oldAlertId IS NULL AND NOT newEventExclude THEN  -- If we have not previously a alert and now the event is not exclude we must create alert
+        EXECUTE presences.create_alert(NEW.id, 'LATENESS', NEW.student_id, structureId);
+    END IF;
+    RETURN NEW;
+END
+$BODY$
+    LANGUAGE plpgsql;
+
+-- For each update we need to update associated alert
+CREATE TRIGGER update_lateness_alert BEFORE UPDATE OF reason_id ON presences.event
+    FOR EACH ROW WHEN (NEW.type_id = 2) EXECUTE PROCEDURE presences.update_lateness_alert();

--- a/presences/src/main/resources/sql/scriptSQLReverse/047-MA-966-function-make-alerts-configurable-reverse.sql
+++ b/presences/src/main/resources/sql/scriptSQLReverse/047-MA-966-function-make-alerts-configurable-reverse.sql
@@ -1,0 +1,69 @@
+DROP FUNCTION presences.absence_exclude_alert(presences.event, varchar);
+DROP FUNCTION presences.lateness_exclude_alert(presences.event, varchar);
+DROP FUNCTION incidents.incident_exclude_alert(incidents.incident);
+DROP FUNCTION incidents.incident_protagonist_exclude_alert(incidents.protagonist, varchar);
+DROP FUNCTION presences.notebook_exclude_alert(varchar);
+
+DROP FUNCTION presences.get_id_absence_event_siblings_in_same_day(presences.event, time, time, varchar, boolean);
+-- Return the id of the absence event siblings of the event in params, included in the provided time.
+-- If no event is found then we return null.
+-- absenceEvent     The event with absence type of which we must find the siblings
+-- startTime        Siblings must be after start time
+-- endTime          Siblings must be before end time
+-- needAlert        If true, the siblings must be have an associated alert. If false, the siblings must be have no associated alert.
+CREATE FUNCTION presences.get_id_absence_event_siblings_in_same_day(absenceEvent presences.event, startTime time, endTime time, needAlert boolean) RETURNS bigint AS
+$BODY$
+DECLARE
+    eventId bigint;
+BEGIN
+    SELECT event.id
+    FROM presences.event
+             INNER JOIN presences.register ON (register.id = event.register_id)
+             LEFT JOIN presences.alerts as alert ON (alert.event_id = event.id)
+    WHERE event.start_date::date = absenceEvent.start_date::date
+      AND event.start_date::time >= startTime
+      AND event.start_date::time <= endTime
+      AND event.student_id = absenceEvent.student_id
+      AND type_id = 1
+      AND event.id != absenceEvent.id
+      AND ((needAlert AND alert.event_id IS NOT NULL) OR (NOT needAlert AND alert.event_id IS NULL))
+    LIMIT 1 -- Only take one
+    INTO eventId;
+
+    RETURN eventId;
+END;
+$BODY$
+    LANGUAGE plpgsql;
+
+-- Return the id of the absence event siblings of the event in params.
+-- If no event is found then we return null.
+-- absenceEvent     The event with absence type of which we must find the siblings
+-- structureId      The structure of the event
+-- needAlert        If true, the siblings must be have an associated alert. If false, the siblings must be have no associated alert.
+CREATE or replace FUNCTION presences.get_id_absence_event_siblings(event presences.event, structureId varchar, needAlert boolean) RETURNS bigint AS
+$BODY$
+DECLARE
+    recoveryMethod character varying;
+    absenceOtherId bigint = NULL;
+    endOfHalfDay time without time zone;
+BEGIN
+    SELECT event_recovery_method FROM presences.settings WHERE structure_id = structureId INTO recoveryMethod; -- Get recovery method
+    CASE recoveryMethod
+        WHEN 'HALF_DAY' THEN
+            -- First retrieve half day hour
+            SELECT time_slots.end_of_half_day FROM viesco.time_slots WHERE id_structure = structureId INTO endOfHalfDay;
+            if event.start_date::time < endOfHalfDay THEN -- If we are in morning
+                SELECT presences.get_id_absence_event_siblings_in_same_day(event, '00:00:00'::time, endOfHalfDay, needAlert) INTO absenceOtherId;
+            ELSE -- If we are afternoon
+                SELECT presences.get_id_absence_event_siblings_in_same_day(event, endOfHalfDay,'23:59:59'::time, needAlert) INTO absenceOtherId;
+            END IF;
+        WHEN 'DAY' THEN
+            -- Check if student already have absence for the day based on provided structure identifier
+            SELECT presences.get_id_absence_event_siblings_in_same_day(event, '00:00:00'::time, '23:59:59'::time, needAlert) INTO absenceOtherId;
+        -- 'HOUR' is a classic case. No other absence can be on the same date.
+        ELSE
+        END CASE;
+    RETURN absenceOtherId;
+END;
+$BODY$
+    LANGUAGE plpgsql;

--- a/presences/src/main/resources/sql/scriptSQLReverse/048-MA-966-create-trigger-make-alerts-configurable-reverse.sql
+++ b/presences/src/main/resources/sql/scriptSQLReverse/048-MA-966-create-trigger-make-alerts-configurable-reverse.sql
@@ -1,0 +1,130 @@
+DROP FUNCTION presences.create_alert(bigint, varchar, varchar, varchar);
+-- Create a new function that initialize an alert for given student.
+CREATE OR REPLACE FUNCTION presences.create_alert(studentId varchar, structureId varchar, alertType varchar) RETURNS void AS
+$BODY$
+DECLARE
+    studentExist boolean;
+BEGIN
+    -- Check if student alert exists
+    SELECT exists(SELECT * FROM presences.alerts WHERE student_id = studentId AND structure_id = structureId AND type = alertType) INTO studentExist;
+
+    -- IF student alert does not exists, creates one.
+    IF studentExist IS FALSE THEN
+        INSERT INTO presences.alerts (student_id, structure_id, type) VALUES (studentId, structureId, alertType);
+    END IF;
+    RETURN;
+END;
+$BODY$
+    LANGUAGE plpgsql;
+
+DROP TRIGGER add_event_alert ON presences.event;
+DROP FUNCTION presences.add_event_alert();
+CREATE FUNCTION presences.increment_event_alert() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+    structure_identifier character varying;
+    recovery_method character varying;
+    should_increment boolean;
+    end_of_half_day time without time zone;
+BEGIN
+    -- Retrieve event structure identifier based on new event register identifier
+    SELECT structure_id FROM presences.register WHERE id = NEW.register_id INTO structure_identifier;
+
+    CASE NEW.type_id
+        WHEN 1 THEN -- Absence creation
+        -- Check if alert exists. If it does not exists, it creates the alert based on provided student, structure and type information
+            IF NEW.reason_id IS NULL THEN
+                EXECUTE presences.create_alert(NEW.student_id, structure_identifier, 'ABSENCE');
+
+                SELECT event_recovery_method FROM presences.settings WHERE structure_id = structure_identifier INTO recovery_method;
+
+                CASE recovery_method
+                    WHEN 'HALF_DAY' THEN
+                        -- First retrieve half day hour
+                        SELECT time_slots.end_of_half_day FROM viesco.time_slots WHERE id_structure = structure_identifier INTO end_of_half_day;
+                        if NEW.start_date::time < end_of_half_day THEN
+                            SELECT NOT presences.exists_absence_in_half_day(NEW.start_date::date, '00:00:00'::time, end_of_half_day, NEW.student_id, structure_identifier) INTO should_increment;
+                        ELSE
+                            SELECT NOT presences.exists_absence_in_half_day(NEW.start_date::date, end_of_half_day,'23:59:59'::time, NEW.student_id, structure_identifier) INTO should_increment;
+                        END IF;
+                    WHEN 'DAY' THEN
+                        -- Check if student already have absence for the day based on provided structure identifier
+                        SELECT NOT presences.exists_absence_in_day(NEW.start_date::date, NEW.student_id, structure_identifier) INTO should_increment;
+                    ELSE
+                        -- 'HOUR' is a classic case. Just increment count.
+                        should_increment = true;
+                    END CASE;
+            ELSE
+                should_increment = false;
+            END IF;
+
+            IF should_increment THEN
+                UPDATE presences.alerts SET count = (count + 1)
+                WHERE student_id = NEW.student_id AND structure_id = structure_identifier AND type = 'ABSENCE';
+            END IF;
+        WHEN 2 THEN -- Lateness creation
+        -- Check if alert exists. If it does not exists, it creates the alert based on provided student, structure and type information
+            EXECUTE presences.create_alert(NEW.student_id, structure_identifier, 'LATENESS');
+
+            -- Increment event alert number
+            UPDATE presences.alerts SET count = (count + 1)
+            WHERE student_id = NEW.student_id AND structure_id = structure_identifier AND type = 'LATENESS';
+        ELSE
+            RETURN NEW;
+        END CASE;
+    RETURN NEW;
+END
+$BODY$
+    LANGUAGE plpgsql;
+CREATE TRIGGER increment_event_alert_after_unjustifying BEFORE UPDATE OF reason_id ON presences.event
+    FOR EACH ROW WHEN (NEW.reason_id IS NULL) EXECUTE PROCEDURE presences.increment_event_alert();
+
+CREATE TRIGGER increment_event_alert BEFORE INSERT ON presences.event
+    FOR EACH ROW EXECUTE PROCEDURE presences.increment_event_alert();
+
+
+
+
+DROP TRIGGER add_incident_alert ON incidents.protagonist;
+DROP FUNCTION incidents.add_incident_alert();
+CREATE FUNCTION incidents.increment_incident_alert() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+    structureId character varying;
+BEGIN
+    -- Retrieve structure identifier based on incident identifier
+    SELECT structure_id FROM incidents.incident WHERE id = NEW.incident_id INTO structureId;
+
+    -- Check if alert exists. If it does not exists, it creates the alert based on provided student, structure and type information
+    EXECUTE presences.create_alert(NEW.user_id, structureId, 'INCIDENT');
+
+    -- Increment student incident alert
+    UPDATE presences.alerts SET count = (count + 1)
+    WHERE student_id = NEW.user_id AND structure_id = structureId AND type = 'INCIDENT';
+
+    RETURN NEW;
+END
+$BODY$
+    LANGUAGE plpgsql;
+CREATE TRIGGER increment_incident_alert AFTER INSERT ON incidents.protagonist FOR EACH ROW EXECUTE PROCEDURE incidents.increment_incident_alert();
+
+
+
+
+DROP TRIGGER add_notebook_alert ON presences.forgotten_notebook;
+DROP FUNCTION presences.add_notebook_alert();
+CREATE FUNCTION presences.increment_notebook_alert() RETURNS TRIGGER AS
+$BODY$
+BEGIN
+    -- Check if alert exists. If it does not exists, it creates the alert based on provided student, structure and type information
+    EXECUTE presences.create_alert(NEW.student_id, NEW.structure_id, 'FORGOTTEN_NOTEBOOK');
+
+    -- Increment student forgotten_notebook alert
+    UPDATE presences.alerts SET count = (count + 1)
+    WHERE student_id = NEW.student_id AND structure_id = NEW.structure_id AND type = 'FORGOTTEN_NOTEBOOK';
+
+    RETURN NEW;
+END
+$BODY$
+    LANGUAGE plpgsql;
+CREATE TRIGGER increment_notebook_alert AFTER INSERT ON presences.forgotten_notebook FOR EACH ROW EXECUTE PROCEDURE presences.increment_notebook_alert();

--- a/presences/src/main/resources/sql/scriptSQLReverse/049-MA-966-delete-trigger-make-alerts-configurable-reverse.sql
+++ b/presences/src/main/resources/sql/scriptSQLReverse/049-MA-966-delete-trigger-make-alerts-configurable-reverse.sql
@@ -1,0 +1,155 @@
+DROP FUNCTION presences.delete_alert(bigint, varchar, varchar, varchar);
+
+DROP TRIGGER remove_associate_reason_alert_before_delete_reason ON presences.reason;
+DROP FUNCTION presences.remove_associate_reason_alert();
+
+DROP TRIGGER remove_event_alert ON presences.event;
+DROP FUNCTION presences.remove_event_alert();
+CREATE FUNCTION presences.decrement_event_alert() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+    structure_identifier character varying;
+    recovery_method character varying;
+    should_decrement boolean;
+    end_of_half_day time without time zone;
+    count_alert bigint;
+BEGIN
+    -- Retrieve event structure identifier based on new event register identifier
+    SELECT structure_id FROM presences.register WHERE id = OLD.register_id INTO structure_identifier;
+
+    CASE OLD.type_id
+        WHEN 1 THEN -- Absence creation
+        -- Check if alert exists. If it does not exists, it creates the alert based on provided student, structure and type information
+            EXECUTE presences.create_alert(OLD.student_id, structure_identifier, 'ABSENCE');
+
+            SELECT event_recovery_method FROM presences.settings WHERE structure_id = structure_identifier INTO recovery_method;
+
+            CASE recovery_method
+                WHEN 'HALF_DAY' THEN
+                    -- First retrieve half day hour
+                    SELECT time_slots.end_of_half_day FROM viesco.time_slots WHERE id_structure = structure_identifier INTO end_of_half_day;
+                    if OLD.start_date::time < end_of_half_day THEN
+                        SELECT NOT presences.exists_absence_in_half_day(OLD.start_date::date, '00:00:00'::time, end_of_half_day, OLD.student_id, structure_identifier) INTO should_decrement;
+                    ELSE
+                        SELECT NOT presences.exists_absence_in_half_day(OLD.start_date::date, end_of_half_day,'23:59:59'::time, OLD.student_id, structure_identifier) INTO should_decrement;
+                    END IF;
+                WHEN 'DAY' THEN
+                    -- Check if student already have absence for the day based on provided structure identifier
+                    SELECT NOT presences.exists_absence_in_day(OLD.start_date::date, OLD.student_id, structure_identifier) INTO should_decrement;
+                ELSE
+                    -- 'HOUR' is a classic case. Just increment count.
+                    should_decrement = true;
+                END CASE;
+
+            IF should_decrement THEN
+                SELECT count FROM presences.alerts WHERE student_id = OLD.student_id AND structure_id = structure_identifier AND type = 'ABSENCE' INTO count_alert;
+
+                IF count_alert > 0 THEN
+                    UPDATE presences.alerts SET count = (count - 1)
+                    WHERE student_id = OLD.student_id AND structure_id = structure_identifier AND type = 'ABSENCE';
+                END IF;
+            END IF;
+        WHEN 2 THEN -- Lateness creation
+        -- Check if alert exists. If it does not exists, it creates the alert based on provided student, structure and type information
+            EXECUTE presences.create_alert(OLD.student_id, structure_identifier, 'LATENESS');
+
+            SELECT count FROM presences.alerts WHERE student_id = OLD.student_id AND structure_id = structure_identifier AND type = 'LATENESS' INTO count_alert;
+            IF count_alert > 0 THEN
+                UPDATE presences.alerts SET count = (count - 1)
+                WHERE student_id = OLD.student_id AND structure_id = structure_identifier AND type = 'LATENESS';
+            END IF;
+        ELSE
+            RETURN OLD;
+        END CASE;
+    RETURN OLD;
+END
+$BODY$
+    LANGUAGE plpgsql;
+
+DROP TRIGGER remove_incident_alert ON incidents.protagonist;
+DROP FUNCTION incidents.remove_incident_alert();
+CREATE TRIGGER decrement_event_alert_after_justifying AFTER UPDATE OF reason_id ON presences.event
+    FOR EACH ROW WHEN (NEW.reason_id IS NOT NULL) EXECUTE PROCEDURE presences.decrement_event_alert();
+CREATE TRIGGER decrement_event_alert AFTER DELETE ON presences.event
+    FOR EACH ROW EXECUTE PROCEDURE presences.decrement_event_alert();
+
+-- Create a new function that manage alert and delete incident. To delete an incident, use the function as: SELECT incidents.delete_incident(42);
+CREATE OR REPLACE FUNCTION incidents.delete_incident(incidentId bigint) RETURNS void AS
+$BODY$
+DECLARE
+    countAlert bigint;
+    incident incidents.incident%rowtype;
+    protagonist incidents.protagonist%rowtype;
+BEGIN
+    SELECT * FROM incidents.incident WHERE id = incidentId INTO incident;
+    FOR protagonist IN SELECT * FROM incidents.protagonist WHERE incident_id = incidentId
+        -- Before deleting incident, for each protagonist
+        LOOP
+            -- Check if alert exists. If it does not exists, it creates the alert based on provided student, structure and type information
+            EXECUTE presences.create_alert(protagonist.user_id, incident.structure_id, 'INCIDENT');
+
+            -- Get alert count. We need it because we need to check if it is > 0
+            SELECT count FROM presences.alerts WHERE student_id = protagonist.user_id AND structure_id = incident.structure_id AND type = 'INCIDENT' INTO countAlert;
+
+            -- If count > 0 then update student alert for current type
+            IF countAlert  > 0 THEN
+                UPDATE presences.alerts SET count = (count - 1)
+                WHERE student_id = protagonist.user_id AND structure_id = incident.structure_id AND type = 'INCIDENT';
+            END IF;
+        END LOOP;
+
+    DELETE FROM incidents.incident WHERE id = incidentId;
+END;
+$BODY$
+    LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION incidents.decrement_incident_alert() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+    structureId character varying;
+BEGIN
+    -- Retrieve structure identifier based on incident identifier
+    SELECT structure_id FROM incidents.incident WHERE id = OLD.incident_id INTO structureId;
+
+    -- Check if alert exists. If it does not exists, it creates the alert based on provided student, structure and type information
+    EXECUTE presences.create_alert(OLD.user_id, structureId, 'INCIDENT');
+
+    -- Decrement student incident alert
+    UPDATE presences.alerts SET count = (count - 1)
+    WHERE student_id = OLD.user_id AND structure_id = structureId AND type = 'INCIDENT';
+
+    RETURN OLD;
+END
+$BODY$
+    LANGUAGE plpgsql;
+
+CREATE TRIGGER decrement_incident_alert AFTER DELETE ON incidents.protagonist
+    FOR EACH ROW EXECUTE PROCEDURE incidents.decrement_incident_alert();
+
+
+
+
+
+DROP TRIGGER remove_notebook_alert ON presences.forgotten_notebook;
+DROP FUNCTION presences.remove_notebook_alert();
+CREATE FUNCTION presences.decrement_notebook_alert() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+    countAlert bigint;
+BEGIN
+    -- Check if alert exists. If it does not exists, it creates the alert based on provided student, structure and type information
+    EXECUTE presences.create_alert(OLD.student_id, OLD.structure_id, 'FORGOTTEN_NOTEBOOK');
+
+    -- Get alert count. We need it because we need to check if it is > 0
+    SELECT count FROM presences.alerts WHERE student_id = OLD.student_id AND structure_id = OLD.structure_id AND type = 'FORGOTTEN_NOTEBOOK' INTO countAlert ;
+
+    -- If count > 0 then update student alert for current type
+    IF countAlert > 0 THEN
+        UPDATE presences.alerts SET count = (count - 1)
+        WHERE student_id = OLD.student_id AND structure_id = OLD.structure_id AND type = 'FORGOTTEN_NOTEBOOK';
+    END IF;
+    RETURN OLD;
+END
+$BODY$
+    LANGUAGE plpgsql;
+CREATE TRIGGER decrement_notebook_alert AFTER DELETE ON presences.forgotten_notebook FOR EACH ROW EXECUTE PROCEDURE presences.decrement_notebook_alert();

--- a/presences/src/main/resources/sql/scriptSQLReverse/050-MA-966-update-trigger-make-alerts-configurable-reverse.sql
+++ b/presences/src/main/resources/sql/scriptSQLReverse/050-MA-966-update-trigger-make-alerts-configurable-reverse.sql
@@ -1,0 +1,8 @@
+DROP TRIGGER update_absence_alert ON presences.event;
+DROP FUNCTION presences.update_absence_alert();
+
+DROP TRIGGER update_lateness_alert ON presences.event;
+DROP FUNCTION presences.update_lateness_alert();
+
+DROP TRIGGER update_incident_alert ON incidents.incident;
+DROP FUNCTION incidents.update_incident_alert();

--- a/presences/src/main/resources/sql/scriptSQLReverse/testScript.sql
+++ b/presences/src/main/resources/sql/scriptSQLReverse/testScript.sql
@@ -1,0 +1,262 @@
+do $$
+    declare
+        structureId varchar = '46094e4c-a86f-4b73-812e-890e791a6900';
+        studentId1 varchar = 'a732e55d-744f-456a-a9be-271ef3e443b9';
+        studentId2 varchar = 'e2d5f0f4-0085-45ce-8c42-537c881c6783';
+        countAlert bigint = 0;
+    begin
+        -- Insert and define default value
+        TRUNCATE TABLE presences.alerts;
+        TRUNCATE TABLE presences.alert_history;
+        DELETE FROM presences.forgotten_notebook WHERE student_id = studentId1 OR student_id = studentId2;
+        UPDATE presences.settings SET alert_forgotten_notebook_threshold = 2 WHERE structure_id = structureId;
+        UPDATE presences.settings SET alert_incident_threshold = 3 WHERE structure_id = structureId;
+        UPDATE presences.settings SET alert_lateness_threshold = 4 WHERE structure_id = structureId;
+        UPDATE presences.settings SET alert_absence_threshold = 5 WHERE structure_id = structureId;
+
+        UPDATE presences.settings SET event_recovery_method = 'HOUR' WHERE structure_id = structureId;
+        UPDATE presences.settings SET exclude_alert_absence_no_reason = false WHERE structure_id = structureId;
+        UPDATE presences.settings SET exclude_alert_forgotten_notebook = false WHERE structure_id = structureId;
+        UPDATE presences.settings SET exclude_alert_lateness_no_reason = false WHERE structure_id = structureId;
+
+        INSERT INTO presences.reason(id, structure_id, label, reason_type_id) VALUES (9999, structureId, '', 1);
+        INSERT INTO presences.reason(id, structure_id, label, reason_type_id) VALUES (9998, structureId, '', 1);
+        INSERT INTO presences.reason(id, structure_id, label, reason_type_id) VALUES (9995, structureId, '', 1);
+        INSERT INTO presences.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) VALUES (structureId, 9999, 2);
+        INSERT INTO presences.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) VALUES (structureId, 9998, 2);
+        INSERT INTO presences.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) VALUES (structureId, 9998, 1);
+        INSERT INTO presences.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) VALUES (structureId, 9995, 1);
+        INSERT INTO presences.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) VALUES (structureId, 9995, 2);
+
+        INSERT INTO presences.reason(id, structure_id, label, reason_type_id) VALUES (9997, structureId, '', 2);
+        INSERT INTO presences.reason(id, structure_id, label, reason_type_id) VALUES (9996, structureId, '', 2);
+        INSERT INTO presences.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) VALUES (structureId, 9996, 3);
+
+        INSERT INTO incidents.seriousness(id, structure_id, label, exclude_alert_seriousness) VALUES (9899, structureId, '', false);
+        INSERT INTO incidents.seriousness(id, structure_id, label, exclude_alert_seriousness) VALUES (9898, structureId, '', true);
+        INSERT INTO incidents.protagonist_type(id, structure_id, label) VALUES (9799, structureId, '');
+
+        -- Test forgotten notebook
+        INSERT INTO presences.forgotten_notebook(id, date, student_id, structure_id) VALUES (9699, now(), studentId1, structureId);
+        INSERT INTO presences.forgotten_notebook(id, date, student_id, structure_id) VALUES (9698, now(), studentId2, structureId);
+        INSERT INTO presences.forgotten_notebook(id, date, student_id, structure_id) VALUES (9697, now() - INTERVAL '1 day', studentId1, structureId);
+        SELECT count(*) FROM presences.alerts WHERE student_id = studentId2 INTO countAlert;
+        assert countAlert = 1, 'create alert for studentId2 assert 1 != ' || countAlert;
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 3, 'create alert forgotten_notebook assert 3 != ' || countAlert;
+        UPDATE presences.settings SET exclude_alert_forgotten_notebook = true WHERE structure_id = structureId;
+        INSERT INTO presences.forgotten_notebook(id, date, student_id, structure_id) VALUES (9696, now() - INTERVAL '1 day', studentId2, structureId);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 3, 'do not create alert when exclude_alert_forgotten_notebook assert 3 != ' || countAlert;
+        DELETE FROM presences.alerts WHERE 1 = 1;
+        DELETE FROM presences.forgotten_notebook WHERE id IN (9699, 9698, 9697, 9696);
+        UPDATE presences.settings SET exclude_alert_forgotten_notebook = false WHERE structure_id = structureId;
+
+        -- Test incidents
+        INSERT INTO incidents.incident(id, owner, structure_id, date, seriousness_id) VALUES (9599, '', structureId, now(), 9899);
+        INSERT INTO incidents.incident(id, owner, structure_id, date, seriousness_id) VALUES (9598, '', structureId, now(), 9898);
+        INSERT INTO incidents.protagonist(user_id, incident_id, type_id) VALUES (studentId1, 9599, 9799);
+        INSERT INTO incidents.protagonist(user_id, incident_id, type_id) VALUES (studentId2, 9599, 9799);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 2, 'create alert for incident assert 2 != ' || countAlert;
+        INSERT INTO incidents.protagonist(user_id, incident_id, type_id) VALUES (studentId1, 9598, 9799);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 2, 'do not create alert when seriousness is exclude assert 2 != ' || countAlert;
+        UPDATE incidents.incident SET seriousness_id = 9899 WHERE seriousness_id = 9898;
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 3, 'create alert when update to a non exclude seriousness assert 3 != ' || countAlert;
+        UPDATE incidents.incident SET seriousness_id = 9898 WHERE seriousness_id = 9899;
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 0, 'delete alert when update to a exclude seriousness assert 0 != ' || countAlert;
+        UPDATE incidents.incident SET seriousness_id = 9899 WHERE seriousness_id = 9898;
+        EXECUTE incidents.delete_incident(9599);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 1, 'delete alert if the incident is delete assert 1 != ' || countAlert;
+        DELETE FROM incidents.protagonist WHERE user_id = studentId1;
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 0, 'delete alert if the protagonist is delete assert 0 != ' || countAlert;
+        DELETE FROM incidents.incident WHERE id IN (9599, 9598, 9597, 9596);
+        DELETE FROM incidents.seriousness WHERE id IN (9899, 9898, 9897, 9896);
+        DELETE FROM incidents.protagonist_type WHERE id IN (9799, 9798, 9797, 9796);
+        TRUNCATE TABLE presences.alerts;
+
+        --Test event
+        INSERT INTO presences.register(id, personnel_id, course_id, state_id, owner, structure_id) VALUES (9399, '', '', 3, '', structureId);
+        INSERT INTO presences.register(id, personnel_id, course_id, state_id, owner, structure_id) VALUES (9398, '', '', 3, '', structureId);
+
+        -- Test lateness event
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9499, now()::date + '09:00:00'::time, now()::date + '09:55:00'::time, studentId1, 9398, 2, NULL, '', false);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 1, 'create alert for lateness without reason assert 1 != ' || countAlert;
+
+        UPDATE presences.settings SET exclude_alert_lateness_no_reason = true WHERE structure_id = structureId;
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9496, now()::date + '09:00:00'::time, now()::date + '09:55:00'::time, studentId1, 9398, 2, NULL, '', false);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 1, 'do not create alert when exclude_alert_lateness_no_reason assert 1 != ' || countAlert;
+
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9498, now()::date + '09:00:00'::time, now()::date + '09:55:00'::time, studentId1, 9398, 2, 9997, '', false);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 2, 'create alert for lateness with reason not exclude assert 2 != ' || countAlert;
+
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9497, now()::date + '09:00:00'::time, now()::date + '09:55:00'::time, studentId1, 9398, 2, 9996, '', false);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 2, 'do not create alert for lateness with reason exclude assert 2 != ' || countAlert;
+
+        UPDATE presences.event SET reason_id = 9996 WHERE id = 9498;
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 1, 'delete alert when update lateness with reason exclude assert 1 != ' || countAlert;
+        DELETE FROM presences.event WHERE id IN (9499, 9498, 9497, 9496, 9495, 9494, 9493, 9492, 9491, 9490);
+        TRUNCATE TABLE presences.alerts;
+
+        -- Test absence event exclude_alert_absence_no_reason
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9499, now()::date + '10:00:00'::time, now()::date + '10:55:00'::time, studentId2, 9399, 1, NULL, '', false);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 1, 'create alert for absence without reason assert 1 != ' || countAlert;
+
+        UPDATE presences.settings SET exclude_alert_absence_no_reason = true WHERE structure_id = structureId;
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9497, now()::date + '10:00:00'::time, now()::date + '10:55:00'::time, studentId2, 9398, 1, NULL, '', false);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 1, 'do not create when exclude_alert_absence_no_reason assert 1 != ' || countAlert;
+
+        -- Test absence event no_regularized
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9498, now()::date + '10:00:00'::time, now()::date + '10:55:00'::time, studentId1, 9399, 1, 9999, '', false);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 1, 'do not create alert for exclude reason assert 1 != ' || countAlert;
+
+        UPDATE presences.reason_alert SET deleted_at = now() WHERE reason_id = 9999 AND structure_id = structureId;
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9495, now()::date + '10:00:00'::time, now()::date + '10:55:00'::time, studentId1, 9399, 1, 9999, '', false);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 2, 'create alert for not exclude reason assert 12: 2 != ' || countAlert;
+
+        -- Test absence event regularized
+        UPDATE presences.event SET reason_id = 9998 WHERE id = 9495;
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 1, 'delete alert when update to a exclude reason assert 13: 1 != ' || countAlert;
+
+        UPDATE presences.event SET reason_id = 9999 WHERE id = 9495;
+        UPDATE presences.event SET counsellor_regularisation = true WHERE id = 9495;
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 2, 'create alert when regularised is not exclude assert 14: 2 != ' || countAlert;
+
+        UPDATE presences.event SET reason_id = 9998 WHERE id = 9495;
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 1, 'delete alert when regularised is exclude assert 15: 1 != ' || countAlert;
+
+        DELETE FROM presences.event WHERE id IN (9499, 9498, 9497, 9496, 9495, 9494, 9493, 9492, 9491, 9490);
+        TRUNCATE TABLE presences.alerts;
+
+        -- Test absence event recoveryMethod HOUR
+        UPDATE presences.settings SET exclude_alert_absence_no_reason = false WHERE structure_id = structureId;
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9499, now()::date + '09:00:00'::time, now()::date + '09:55:00'::time, studentId2, 9399, 1, NULL, '', false);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 1, 'assert 16: 1 != ' || countAlert;
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9498, now()::date + '09:00:00'::time, now()::date + '09:55:00'::time, studentId2, 9398, 1, NULL, '', false);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 2, 'create alert when recoveryMethod HOUR and same time assert 2 != ' || countAlert;
+
+        -- Test absence event recoveryMethod HALF_DAY
+        UPDATE presences.settings SET event_recovery_method = 'HALF_DAY' WHERE structure_id = structureId;
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9497, now()::date + '10:00:00'::time, now()::date + '10:55:00'::time, studentId2, 9398, 1, NULL, '', false);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 2, 'do not create alert when recoveryMethod HALF_DAY and same time assert 2 != ' || countAlert;
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9496, now()::date + '16:00:00'::time, now()::date + '16:55:00'::time, studentId2, 9398, 1, NULL, '', false);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 3, 'create alert when recoveryMethod HALF_DAY and not same time assert 3 != ' || countAlert;
+
+        -- Test absence event recoveryMethod DAY
+        UPDATE presences.settings SET event_recovery_method = 'DAY' WHERE structure_id = structureId;
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9495, now()::date + '10:00:00'::time, now()::date + '10:55:00'::time, studentId1, 9398, 1, NULL, '', false);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 4, 'create alert when recoveryMethod DAY and not same day assert 4 != ' || countAlert;
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9494, now()::date + '16:00:00'::time, now()::date + '16:55:00'::time, studentId1, 9398, 1, NULL, '', false);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 4, 'do not create alert when recoveryMethod DAY and same day assert 4 != ' || countAlert;
+        DELETE FROM presences.event WHERE id IN (9499, 9498, 9497, 9496, 9495, 9494, 9493, 9492, 9491, 9490);
+        TRUNCATE TABLE presences.alerts;
+
+        -- Test complex case Update alert when having siblings in same time
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9499, now()::date + '10:00:00'::time, now()::date + '10:55:00'::time, studentId2, 9398, 1, NULL, '', false);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 1, 'assert 20: 1 != ' || countAlert;
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9498, now()::date + '09:00:00'::time, now()::date + '09:55:00'::time, studentId2, 9398, 1, NULL, '', false);
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 1, 'assert 21: 1 != ' || countAlert;
+        SELECT count(*) FROM presences.alerts WHERE event_id = 9499 INTO countAlert;
+        assert countAlert = 1, 'assert 22: 1 != ' || countAlert;
+
+        UPDATE presences.event SET reason_id = 9998 WHERE id = 9499;
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 1, 'assert 23: 1 != ' || countAlert;
+        SELECT count(*) FROM presences.alerts WHERE event_id = 9498 INTO countAlert;
+        assert countAlert = 1, 'assert 24: 1 != ' || countAlert;
+
+        UPDATE presences.event SET reason_id = 9995 WHERE id = 9499;
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 1, 'assert 24.1: 1 != ' || countAlert;
+        SELECT count(*) FROM presences.alerts WHERE event_id = 9498 INTO countAlert;
+        assert countAlert = 1, 'assert 24.2: 1 != ' || countAlert;
+
+        UPDATE presences.event SET reason_id = 9999 WHERE id = 9499;
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 1, 'assert 25: 1 != ' || countAlert;
+        SELECT count(*) FROM presences.alerts WHERE event_id = 9498 INTO countAlert;
+        assert countAlert = 1, 'assert 26: 1 != ' || countAlert;
+
+        DELETE FROM presences.event WHERE id = 9498;
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 1, 'assert 27: 1 != ' || countAlert;
+        SELECT count(*) FROM presences.alerts WHERE event_id = 9499 INTO countAlert;
+        assert countAlert = 1, 'assert 28: 1 != ' || countAlert;
+
+        TRUNCATE TABLE presences.alerts;
+        TRUNCATE TABLE presences.alert_history;
+        UPDATE presences.settings SET alert_absence_threshold = 3 WHERE structure_id = structureId;
+
+        --Test history
+        INSERT INTO presences.alerts(id, student_id, structure_id, type, created, event_id) VALUES (1, studentId1, structureId, 'ABSENCE', now(), 1);
+        DELETE FROM presences.alerts WHERE id = 1;
+        SELECT count(*) FROM presences.alert_history INTO countAlert;
+        assert countAlert = 0, 'assert 29: 0 != ' || countAlert;
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 0, 'assert 29.1: 0 != ' || countAlert;
+
+        INSERT INTO presences.alerts(id, student_id, structure_id, type, created, event_id) VALUES (1, studentId1, structureId, 'ABSENCE', now(), 1);
+        INSERT INTO presences.alerts(id, student_id, structure_id, type, created, event_id) VALUES (2, studentId1, structureId, 'ABSENCE', now(), 2);
+        INSERT INTO presences.alerts(id, student_id, structure_id, type, created, event_id) VALUES (3, studentId1, structureId, 'ABSENCE', now(), 3);
+        INSERT INTO presences.alerts(id, student_id, structure_id, type, created, event_id) VALUES (4, studentId1, structureId, 'ABSENCE', now(), 4);
+        DELETE FROM presences.alerts WHERE id = 1;
+        SELECT count(*) FROM presences.alert_history INTO countAlert;
+        assert countAlert = 0, 'do not create histrory when < to thresholder assert 0 != ' || countAlert;
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 3, 'assert 30.1: 3 != ' || countAlert;
+
+        INSERT INTO presences.alerts(id, student_id, structure_id, type, created, event_id) VALUES (1, studentId1, structureId, 'ABSENCE', now(), 1);
+        DELETE FROM presences.alerts WHERE 1 = 1;
+        SELECT count(*) FROM presences.alert_history INTO countAlert;
+        assert countAlert = 4, 'create history when > to thresholder assert 4 != ' || countAlert;
+        SELECT count(*) FROM presences.alerts INTO countAlert;
+        assert countAlert = 0, 'assert 31.1: 0 != ' || countAlert;
+
+        --Test delete reason_alert
+        DELETE FROM presences.event WHERE id IN (9499, 9498, 9497, 9496, 9495, 9494, 9493, 9492, 9491, 9490);
+        DELETE FROM presences.register WHERE id IN (9399, 9398, 9397, 9396);
+        DELETE FROM presences.reason WHERE id IN (9999, 9998, 9997, 9996, 9995);
+        SELECT count(*) FROM presences.reason_alert WHERE reason_id IN (9999, 9998, 9997, 9996, 9995) INTO countAlert;
+        assert countAlert = 0, 'clear associated reason_alert when deleting reason assert 0 != ' || countAlert;
+    end$$;


### PR DESCRIPTION
## Describe your changes
Part 2/3 of the ticket [MA-662](https://entsupport.gdapublic.fr/browse/MA-662)

Edit trigger and function for the MA-662.
MA-662 makes alerts configurable.

The tests are provided in the PR #140 

Doc: https://entconf.gdapublic.fr/pages/viewpage.action?pageId=96436457

The files in the "SQLReverseScript" folder is used in case of a problem in production. They must allow to restore the database to the state before the ticket. They will be deleted in the PR of the MA-770 ticket.

## Checklist tests
Nothing. Just execute this file after MA-662 complete 
https://github.com/OPEN-ENT-NG/presences/pull/140/files#diff-849bfe6ffcfd3d258ea47768804e674f38c73d03c0da7520bebbcbef54fbccd2

## Issue ticket number and link
[MA-968](https://entsupport.gdapublic.fr/browse/MA-968)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

