### PR TITLE
fix(registry): #MA-876 display green absence when regularized event w/ lateness on the same day

### DIFF
--- a/presences/src/main/resources/public/ts/controllers/__tests__/registry.controller.test.ts
+++ b/presences/src/main/resources/public/ts/controllers/__tests__/registry.controller.test.ts
@@ -1,0 +1,85 @@
+import {ng} from "@presences/models/__mocks__/entcore";
+import * as angular from 'angular';
+import 'angular-mocks';
+import {registryController} from "@presences/controllers";
+import {GroupService, SearchService} from "@common/services";
+import {RegistryEvent, registryService} from "@presences/services";
+
+describe('RegistryController', () => {
+    let registryControllerTest: any;
+
+    let registryEventNotRegularized: RegistryEvent = {
+        type: "ABSENCE",
+        startDate: "2020-01-01 08:00:00",
+        endDate: "2020-01-01 09:00:00",
+        student_id: "1",
+        counsellor_regularisation: false,
+        followed: false
+    };
+
+    let registryEventRegularized: RegistryEvent = {
+        type: "ABSENCE",
+        startDate: "2020-01-01 08:00:00",
+        endDate: "2020-01-01 09:00:00",
+        student_id: "2",
+        counsellor_regularisation: true,
+        followed: false
+    };
+
+    let registryEventLateness: RegistryEvent = {
+        type: "LATENESS",
+        startDate: "2020-01-01 08:00:00",
+        endDate: "2020-01-01 09:00:00",
+        student_id: "2",
+        counsellor_regularisation: false,
+        followed: false
+    };
+
+    beforeEach(() => {
+        // Registering a module for testing
+        const testApp = angular.module('app', []);
+        let $controller, $rootScope;
+
+        // Mockup test module
+        angular.mock.module('app');
+
+        // Instantiation of the services, controllers, directives we need
+        registryController;
+
+        // Adding services, controllers, directives in the module
+        ng.initMockedModules(testApp);
+
+        // Controller Injection
+        angular.mock.inject((_$controller_, _$rootScope_) => {
+            // The injector unwraps the underscores (_) from around the parameter names when matching
+            $controller = _$controller_;
+            $rootScope = _$rootScope_;
+        });
+
+        // Creates a new instance of scope
+        let $scope = $rootScope.$new();
+
+        // Fetching $location
+        testApp.run(($rootScope, $location) => {
+            $rootScope.location = $location;
+        });
+
+        // Controller Recovery
+        registryControllerTest = $controller('RegistryController', {
+            $scope: $scope,
+            $route: undefined,
+            $location: $rootScope.location,
+            searchService: SearchService,
+            groupService: GroupService,
+            registryService: registryService
+        });
+    });
+
+    it('test isAbsenceRegularized', done => {
+        expect(registryControllerTest.isAbsenceRegularized([registryEventNotRegularized, registryEventRegularized]))
+            .toEqual(false);
+        expect(registryControllerTest.isAbsenceRegularized([registryEventRegularized])).toEqual(true);
+        expect(registryControllerTest.isAbsenceRegularized([registryEventRegularized, registryEventLateness])).toEqual(true);
+        done();
+    });
+});

--- a/presences/src/main/resources/public/ts/controllers/registry.ts
+++ b/presences/src/main/resources/public/ts/controllers/registry.ts
@@ -11,6 +11,7 @@ import {
 } from "../services";
 import {DateUtils} from "@common/utils";
 import {EventType} from "../models";
+import {EVENT_TYPE} from "@common/core/enum/event-type";
 
 declare let window: any;
 
@@ -84,13 +85,13 @@ interface ViewModel {
     exportCsv(): void;
 }
 
-export const registryController = ng.controller('RegistryController', ['$scope', 'route', '$location',
+export const registryController = ng.controller('RegistryController', ['$scope', '$route', '$location',
     'SearchService', 'GroupService', 'RegistryService',
-    function ($scope, route, $location, SearchService: SearchService, groupService: GroupService, registryService: RegistryService) {
+    function ($scope, $route, $location, SearchService: SearchService, groupService: GroupService, registryService: RegistryService) {
         const vm: ViewModel = this;
 
         /* Fetching information from URL Param and cloning new object RegistryRequest */
-        vm.params = Object.assign({}, $location.search());
+        vm.params = Object.assign({}, $location ? $location.search() : null);
         vm.eventType = [
             EventType[EventType.ABSENCE],
             EventType[EventType.LATENESS],
@@ -100,7 +101,7 @@ export const registryController = ng.controller('RegistryController', ['$scope',
         vm.eventCardId = null;
         vm.eventCardData = {} as EventRegistryCard;
         /* Setting url param default if param not fetched or empty */
-        if (Object.getOwnPropertyNames(vm.params).length === 0) {
+        if ($location && Object.getOwnPropertyNames(vm.params).length === 0) {
             $location.search({
                 month: moment(new Date()).format(DateUtils.FORMAT["YEAR-MONTH"]),
                 type: vm.eventType
@@ -284,11 +285,9 @@ export const registryController = ng.controller('RegistryController', ['$scope',
             return event.some((event: RegistryEvent) => event.hasOwnProperty('reason_id'));
         };
 
-        vm.isAbsenceRegularized = (event: RegistryEvent[]): boolean => {
-            if (event.length === 0) {
-                return false;
-            }
-            return !event.some((event: RegistryEvent) => event.counsellor_regularisation === false);
+        vm.isAbsenceRegularized = (event: Array<RegistryEvent>): boolean => {
+            return (event.length > 0) && !event.some((event: RegistryEvent) => event.type === EVENT_TYPE.ABSENCE &&
+                event.counsellor_regularisation === false);
         };
 
         vm.isAbsenceFollowed = (event: RegistryEvent[]): boolean => {


### PR DESCRIPTION
## Describe your changes

- display green square when a regularized absence is on the same day as a lateness event

## Checklist tests

- check if the colors are matching the events properly

## Issue ticket number and link

https://entsupport.gdapublic.fr/browse/MA-876

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

