### PR TITLE
feat(alert): #MA-964 update alert endpoints

### DIFF
--- a/common/src/main/java/fr/openent/presences/common/helper/FutureHelper.java
+++ b/common/src/main/java/fr/openent/presences/common/helper/FutureHelper.java
@@ -1,7 +1,7 @@
 package fr.openent.presences.common.helper;
 
-import fr.openent.presences.core.constants.Field;
 import fr.wseduc.webutils.Either;
+import fr.openent.presences.core.constants.Field;
 import io.vertx.core.*;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.impl.CompositeFutureImpl;
@@ -31,7 +31,7 @@ public class FutureHelper {
     }
 
     /**
-     * @deprecated  Replaced by {@link #handlerFuture(Promise)}
+     * @deprecated  Replaced by {@link #handlerEitherPromise(Promise)}
      */
     @Deprecated
     public static Handler<Either<String, JsonArray>> handlerJsonArray(Promise<JsonArray> promise) {
@@ -48,7 +48,7 @@ public class FutureHelper {
     }
 
     /**
-     * @deprecated  Replaced by {@link #handlerFuture(Promise)}
+     * @deprecated  Replaced by {@link #handlerEitherPromise(Promise)}
      */
     @Deprecated
     public static Handler<Either<String, JsonObject>> handlerJsonObject(Promise<JsonObject> promise) {
@@ -64,7 +64,7 @@ public class FutureHelper {
         };
     }
 
-    public static <L, R> Handler<Either<L, R>> handlerPromise(Promise<R> promise) {
+    public static <L, R> Handler<Either<L, R>> handlerEitherPromise(Promise<R> promise) {
         return event -> {
             if (event.isRight()) {
                 promise.complete(event.right().getValue());

--- a/common/src/main/java/fr/openent/presences/core/constants/Field.java
+++ b/common/src/main/java/fr/openent/presences/core/constants/Field.java
@@ -320,6 +320,10 @@ public class Field {
     public static final String REASON_ALERT_RULES = "reason_alert_rules";
     public static final String USED = "used";
     public static final String RULE_TYPE = "rule_type";
+    public static final String DELETED_ALERT = "deleted_alert";
+    public static final String CLASS = "class";
+    public static final String STUDENTSID = "studentsId";
+    public static final String AUDIENCE = "audience";
 
     private Field() {
         throw new IllegalStateException("Utility class");

--- a/incidents/src/main/java/fr/openent/incidents/service/impl/DefaultSeriousnessService.java
+++ b/incidents/src/main/java/fr/openent/incidents/service/impl/DefaultSeriousnessService.java
@@ -75,7 +75,7 @@ public class DefaultSeriousnessService implements SeriousnessService {
                 .add(seriousnessBody.getString("label"))
                 .add(seriousnessBody.getInteger("level"))
                 .add(seriousnessBody.getBoolean("excludeAlertSeriousness"));
-        Sql.getInstance().prepared(query, params, SqlResult.validUniqueResultHandler(FutureHelper.handlerPromise(promise)));
+        Sql.getInstance().prepared(query, params, SqlResult.validUniqueResultHandler(FutureHelper.handlerEitherPromise(promise)));
 
         return promise.future();
     }
@@ -92,7 +92,7 @@ public class DefaultSeriousnessService implements SeriousnessService {
                 .add(seriousnessBody.getBoolean("hidden"))
                 .add(seriousnessBody.getBoolean("excludeAlertSeriousness"))
                 .add(seriousnessBody.getInteger("id"));
-        Sql.getInstance().prepared(query, params, SqlResult.validUniqueResultHandler(FutureHelper.handlerPromise(promise)));
+        Sql.getInstance().prepared(query, params, SqlResult.validUniqueResultHandler(FutureHelper.handlerEitherPromise(promise)));
 
         return promise.future();
     }

--- a/presences/src/main/java/fr/openent/presences/controller/AlertController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/AlertController.java
@@ -5,21 +5,26 @@ import fr.openent.presences.common.service.GroupService;
 import fr.openent.presences.common.service.impl.DefaultGroupService;
 import fr.openent.presences.constants.Actions;
 import fr.openent.presences.constants.Alerts;
-import fr.openent.presences.core.constants.*;
+import fr.openent.presences.core.constants.Field;
 import fr.openent.presences.export.AlertsCSVExport;
 import fr.openent.presences.security.Alert.AlertStudentNumber;
 import fr.openent.presences.security.AlertFilter;
 import fr.openent.presences.security.DeleteAlertFilter;
 import fr.openent.presences.service.AlertService;
 import fr.openent.presences.service.impl.DefaultAlertService;
-import fr.wseduc.rs.*;
+import fr.wseduc.rs.ApiDoc;
+import fr.wseduc.rs.Delete;
+import fr.wseduc.rs.Get;
 import fr.wseduc.security.ActionType;
 import fr.wseduc.security.SecuredAction;
 import fr.wseduc.webutils.Either;
+import fr.wseduc.webutils.request.RequestUtils;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import org.entcore.common.controller.ControllerHelper;
 import org.entcore.common.http.filter.ResourceFilter;
 import org.entcore.common.http.filter.Trace;
@@ -27,6 +32,8 @@ import org.entcore.common.http.filter.Trace;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.entcore.common.http.response.DefaultResponseHandler.arrayResponseHandler;
 import static org.entcore.common.http.response.DefaultResponseHandler.defaultResponseHandler;
@@ -39,20 +46,26 @@ public class AlertController extends ControllerHelper {
         groupService = new DefaultGroupService(eb);
     }
 
-    @Delete("/alerts")
+    @Delete("/structures/:id/alerts")
     @SecuredAction(value = "", type = ActionType.RESOURCE)
     @ResourceFilter(DeleteAlertFilter.class)
     @Trace(Actions.ALERT_DELETION)
     @ApiDoc("reset alerts")
     public void delete(HttpServerRequest request) {
-        List<String> alertIds = request.params().getAll(Field.ID);
-        String structureId = request.params().get(Field.STRUCTUREID);
-        String startAt = request.params().get(Field.STARTAT);
-        String endAt = request.params().get(Field.ENDAT);
+        RequestUtils.bodyToJson(request, pathPrefix + "alertDelete", body -> {
+            final Map<String, List<String>> deletedAlertMap = body.getJsonArray(Field.DELETED_ALERT).stream().map(JsonObject.class::cast)
+                    .collect(Collectors.groupingBy(jsonObject -> jsonObject.getString(Field.STUDENT_ID)))
+                    .entrySet()
+                    .stream()
+                    .collect(Collectors.toMap(Map.Entry::getKey, stringListEntry -> stringListEntry.getValue().stream()
+                            .map(jsonObject -> jsonObject.getString(Field.TYPE))
+                            .filter(Alerts.ALERT_LIST::contains)
+                            .collect(Collectors.toList())));
 
-        alertService.delete(structureId, alertIds, startAt, endAt)
-                .onSuccess(result -> renderJson(request, result))
-                .onFailure(err -> renderError(request));
+            alertService.delete(request.getParam(Field.ID), deletedAlertMap, body.getString(Field.START_AT), body.getString(Field.END_AT))
+                    .onSuccess(result -> renderJson(request, result))
+                    .onFailure(err -> renderError(request));
+        });
     }
 
     @Get("/structures/:id/alerts/summary")
@@ -60,7 +73,9 @@ public class AlertController extends ControllerHelper {
     @ResourceFilter(AlertFilter.class)
     @ApiDoc("Get given structure")
     public void get(HttpServerRequest request) {
-        alertService.getSummary(request.getParam("id"), defaultResponseHandler(request));
+        alertService.getSummary(request.getParam(Field.ID))
+                .onSuccess(result -> renderJson(request, result))
+                .onFailure(err -> renderError(request));
     }
 
     @Get("/structures/:id/alerts")
@@ -68,50 +83,33 @@ public class AlertController extends ControllerHelper {
     @ResourceFilter(AlertFilter.class)
     @ApiDoc("Get given structure")
     public void getStudentsAlerts(HttpServerRequest request) {
-        List<String> types = request.params().getAll("type");
-        List<String> students = request.params().getAll("student");
-        List<String> classes = request.params().getAll("class");
+        List<String> types = request.params().getAll(Field.TYPE);
+        List<String> students = request.params().getAll(Field.STUDENT_ID);
+        List<String> classes = request.params().getAll(Field.CLASS);
+        String startAt = request.params().get(Field.START_AT);
+        String endAt = request.params().get(Field.END_AT);
         if (types.size() == 0) {
             badRequest(request);
             return;
         }
-        getAlerts(request, types, students, classes, arrayResponseHandler(request));
+        getAlerts(request, types, students, classes, startAt, endAt, arrayResponseHandler(request));
     }
 
     private void getAlerts(HttpServerRequest request, List<String> types, List<String> students, List<String> classes,
-                           Handler<Either<String, JsonArray>> handler) {
-        if (classes.isEmpty())
-            alertService.getAlertsStudents(request.getParam("id"), types, students, event -> {
-                if (event.isLeft()) {
-                    String message = "[Presences@AlertController::getAlerts] Failed to retrieve alerts info.";
-                    log.error(message);
-                    handler.handle(new Either.Left(message));
-                } else {
-                    handler.handle(new Either.Right<>(event.right().getValue()));
-                }
-            });
-        else {
-            groupService.getGroupStudents(classes, resp -> {
-                if (resp.isLeft()) {
-                    String message = "[Presences@AlertController::getAlerts] Failed to retrieve groupStudents info.";
-                    log.error(message);
-                    handler.handle(new Either.Left(message));
-                    return;
-                }
-
-                JsonArray users = resp.right().getValue();
-                for (int i = 0; i < users.size(); i++) students.add(users.getJsonObject(i).getString("id"));
-                alertService.getAlertsStudents(request.getParam("id"), types, students, event -> {
-                    if (event.isLeft()) {
-                        String message = "[Presences@AlertsController::getAlerts] Failed to fetch alerts";
-                        log.error(message, event.left().getValue());
-                        handler.handle(new Either.Left(message));
-                    } else {
-                        handler.handle(new Either.Right<>(event.right().getValue()));
-                    }
+                           String startAt, String endAt, Handler<Either<String, JsonArray>> handler) {
+        Future<JsonArray> groupStudentFuture = (classes.isEmpty()) ? Future.succeededFuture(new JsonArray()) : groupService.getGroupStudents(classes);
+        groupStudentFuture.compose(users -> {
+                    users.stream()
+                            .map(o -> (JsonObject)o)
+                            .map(jsonObject -> jsonObject.getString(Field.ID))
+                            .forEach(students::add);
+                    return alertService.getAlertsStudents(request.getParam(Field.ID), types, students, startAt, endAt);
+                })
+                .onSuccess(alert -> handler.handle(new Either.Right<>(alert)))
+                .onFailure(error -> {
+                    log.error(String.format("[Presences@AlertController::getAlerts] Failed to retrieve alerts info. %s", error.getMessage()));
+                    handler.handle(new Either.Left<>(error.getMessage()));
                 });
-            });
-        }
     }
 
     @Get("/structures/:id/students/:studentId/alerts")
@@ -151,14 +149,14 @@ public class AlertController extends ControllerHelper {
     @Get("/structures/:id/alerts/export")
     @ApiDoc("Export alerts")
     public void exportAlerts(HttpServerRequest request) {
-        List<String> types = request.params().getAll("type");
-        List<String> students = request.params().getAll("student");
-        List<String> classes = request.params().getAll("class");
+        List<String> types = request.params().getAll(Field.TYPE);
+        List<String> students = request.params().getAll(Field.STUDENT);
+        List<String> classes = request.params().getAll(Field.CLASS);
         if (types.size() == 0) {
             badRequest(request);
             return;
         }
-        getAlerts(request, types, students, classes, event -> {
+        getAlerts(request, types, students, classes, null, null, event -> {
             if (event.isLeft()) {
                 log.error("[Presences@AlertsController::exportAlerts] Failed to fetch alerts", event.left().getValue());
                 renderError(request);

--- a/presences/src/main/java/fr/openent/presences/security/DeleteAlertFilter.java
+++ b/presences/src/main/java/fr/openent/presences/security/DeleteAlertFilter.java
@@ -1,53 +1,21 @@
 package fr.openent.presences.security;
 
-import fr.openent.presences.Presences;
 import fr.openent.presences.core.constants.Field;
 import fr.wseduc.webutils.http.Binding;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.json.JsonArray;
 import org.entcore.common.http.filter.ResourcesProvider;
-import org.entcore.common.sql.Sql;
-import org.entcore.common.sql.SqlResult;
 import org.entcore.common.user.UserInfos;
-
-import java.util.List;
 
 public class DeleteAlertFilter implements ResourcesProvider {
     @Override
     public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
-        List<String> alertIds = request.params().getAll(Field.ID);
-        String structureId = request.params().get(Field.STRUCTUREID);
+        String structureId = request.getParam(Field.ID);
 
-        if (structureId == null && (alertIds == null || alertIds.isEmpty())) {
+        if (structureId == null) {
             handler.handle(false);
             return;
         }
-
-        if (structureId != null) {
-            handler.handle(user.getStructures().contains(structureId));
-            return;
-        }
-
-        authorizeFromAlertIds(alertIds, user, handler);
+        handler.handle(user.getStructures().contains(structureId));
     }
-
-    private void authorizeFromAlertIds(List<String> alertIds, UserInfos user, Handler<Boolean> handler) {
-        String query = "SELECT COUNT(id) as count " +
-                "FROM " + Presences.dbSchema + ".alerts " +
-                "WHERE id IN " + Sql.listPrepared(alertIds) +
-                " AND structure_id IN " + Sql.listPrepared(user.getStructures());
-
-        JsonArray params = new JsonArray().addAll(new JsonArray(alertIds)).addAll(new JsonArray(user.getStructures()));
-        Sql.getInstance().prepared(query, params, SqlResult.validUniqueResultHandler(res -> {
-            if (res.isLeft()) {
-                handler.handle(false);
-                return;
-            }
-
-            Integer count = res.right().getValue().getInteger(Field.COUNT);
-            handler.handle(count == alertIds.size());
-        }));
-    }
-
 }

--- a/presences/src/main/java/fr/openent/presences/service/AlertService.java
+++ b/presences/src/main/java/fr/openent/presences/service/AlertService.java
@@ -6,45 +6,36 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.util.List;
+import java.util.Map;
 
 public interface AlertService {
-    /**
-     * Delete alerts based on given identifiers.
-     * Alert deletion trigger plsql trigger that create a new row in history table.
-     *
-     * @param alerts  alert identifiers
-     * @param handler function handler returning data
-     */
-    void delete(List<String> alerts, Handler<Either<String, JsonObject>> handler);
-
     /**
      * Delete alerts based on filter required
      * Alert deletion trigger plsql trigger that create a new row in history table.
      *
-     * @param structureId Structure identifier
-     * @param alertIds    alert identifiers
-     * @param startAt     start date from which we need remove alerts
-     * @param endAt       end date until which we need remove alerts
+     * @param structureId       Structure identifier
+     * @param deletedAlertMap   Map with key the student id and in value the alert type witch must be deleted
+     *                          null -> delete All, empty -> do nothing
+     * @param startAt           start date from which we need remove alerts
+     * @param endAt             end date until which we need remove alerts
      * @return request result Future
      */
-    Future<JsonObject> delete(String structureId, List<String> alertIds, String startAt, String endAt);
+    Future<JsonObject> delete(String structureId, Map<String, List<String>> deletedAlertMap, String startAt, String endAt);
 
     /**
      * Get alerts count
      *
      * @param structureId structure identifier
-     * @param handler     function handler returning data
      */
-    void getSummary(String structureId, Handler<Either<String, JsonObject>> handler);
+    Future<JsonObject> getSummary(String structureId);
 
     /**
      * Get alerts for all students
      *
      * @param structureId structure identifier
      * @param types       alert types
-     * @param handler     function handler returning data
      */
-    void getAlertsStudents(String structureId, List<String> types, List<String> students, Handler<Either<String, JsonArray>> handler);
+    Future<JsonArray> getAlertsStudents(String structureId, List<String> types, List<String> students, String startAt, String endAt);
 
     /**
      * Get student alert number by given type with the corresponding threshold

--- a/presences/src/main/java/fr/openent/presences/service/impl/DefaultReasonService.java
+++ b/presences/src/main/java/fr/openent/presences/service/impl/DefaultReasonService.java
@@ -78,7 +78,7 @@ public class DefaultReasonService implements ReasonService {
                 " WHERE reason_alert.deleted_at IS NULL" +
                 " AND reason.reason_type_id = ?";
         JsonArray params = new JsonArray(Collections.singletonList(reasonTypeId));
-        Sql.getInstance().prepared(query, params, SqlResult.validResultHandler(FutureHelper.handlerPromise(promise)));
+        Sql.getInstance().prepared(query, params, SqlResult.validResultHandler(FutureHelper.handlerEitherPromise(promise)));
         return promise.future();
     }
 

--- a/presences/src/main/resources/jsonschema/alertDelete.json
+++ b/presences/src/main/resources/jsonschema/alertDelete.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://jsonschema.net",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "start_at": {
+      "type": "string"
+    },
+    "end_at": {
+      "type": "string"
+    },
+    "deleted_alert": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "student_id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "deleted_alert"
+  ]
+}

--- a/presences/src/main/resources/public/template/alerts/header.html
+++ b/presences/src/main/resources/public/template/alerts/header.html
@@ -7,9 +7,9 @@
     <!-- Student search bar -->
     <div class="cell four paddingRight">
         <div class="cell twelve search-input">
-            <async-autocomplete data-ng-disabled="false"
+            <async-autocomplete data-ng-change="vm.selectStudent()"
+                                data-ng-disabled="false"
                                 data-ng-model="vm.filter.student"
-                                data-ng-change="vm.selectStudent"
                                 data-on-search="vm.searchStudent"
                                 data-options="vm.filter.students"
                                 data-placeholder="presences.exemptions.search.student"
@@ -19,8 +19,8 @@
 
         <div class="cell twelve">
             <ul class="cell twelve search-input-ul">
-                <li ng-repeat="student in vm.filter.selected.students"
-                    ng-click="vm.dropFilter(student, 'students')">
+                <li ng-click="vm.dropFilter(student, 'students')"
+                    ng-repeat="student in vm.filter.selected.students">
                     [[student.displayName]]
                     <i class="close"></i>
                 </li>
@@ -32,9 +32,9 @@
     <!-- Classes/Groups search bar -->
     <div class="cell four paddingLeft">
         <div class="cell twelve search-input">
-            <async-autocomplete data-ng-disabled="false"
+            <async-autocomplete data-ng-change="vm.selectClass()"
+                                data-ng-disabled="false"
                                 data-ng-model="vm.filter.class"
-                                data-ng-change="vm.selectClass"
                                 data-on-search="vm.searchClass"
                                 data-options="vm.filter.classes"
                                 data-placeholder="presences.exemptions.search.audience"
@@ -59,7 +59,7 @@
         <button class="right-magnet" data-ng-click="vm.exportAlertCSV()">
             <i18n>presences.export.tocsv</i18n>
         </button>
-        <sniplet template="punishment-form" application="incidents"></sniplet>
+        <sniplet application="incidents" template="punishment-form"></sniplet>
         <button class="right-magnet" data-ng-click="vm.reset()"
                 ng-disabled="!vm.someSelectedAlert()">
             <i18n>presences.reset</i18n>
@@ -67,11 +67,23 @@
     </div>
 
     <!-- Alert Type Filter -->
-    <div>
-        <div class="chips cell">
-            <label class="chip" ng-repeat="filter in vm.filters"
-                   ng-class="{selected: vm.filter.types[filter]}"
+    <div class="display-flex flex-column">
+        <div class="cell top5 margin-bottom-md">
+            <i18n>presences.from</i18n>
+            :
+            <span class="card date-picker">
+                <date-picker ng-change="vm.getStudentAlert();" ng-model="vm.filter.startDate"></date-picker>
+            </span>
+            <i18n>presences.to</i18n>
+            :
+            <span class="card date-picker">
+                <date-picker ng-change="vm.getStudentAlert();" ng-model="vm.filter.endDate"></date-picker>
+            </span>
+        </div>
+        <div class="chips cell margin-bottom-lg">
+            <label class="chip" ng-class="{selected: vm.filter.types[filter]}"
                    ng-click="vm.switchFilter(filter)"
+                   ng-repeat="filter in vm.filters"
             >
                 <span class="no-style">[[lang.translate('presences.alerts.filter.' + filter)]]</span>
             </label>
@@ -83,7 +95,7 @@
 <!-- Checkbox selectAll -->
 <div class="row">
     <label class="checkbox">
-        <input type="checkbox" ng-change="vm.selectAll()" ng-model="vm.selection.all">
+        <input ng-change="vm.selectAll()" ng-model="vm.selection.all" type="checkbox">
         <span><i18n>presences.select.all</i18n></span>
     </label>
 </div>

--- a/presences/src/main/resources/public/ts/models/Alert.ts
+++ b/presences/src/main/resources/public/ts/models/Alert.ts
@@ -12,3 +12,18 @@ export interface Alert {
     classes: any;
     userId: string;
 }
+
+export interface StudentAlert {
+    "student_id": string,
+    "type": string,
+    "count": number,
+    "name": string,
+    "audience": string,
+    selected?: boolean
+}
+
+export interface DeleteAlertRequest {
+    start_at: string,
+    end_at: string,
+    deleted_alert: Array<StudentAlert>,
+}

--- a/presences/src/main/resources/public/ts/services/AlertService.ts
+++ b/presences/src/main/resources/public/ts/services/AlertService.ts
@@ -1,15 +1,15 @@
 import {ng} from 'entcore';
 import http, {AxiosResponse} from 'axios';
-import {Alert} from "@presences/models/Alert";
+import {Alert, DeleteAlertRequest, StudentAlert} from "@presences/models/Alert";
 
 export interface AlertService {
     getAlerts(structureId: string): Promise<Alert>;
 
-    getStudentsAlerts(structureId: string, type: string[], students, classes): Promise<Array<Alert>>;
+    getStudentsAlerts(structureId: string, type: string[], students: string[], classes: string[], start_at: string, end_at: string): Promise<Array<StudentAlert>>;
 
     getStudentAlerts(structureId: string, studentId: string, type: string): Promise<{ count: number, threshold: number }>;
 
-    reset(alerts: Array<number>): Promise<void>;
+    reset(structureId: string, body: DeleteAlertRequest): Promise<void>;
 
     resetStudentAlertsCount(structureId: string, studentId: string, type: string): Promise<AxiosResponse>;
 
@@ -17,14 +17,11 @@ export interface AlertService {
 }
 
 export const alertService: AlertService = {
-    async reset(alerts: Array<number>): Promise<void> {
+    async reset(structureId: string, body: DeleteAlertRequest): Promise<void> {
         try {
-            let url = `/presences/alerts?`;
-            alerts.forEach(alert => {
-                url += `&id=${alert}`;
-            });
+            const url: string = `/presences/structures/${structureId}/alerts`;
 
-            const {data} = await http.delete(url);
+            const {data} = await http.delete(url, {data: body});
             return data;
         } catch (e) {
             throw e;
@@ -40,10 +37,11 @@ export const alertService: AlertService = {
         }
     },
 
-    async getStudentsAlerts(structureId: string, types: string[], students: string[] = null, groups: string[]) {
+    async getStudentsAlerts(structureId: string, types: string[], students: string[] = null, groups: string[], start_at: string, end_at: string): Promise<Array<StudentAlert>> {
         try {
-            let studentsFilter = '';
-            let groupsFilter = '';
+            let studentsFilter: string = '';
+            let groupsFilter: string = '';
+            let dateFilter: string = ''
             if (students && students.length > 0) {
                 students.map((student) => studentsFilter += `student=${student}&`);
             }
@@ -52,7 +50,11 @@ export const alertService: AlertService = {
                 groups.map((group) => groupsFilter += `class=${group}&`);
             }
 
-            let url = `/presences/structures/${structureId}/alerts?${studentsFilter}${groupsFilter}`;
+            if (start_at && end_at) {
+                dateFilter = `start_at=${start_at}&end_at=${end_at}&`;
+            }
+
+            let url: string = `/presences/structures/${structureId}/alerts?${studentsFilter}${groupsFilter}${dateFilter}`;
             types.forEach(type => {
                 url += `&type=${type}`;
             });
@@ -66,7 +68,7 @@ export const alertService: AlertService = {
 
     async getStudentAlerts(structureId: string, studentId: string, type: string): Promise<any> {
         try {
-            let url = `/presences/structures/${structureId}/students/${studentId}/alerts?type=${type}`;
+            let url: string = `/presences/structures/${structureId}/students/${studentId}/alerts?type=${type}`;
             const {data} = await http.get(url);
             return data;
         } catch (e) {

--- a/presences/src/main/resources/public/ts/services/__tests__/alert.service.test.ts
+++ b/presences/src/main/resources/public/ts/services/__tests__/alert.service.test.ts
@@ -1,0 +1,92 @@
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import {alertService} from "@presences/services";
+import {DeleteAlertRequest, StudentAlert} from "@presences/models/Alert";
+
+describe('AlertService', () => {
+    it('returns data when reset request is correctly called', done => {
+        const mock = new MockAdapter(axios);
+        const deleted_alert: Array<StudentAlert> = [{
+            student_id: "student_id",
+            type: "type",
+            count: 3,
+            name: "name",
+            audience: "audience",
+            selected: false}]
+        const data = {response: true};
+        const body : DeleteAlertRequest = {
+            start_at: "start_at",
+            end_at: "end_at",
+            deleted_alert: deleted_alert
+        };
+        const structure_id: string = "structure_id";
+        mock.onDelete(`/presences/structures/structure_id/alerts`, {data: body})
+            .reply(200, data);
+
+        alertService.reset(structure_id, body).then(response => {
+            expect(response).toEqual(data);
+            done();
+        });
+    });
+
+    it('returns data when getAlerts request is correctly called', done => {
+        const mock = new MockAdapter(axios);
+        const structureId: string = "structure_id";
+        const data = {response: true};
+        mock.onGet(`/presences/structures/${structureId}/alerts/summary`)
+            .reply(200, data);
+
+        alertService.getAlerts(structureId).then(response => {
+            expect(response).toEqual(data);
+            done();
+        });
+    });
+
+    it('returns data when getStudentsAlerts request is correctly called', done => {
+        const mock = new MockAdapter(axios);
+        const structureId: string = "structure_id";
+        const types: string[] = ["type1", "type2"];
+        const students: string[] = ["student1", "student2"];
+        const groups: string[] = ["group1", "group2"];
+        const start_at: string = "start_at";
+        const end_at: string = "end_at";
+        const data = {response: true};
+        mock.onGet(`/presences/structures/structure_id/alerts?student=student1&student=student2&class=group1&class=group2&start_at=start_at&end_at=end_at&&type=type1&type=type2`)
+            .reply(200, data);
+
+        alertService.getStudentsAlerts(structureId, types, students, groups, start_at, end_at).then(response => {
+            expect(response).toEqual(data);
+            done();
+        });
+    });
+
+    it('returns data when getStudentAlerts request is correctly called', done => {
+        const mock = new MockAdapter(axios);
+        const structureId: string = "structure_id";
+        const studentId: string = "studentId";
+        const type: string = "type";
+        const data = {response: true};
+        mock.onGet(`/presences/structures/${structureId}/students/${studentId}/alerts?type=${type}`)
+            .reply(200, data);
+
+        alertService.getStudentAlerts(structureId, studentId, type).then(response => {
+            expect(response).toEqual(data);
+            done();
+        });
+    });
+
+    it('returns data when resetStudentAlertsCount request is correctly called', done => {
+        const mock = new MockAdapter(axios);
+        const structureId: string = "structure_id";
+        const studentId: string = "studentId";
+        const type: string = "type";
+        const data = {response: true};
+        mock.onDelete(`/presences/structures/${structureId}/students/${studentId}/alerts/reset?type=${type}`)
+            .reply(200, data);
+
+        alertService.resetStudentAlertsCount(structureId, studentId, type).then(response => {
+            expect(response.data).toEqual(data);
+            done();
+        });
+    });
+});

--- a/presences/src/main/resources/sql/051-MA-964-update-alert-endpoint.sql
+++ b/presences/src/main/resources/sql/051-MA-964-update-alert-endpoint.sql
@@ -1,0 +1,15 @@
+-- Gets the alert threshold for a structure and data type
+CREATE OR REPLACE FUNCTION presences.get_alert_thresholder(type character varying, structureId varchar) RETURNS BIGINT AS
+$BODY$
+DECLARE
+    result bigint;
+BEGIN
+    CASE type
+        WHEN 'ABSENCE' THEN result = (SELECT alert_absence_threshold FROM presences.settings WHERE structure_id = structureId LIMIT 1);
+        WHEN 'LATENESS' THEN result = (SELECT alert_lateness_threshold FROM presences.settings WHERE structure_id = structureId LIMIT 1);
+        WHEN 'INCIDENT' THEN result = (SELECT alert_incident_threshold FROM presences.settings WHERE structure_id = structureId LIMIT 1);
+        WHEN 'FORGOTTEN_NOTEBOOK' THEN result = (SELECT alert_forgotten_notebook_threshold FROM presences.settings WHERE structure_id = structureId LIMIT 1); END CASE;
+    RETURN result;
+END
+$BODY$
+    LANGUAGE plpgsql;

--- a/presences/src/main/resources/sql/scriptSQLReverse/051-MA-964-update-alert-endpoint-reverse.sql
+++ b/presences/src/main/resources/sql/scriptSQLReverse/051-MA-964-update-alert-endpoint-reverse.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION presences.get_alert_thresholder(type character varying, structureId varchar);

--- a/presences/src/test/java/fr/openent/presences/service/impl/AlertServiceTest.java
+++ b/presences/src/test/java/fr/openent/presences/service/impl/AlertServiceTest.java
@@ -5,36 +5,49 @@ import fr.openent.presences.core.constants.*;
 import fr.openent.presences.db.*;
 import fr.openent.presences.db.DB;
 import fr.openent.presences.service.*;
+import fr.wseduc.webutils.eventbus.ResultMessage;
 import io.vertx.core.*;
+import io.vertx.core.eventbus.Message;
+import io.vertx.core.impl.VertxImpl;
 import io.vertx.core.json.*;
 import io.vertx.ext.unit.*;
 import io.vertx.ext.unit.junit.*;
+import org.entcore.common.neo4j.Neo4j;
 import org.entcore.common.sql.*;
 import org.junit.*;
 import org.junit.runner.*;
 import org.mockito.*;
 import org.mockito.stubbing.*;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 import org.powermock.reflect.*;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
 
-@RunWith(VertxUnitRunner.class)
+@RunWith(PowerMockRunner.class) //Using the PowerMock runner
+@PowerMockRunnerDelegate(VertxUnitRunner.class) //And the Vertx runner
+@PrepareForTest({Sql.class, Neo4j.class}) //Prepare the static class you want to test
 public class AlertServiceTest extends DBService {
 
-    Sql sql = Mockito.mock(Sql.class);
+    Sql sql = PowerMockito.mock(Sql.class);
+    Neo4j neo4j = PowerMockito.mock(Neo4j.class);
+    Vertx vertx;
 
     private AlertService alertService;
 
     private static final String STRUCTURE_ID = "111";
-    private static final List<String> REASON_IDS = Arrays.asList("222", "333");
-    private static final String START = "2022-06-01 08:00:00";
-    private static final String END = "2022-06-30 23:59:59";
+    private static final String START = "2022-06-01";
+    private static final String END = "2022-06-30";
 
     @Before
     public void setUp() {
         DB.getInstance().init(null, sql, null);
         this.alertService = new DefaultAlertService();
+        this.vertx = Vertx.vertx();
+        Sql.getInstance().init(vertx.eventBus(), "fr.openent.presences");
     }
 
     @Test
@@ -57,9 +70,14 @@ public class AlertServiceTest extends DBService {
 
     @Test
     public void testDelete(TestContext ctx) throws Exception {
-        String expectedQuery = String.format("DELETE FROM %s.alerts WHERE structure_id = ? AND id IN (?,?) AND created >= ? AND created <= ? ",
-                Presences.dbSchema
-        );
+        Async async = ctx.async();
+        String expectedQuery = "DELETE FROM null.alerts WHERE structure_id = ?  AND ((student_id = ? AND type IN (?,?)) " +
+                "OR (student_id = ? AND type IN (?))) AND created >= ?::date + '00:00:00'::time AND created <= ?::date + '23:59:59'::time ";
+        String expectedParams = "[\"111\",\"student2\",\"ABSENCE\",\"LATENESS\",\"student1\",\"ABSENCE\",\"2022-06-01\",\"2022-06-30\"]";
+
+        Map<String, List<String>> deletedAlertMap = new HashMap<>();
+        deletedAlertMap.put("student1", Collections.singletonList("ABSENCE"));
+        deletedAlertMap.put("student2", Arrays.asList("ABSENCE", "LATENESS"));
 
         Mockito.doAnswer((Answer<Void>) invocation -> {
             String query = invocation.getArgument(0);
@@ -67,17 +85,77 @@ public class AlertServiceTest extends DBService {
 
             ctx.assertEquals(query, expectedQuery);
 
-            ctx.assertEquals(params, new JsonArray()
-                    .add(STRUCTURE_ID)
-                    .addAll(new JsonArray(REASON_IDS))
-                    .add(START)
-                    .add(END));
+            ctx.assertEquals(params.toString(), expectedParams);
 
+            async.complete();
             return null;
         }).when(sql).prepared(Mockito.anyString(), Mockito.any(JsonArray.class), Mockito.any(Handler.class));
 
-        Whitebox.invokeMethod(alertService, "delete",
-                STRUCTURE_ID, REASON_IDS, START, END);
+        this.alertService.delete(STRUCTURE_ID, deletedAlertMap, START, END);
+    }
+
+    @Test
+    public void testGetSummary(TestContext ctx) {
+        Async async = ctx.async();
+        String expectedQuery = "SELECT tc.type, count(*) AS count FROM (SELECT type, count(*) AS count FROM null.alerts" +
+                " WHERE structure_id = ? GROUP BY student_id, type) as tc WHERE tc.count >= null.get_alert_thresholder(tc.type, ?)" +
+                " GROUP BY tc.type;";
+        String expectedParams = "[\"111\",\"111\"]";
+
+        vertx.eventBus().consumer("fr.openent.presences", message -> {
+            JsonObject body = (JsonObject) message.body();
+            ctx.assertEquals("prepared", body.getString("action"));
+            ctx.assertEquals(expectedQuery, body.getString("statement"));
+            ctx.assertEquals(expectedParams, body.getJsonArray("values").toString());
+            async.complete();
+        });
+
+        this.alertService.getSummary(STRUCTURE_ID);
+    }
+
+    @Test
+    public void testGetAlertsStudents(TestContext ctx) {
+        Async async = ctx.strictAsync(2);
+        PowerMockito.spy(Sql.class);
+        PowerMockito.when(Sql.getInstance()).thenReturn(sql);
+        PowerMockito.spy(Neo4j.class);
+        PowerMockito.when(Neo4j.getInstance()).thenReturn(neo4j);
+
+        String expectedQuerySql = "SELECT student_id, type, count(*) AS count FROM null.alerts" +
+                " WHERE structure_id = ? AND type IN (?,?) AND student_id IN (?,?)" +
+                "AND created >= ?::date + '00:00:00'::time AND created <= ?::date + '23:59:59'::time  " +
+                "GROUP BY student_id, type HAVING count(*) >= null.get_alert_thresholder(type, ?);";
+        String expectedParamsSql = "[\"111\",\"ABSENCE\",\"LATENESS\",\"student3\",\"student4\",\"2022-06-01\",\"2022-06-30\",\"111\"]";
+        String expectedQueryNeo = "MATCH (u:User)-[:IN]->(:ProfileGroup)-[:DEPENDS]->(c:Class) WHERE u.id IN {studentsId}" +
+                " RETURN u.firstName as firstName, u.lastName as lastName, c.name as audience, u.id as student_id;";
+        String expectedParamsNeo = "{\"studentsId\":[\"student1\",\"student2\"]}";
+
+        PowerMockito.doAnswer((Answer<Void>) invocation -> {
+            String query = invocation.getArgument(0);
+            JsonArray params = invocation.getArgument(1);
+            ctx.assertEquals(query, expectedQuerySql);
+            ctx.assertEquals(params.toString(), expectedParamsSql);
+
+            Handler<Message<JsonObject>> handler = invocation.getArgument(2);
+            handler.handle(new ResultMessage(new JsonObject().put("results", new JsonArray(Arrays.asList(
+                    new JsonArray(Arrays.asList("student1")),
+                    new JsonArray(Arrays.asList("student2"))
+                    )))
+                    .put("fields", new JsonArray(Arrays.asList("student_id")))));
+            async.countDown();
+            return null;
+        }).when(sql).prepared(Mockito.anyString(), Mockito.any(JsonArray.class), Mockito.any(Handler.class));
+
+        PowerMockito.doAnswer((Answer<Void>) invocation -> {
+            String queryResult = invocation.getArgument(0);
+            JsonObject paramResult = invocation.getArgument(1);
+            ctx.assertEquals(queryResult, expectedQueryNeo);
+            ctx.assertEquals(paramResult.toString(), expectedParamsNeo);
+            async.countDown();
+            return null;
+        }).when(neo4j).execute(Mockito.anyString(), Mockito.any(JsonObject.class), Mockito.any(Handler.class));
+        this.alertService.getAlertsStudents(STRUCTURE_ID, Arrays.asList("ABSENCE", "LATENESS"), Arrays.asList("student3", "student4"), START, END);
+        async.awaitSuccess(100000);
     }
 
 }


### PR DESCRIPTION
## Describe your changes
Party 3/3 of the ticket [MA-770](https://entsupport.gdapublic.fr/browse/MA-770)

Update alert endpoints to make alerts resettable in function of settings
MA-770 aims to make alerts resettable by dates.

Doc: https://entconf.gdapublic.fr/pages/viewpage.action?pageId=96436457
Doc Alert: https://confluence.support-ent.fr/display/MP/Alert+API

The files in the "SQLReverseScript" folder is used in case of a problem in production. They must allow to restore the database to the state before the ticket. They will be deleted in the PR of the MA-770 ticket.

## Checklist tests
Everything must work as specified in the docs

## Issue ticket number and link
[MA-964](https://entsupport.gdapublic.fr/browse/MA-964)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [x] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

