### PR TITLE
fix(alert): #MA-987 fix date alert and incident alert

### DIFF
--- a/presences/src/main/resources/sql/052-MA-987-recalculates-alerts.sql
+++ b/presences/src/main/resources/sql/052-MA-987-recalculates-alerts.sql
@@ -14,12 +14,12 @@ do $$
                     existingAbsenceWithAlert = NULL;
                     SELECT presences.get_id_absence_event_siblings(eventItems, structureId, true) INTO existingAbsenceWithAlert;
                     IF existingAbsenceWithAlert IS NULL AND NOT presences.absence_exclude_alert(eventItems, structureId) THEN -- If we have no exclude condition and not siblings
-                        INSERT INTO presences.alerts(student_id, structure_id, type, event_id) VALUES (eventItems.student_id , structureId, 'ABSENCE', eventItems.id);
+                        INSERT INTO presences.alerts(student_id, structure_id, type, event_id, created) VALUES (eventItems.student_id , structureId, 'ABSENCE', eventItems.id, eventItems.created);
                     END IF;
                 ELSE
                     IF NOT presences.lateness_exclude_alert(eventItems, structureId) THEN -- If we have no exclude condition
                     -- Create alert
-                        INSERT INTO presences.alerts(student_id, structure_id, type, event_id) VALUES (eventItems.student_id , structureId, 'LATENESS', eventItems.id);
+                        INSERT INTO presences.alerts(student_id, structure_id, type, event_id, created) VALUES (eventItems.student_id , structureId, 'LATENESS', eventItems.id, eventItems.created);
                     END IF;
                 end if;
             end loop;
@@ -27,18 +27,14 @@ do $$
         FOR forgottenNotebook IN SELECT * FROM presences.forgotten_notebook as f LEFT JOIN presences.alerts a on f.id = a.event_id WHERE a IS NULL LOOP
                 IF presences.notebook_exclude_alert(structureId) IS FALSE THEN -- If we have no exclude condition
                 -- Create alert
-                    INSERT INTO presences.alerts(student_id, structure_id, type, event_id) VALUES (forgottenNotebook.student_id , forgottenNotebook.structure_id, 'FORGOTTEN_NOTEBOOK', forgottenNotebook.id);
+                    INSERT INTO presences.alerts(student_id, structure_id, type, event_id, created) VALUES (forgottenNotebook.student_id , forgottenNotebook.structure_id, 'FORGOTTEN_NOTEBOOK', forgottenNotebook.id, forgottenNotebook.created);
                 END IF;
             end loop;
 
-        FOR incident IN SELECT * FROM incidents.incident LOOP
-            FOR protagonist IN SELECT * FROM incidents.protagonist as p LEFT JOIN presences.alerts a on p.incident_id = a.event_id WHERE a IS NULL AND p.incident_id = incident.id
-                LOOP
-                    IF incidents.incident_protagonist_exclude_alert(protagonist, structureId) IS FALSE THEN -- If we have no exclude condition
-                    -- Create alert
-                        INSERT INTO presences.alerts(student_id, structure_id, type, event_id) VALUES (protagonist.user_id, incident.structure_id, 'INCIDENT', incident.id);
-                    END IF;
+        FOR incident IN SELECT * FROM incidents.incident AS i WHERE incidents.incident_exclude_alert(i) IS FALSE LOOP
+                FOR protagonist IN SELECT * FROM incidents.protagonist as p WHERE p.incident_id = incident.id AND NOT exists(SELECT * FROM presences.alerts as a WHERE a.type = 'INCIDENT' AND a.event_id = incident.id)
+                    LOOP
+                        INSERT INTO presences.alerts(student_id, structure_id, type, event_id, created) VALUES (protagonist.user_id, incident.structure_id, 'INCIDENT', incident.id, incident.created);
+                    end loop;
             end loop;
-        end loop;
-
     end$$;


### PR DESCRIPTION
## Describe your changes
Lorsque l'on passe le script , la date des alertes correspond a la date d'aujourd'hui. Elle devrais correspondre a la date de l'évènement associer.
De plus les alertes de type incidents n'étais pas bien calculer.

## Checklist tests
Vérifier que les alertes n'ont pas tous la même date.
Vérifier que les alertes de type incidents sont bien calculé.

## Issue ticket number and link
[MA-987](https://entsupport.gdapublic.fr/browse/MA-987)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

