### PR TITLE
fix(alert) #MA-770 make alert link on the date of the associated event

### DIFF
--- a/incidents/src/main/resources/sql/022-MA-966-create-trigger-make-alerts-configurable.sql
+++ b/incidents/src/main/resources/sql/022-MA-966-create-trigger-make-alerts-configurable.sql
@@ -6,14 +6,14 @@ DROP FUNCTION incidents.increment_incident_alert();
 CREATE FUNCTION incidents.add_incident_alert() RETURNS TRIGGER AS
 $BODY$
 DECLARE
-    structureId character varying;
+    incident incidents.incident;
 BEGIN
     -- Select the structure associate with the new protagonist
-    SELECT structure_id FROM incidents.incident WHERE id = NEW.incident_id INTO structureId;
+    SELECT * FROM incidents.incident WHERE id = NEW.incident_id INTO incident;
 
-    IF incidents.incident_protagonist_exclude_alert(NEW, structureId) IS FALSE THEN -- If we have no exclude condition
+    IF incidents.incident_protagonist_exclude_alert(NEW, incident.structure_id) IS FALSE THEN -- If we have no exclude condition
         -- Create alert
-        EXECUTE presences.create_alert(NEW.incident_id, 'INCIDENT', NEW.user_id, structureId);
+        EXECUTE presences.create_alert(NEW.incident_id, 'INCIDENT', NEW.user_id, incident.structure_id, incident.date);
     END IF;
 
     RETURN NEW;

--- a/presences/src/main/resources/sql/044-MA-967-count-alert-by-line.sql
+++ b/presences/src/main/resources/sql/044-MA-967-count-alert-by-line.sql
@@ -10,6 +10,7 @@ ALTER TABLE presences.alerts ADD COLUMN event_id bigint NOT NULL,
                              DROP COLUMN exceed_date,
                              DROP COLUMN modified,
                              -- Column used in trigger
+                             ADD COLUMN date timestamp without time zone NOT NULL,
                              ADD COLUMN delete_at timestamp without time zone;
 
 ALTER TABLE presences.alert_history DROP COLUMN exceed_date,

--- a/presences/src/main/resources/sql/047-MA-966-function-make-alerts-configurable.sql
+++ b/presences/src/main/resources/sql/047-MA-966-function-make-alerts-configurable.sql
@@ -51,21 +51,21 @@ $BODY$
     LANGUAGE plpgsql;
 
 DROP FUNCTION presences.get_id_absence_event_siblings_in_same_day(presences.event, time, time, boolean);
--- Return the id of the absence event siblings of the event in params, included in the provided time.
+-- Return the absence event siblings of the event in params, included in the provided time.
 -- If no event is found then we return null.
 -- absenceEvent     The event with absence type of which we must find the siblings
 -- startTime        Siblings must be after start time
 -- endTime          Siblings must be before end time
 -- structureId      Structure id of the absenceEvent
 -- needAlert        If true, the siblings must be have an associated alert. If false, the siblings must be have no associated alert.
-CREATE FUNCTION presences.get_id_absence_event_siblings_in_same_day(absenceEvent presences.event, startTime time, endTime time, structureId varchar, needAlert boolean) RETURNS bigint AS
+CREATE OR REPLACE FUNCTION presences.get_id_absence_event_siblings_in_same_day(absenceEvent presences.event, startTime time, endTime time, structureId varchar, needAlert boolean) RETURNS presences.event AS
 $BODY$
 DECLARE
-    eventId bigint;
+    eventResult presences.event;
     noReasonAbsenceExclude boolean;
 BEGIN
     SELECT exclude_alert_absence_no_reason FROM presences.settings WHERE structure_id = structureId INTO noReasonAbsenceExclude;
-    SELECT event.id
+    SELECT *
     FROM presences.event
              INNER JOIN presences.register ON (register.id = event.register_id)
              LEFT JOIN presences.alerts as a ON (a.event_id = event.id)
@@ -85,22 +85,23 @@ BEGIN
       AND event.id != absenceEvent.id
       AND ((needAlert AND a.event_id IS NOT NULL) OR (NOT needAlert AND a.event_id IS NULL))
     LIMIT 1 -- Only take one
-    INTO eventId;
-    RETURN eventId;
+    INTO eventResult;
+    RETURN eventResult;
 END
 $BODY$
     LANGUAGE plpgsql;
 
+DROP FUNCTION presences.get_id_absence_event_siblings(presences.event,character varying,boolean);
 -- Return the id of the absence event siblings of the event in params.
 -- If no event is found then we return null.
 -- absenceEvent     The event with absence type of which we must find the siblings
 -- structureId      The structure of the event
 -- needAlert        If true, the siblings must be have an associated alert. If false, the siblings must be have no associated alert.
-CREATE or replace FUNCTION presences.get_id_absence_event_siblings(event presences.event, structureId varchar, needAlert boolean) RETURNS bigint AS
+CREATE FUNCTION presences.get_id_absence_event_siblings(event presences.event, structureId varchar, needAlert boolean) RETURNS presences.event AS
 $BODY$
 DECLARE
     recoveryMethod character varying;
-    absenceOtherId bigint = NULL;
+    otherAbsence presences.event;
     endOfHalfDay time without time zone;
 BEGIN
     SELECT event_recovery_method FROM presences.settings WHERE structure_id = structureId INTO recoveryMethod; -- Get recovery method
@@ -109,17 +110,17 @@ BEGIN
             -- First retrieve half day hour
             SELECT time_slots.end_of_half_day FROM viesco.time_slots WHERE id_structure = structureId INTO endOfHalfDay;
             if event.start_date::time < endOfHalfDay THEN -- If we are in morning
-                SELECT presences.get_id_absence_event_siblings_in_same_day(event, '00:00:00'::time, endOfHalfDay, structureId, needAlert) INTO absenceOtherId;
+                SELECT * FROM presences.get_id_absence_event_siblings_in_same_day(event, '00:00:00'::time, endOfHalfDay, structureId, needAlert) INTO otherAbsence;
             ELSE -- If we are afternoon
-                SELECT presences.get_id_absence_event_siblings_in_same_day(event, endOfHalfDay,'23:59:59'::time, structureId, needAlert) INTO absenceOtherId;
+                SELECT * FROM presences.get_id_absence_event_siblings_in_same_day(event, endOfHalfDay,'23:59:59'::time, structureId, needAlert) INTO otherAbsence;
             END IF;
         WHEN 'DAY' THEN
             -- Check if student already have absence for the day based on provided structure identifier
-            SELECT presences.get_id_absence_event_siblings_in_same_day(event, '00:00:00'::time, '23:59:59'::time, structureId, needAlert) INTO absenceOtherId;
+            SELECT * FROM presences.get_id_absence_event_siblings_in_same_day(event, '00:00:00'::time, '23:59:59'::time, structureId, needAlert) INTO otherAbsence;
         -- 'HOUR' is a classic case. No other absence can be on the same date.
         ELSE
         END CASE;
-    RETURN absenceOtherId;
+    RETURN otherAbsence;
 END;
 $BODY$
     LANGUAGE plpgsql;

--- a/presences/src/main/resources/sql/050-MA-966-update-trigger-make-alerts-configurable.sql
+++ b/presences/src/main/resources/sql/050-MA-966-update-trigger-make-alerts-configurable.sql
@@ -3,28 +3,29 @@ CREATE OR REPLACE FUNCTION presences.update_absence_alert() RETURNS TRIGGER AS
 $BODY$
 DECLARE
     isNewEventExclude boolean;
-    structureId character varying;
+    register presences.register;
     oldAlertID bigint;
-    eventIdToReplace bigint;
+    eventToReplace presences.event;
 BEGIN
     -- Select the structure associate with the new event
-    SELECT structure_id FROM presences.register WHERE id = NEW.register_id LIMIT 1 INTO structureId;
+    SELECT * FROM presences.register WHERE id = NEW.register_id INTO register;
 
     -- Check if the new event must be exclude
-    SELECT presences.absence_exclude_alert(NEW, structureId) INTO isNewEventExclude;
+    SELECT presences.absence_exclude_alert(NEW, register.structure_id) INTO isNewEventExclude;
     -- Check if the old data have alert
-    SELECT event_id FROM presences.alerts WHERE event_id = OLD.id AND type = 'ABSENCE' AND student_id = OLD.student_id AND structure_id = structureId INTO oldAlertID;
+    SELECT event_id FROM presences.alerts WHERE event_id = OLD.id AND type = 'ABSENCE' AND student_id = OLD.student_id AND structure_id = register.structure_id INTO oldAlertID;
 
     IF oldAlertID IS NOT NULL AND isNewEventExclude THEN -- If we have previously a alert and now the event is exclude we must delete alert
-        SELECT presences.get_id_absence_event_siblings(OLD, structureId, false) INTO eventIdToReplace;
-        EXECUTE presences.delete_alert(OLD.id, 'ABSENCE', OLD.student_id, structureId);
-        IF eventIdToReplace IS NOT NULL THEN -- If we have a no other absence in the same time with no alert, we need to create a alert for other absence
-            EXECUTE presences.create_alert(eventIdToReplace, 'ABSENCE', NEW.student_id, structureId);
+        SELECT * FROM presences.get_id_absence_event_siblings(OLD, register.structure_id, false) INTO eventToReplace;
+        EXECUTE presences.delete_alert(OLD.id, 'ABSENCE', OLD.student_id, register.structure_id);
+        IF eventToReplace.id IS NOT NULL THEN -- If we have a no other absence in the same time with no alert, we need to create a alert for other absence
+            SELECT * FROM presences.register WHERE id = eventToReplace.register_id LIMIT 1 INTO register;
+            EXECUTE presences.create_alert(eventToReplace.id, 'ABSENCE', NEW.student_id, register.structure_id, register.start_date);
         END IF;
     ELSIF oldAlertID IS NULL AND NOT isNewEventExclude THEN -- If we have not previously a alert and now the event is not exclude we must create alert
-        SELECT presences.get_id_absence_event_siblings(OLD, structureId, true) INTO eventIdToReplace;
-        IF eventIdToReplace IS NULL THEN -- If we have a other absence in the same time with alert, we DONT need create a alert
-            EXECUTE presences.create_alert(NEW.id, 'ABSENCE', NEW.student_id, structureId);
+        SELECT * FROM presences.get_id_absence_event_siblings(OLD, register.structure_id, true) INTO eventToReplace;
+        IF eventToReplace.id IS NULL THEN -- If we have a other absence in the same time with alert, we DONT need create a alert
+            EXECUTE presences.create_alert(NEW.id, 'ABSENCE', NEW.student_id, register.structure_id, register.start_date);
         END IF;
     END IF;
     RETURN NEW;
@@ -40,22 +41,22 @@ CREATE FUNCTION presences.update_lateness_alert() RETURNS TRIGGER AS
 $BODY$
 DECLARE
     newEventExclude boolean;
-    structureId character varying;
+    register presences.register;
     oldAlertId bigint;
 BEGIN
     -- Select the structure associate with the new event
-    SELECT structure_id FROM presences.register WHERE id = NEW.register_id LIMIT 1 INTO structureId;
+    SELECT * FROM presences.register WHERE id = NEW.register_id LIMIT 1 INTO register;
 
     -- Check if the new event must be exclude
-    SELECT presences.lateness_exclude_alert(NEW, structureId) INTO newEventExclude;
+    SELECT presences.lateness_exclude_alert(NEW, register.structure_id) INTO newEventExclude;
     -- Check if the old data have alert
-    SELECT event_id FROM presences.alerts WHERE event_id = OLD.id AND type = 'LATENESS' AND student_id = OLD.student_id AND structure_id = structureId INTO oldAlertId;
+    SELECT event_id FROM presences.alerts WHERE event_id = OLD.id AND type = 'LATENESS' AND student_id = OLD.student_id AND structure_id = register.structure_id INTO oldAlertId;
 
 
     IF oldAlertId IS NOT NULL AND newEventExclude THEN -- If we have previously a alert and now the event is exclude we must delete alert
-        EXECUTE presences.delete_alert(OLD.id, 'LATENESS', OLD.student_id, structureId);
+        EXECUTE presences.delete_alert(OLD.id, 'LATENESS', OLD.student_id, register.structure_id);
     ELSIF oldAlertId IS NULL AND NOT newEventExclude THEN  -- If we have not previously a alert and now the event is not exclude we must create alert
-        EXECUTE presences.create_alert(NEW.id, 'LATENESS', NEW.student_id, structureId);
+        EXECUTE presences.create_alert(NEW.id, 'LATENESS', NEW.student_id, register.structure_id, register.start_date);
     END IF;
     RETURN NEW;
 END
@@ -65,3 +66,19 @@ $BODY$
 -- For each update we need to update associated alert
 CREATE TRIGGER update_lateness_alert BEFORE UPDATE OF reason_id ON presences.event
     FOR EACH ROW WHEN (NEW.type_id = 2) EXECUTE PROCEDURE presences.update_lateness_alert();
+
+
+
+-- Update alert date when forgotten notebook date change
+CREATE FUNCTION presences.update_forgotten_alert() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+BEGIN
+    UPDATE presences.alerts SET date = NEW.date WHERE event_id = NEW.id AND type = 'FORGOTTEN_NOTEBOOK';
+    RETURN NEW;
+END
+$BODY$
+    LANGUAGE plpgsql;
+-- For each update we need to update associated alert
+CREATE TRIGGER update_forgotten_alert BEFORE UPDATE OF date ON presences.forgotten_notebook
+    FOR EACH ROW EXECUTE PROCEDURE presences.update_forgotten_alert();

--- a/presences/src/main/resources/sql/052-MA-987-recalculates-alerts.sql
+++ b/presences/src/main/resources/sql/052-MA-987-recalculates-alerts.sql
@@ -12,7 +12,7 @@ do $$
                 SELECT structure_id FROM presences.register WHERE id = eventItems.register_id INTO structureId;
                 if (eventItems.type_id = 1) THEN
                     existingAbsenceWithAlert = NULL;
-                    SELECT presences.get_id_absence_event_siblings(eventItems, structureId, true) INTO existingAbsenceWithAlert;
+                    SELECT * FROM presences.get_id_absence_event_siblings(eventItems, structureId, true) INTO existingAbsenceWithAlert;
                     IF existingAbsenceWithAlert IS NULL AND NOT presences.absence_exclude_alert(eventItems, structureId) THEN -- If we have no exclude condition and not siblings
                         INSERT INTO presences.alerts(student_id, structure_id, type, event_id, created) VALUES (eventItems.student_id , structureId, 'ABSENCE', eventItems.id, eventItems.created);
                     END IF;


### PR DESCRIPTION
## Describe your changes
Actuellement lorsque l'on enclenche la création d'une alerte, la date associer a l'alerte (date qui sert a la retrouver depuis la page des alertes) est la date de création.
Donc imaginons que nous sommes le 10 janvier, on met un abs pour le 1 janvier. Lorsque l'on va aller sur la page des alertes il y aura une alerte pour le 10 janvier.
Le but de ce ticket c'est de faire en sorte que la date soit noté pour le 1 janvier (date de l'évènement associer).
Il y aura des tests sur la PR MA-770.

## Checklist tests
Crée une absence pour le passer, elle doit générer une alerte pour la date passé.

## Issue ticket number and link
[MA-770](https://jira.support-ent.fr/browse/MA-770)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

