### PR TITLE
fix(npe): fix npe in promise fail in statistics

### DIFF
--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/IndicatorWorker.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/IndicatorWorker.java
@@ -289,9 +289,10 @@ public abstract class IndicatorWorker extends AbstractVerticle {
                             studentId,
                             structureId,
                             indicatorName(),
-                            ar.getCause().getMessage()
+                            ar.getMessage()
                     ));
-                    promise.fail(ar.getCause());
+                    promise.fail(ar.getMessage());
+                    ar.printStackTrace();
                 })
                 .onSuccess(ar -> {
                     log.debug(String.format("[StatisticsPresences@IndicatorWorker::processStudent] Student %s proceed", studentId));


### PR DESCRIPTION
## Describe your changes

Une promise qui plante (via NPE) va aller dans son `onFailure` sauf que la gestion d'erreur renvoie une NPE

## Checklist tests

Par exemple dans notre cas, provoquer une NPE : 

`eb.request(address, null, ...);`
le 2eme param étant un JsonObject, l'eb qui recevra l'action tentera de récuperer le contenu d'un JsonObject alors que ça sera null = NPE
l'API en question `/statistics-presences/structures/:structure/process/students/statistics/tasks` répondra avec une 500

## Issue ticket number and link

https://github.com/OPEN-ENT-NG/presences/issues/162

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

