### PR TITLE
chore(node): change args to specify targeted module

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -90,10 +90,10 @@ publish() {
 presences() {
   case $(uname -s) in
   MINGW*)
-    docker-compose run --rm -u "$USER_UID:$GROUP_GID" node sh -c "npm install --no-bin-links && node_modules/gulp/bin/gulp.js build --module=presences"
+    docker-compose run --rm -u "$USER_UID:$GROUP_GID" node sh -c "npm install --no-bin-links && node_modules/gulp/bin/gulp.js build --targetModule=presences"
     ;;
   *)
-    docker-compose run --rm -u "$USER_UID:$GROUP_GID" node sh -c "npm install && node_modules/gulp/bin/gulp.js build --module=presences"
+    docker-compose run --rm -u "$USER_UID:$GROUP_GID" node sh -c "npm install && node_modules/gulp/bin/gulp.js build --targetModule=presences"
     ;;
   esac
   docker-compose run --rm -u "$USER_UID:$GROUP_GID" gradle gradle :presences:shadowJar :presences:install :presences:publishToMavenLocal
@@ -106,10 +106,10 @@ presences:buildGradle() {
 incidents() {
   case $(uname -s) in
   MINGW*)
-    docker-compose run --rm -u "$USER_UID:$GROUP_GID" node sh -c "npm install --no-bin-links && node_modules/gulp/bin/gulp.js build --module=incidents"
+    docker-compose run --rm -u "$USER_UID:$GROUP_GID" node sh -c "npm install --no-bin-links && node_modules/gulp/bin/gulp.js build --targetModule=incidents"
     ;;
   *)
-    docker-compose run --rm -u "$USER_UID:$GROUP_GID" node sh -c "npm install && node_modules/gulp/bin/gulp.js build --module=incidents"
+    docker-compose run --rm -u "$USER_UID:$GROUP_GID" node sh -c "npm install && node_modules/gulp/bin/gulp.js build --targetModule=incidents"
     ;;
   esac
   docker-compose run --rm -u "$USER_UID:$GROUP_GID" gradle gradle :incidents:shadowJar :incidents:install :incidents:publishToMavenLocal
@@ -122,10 +122,10 @@ incidents:buildGradle() {
 massmailing() {
   case $(uname -s) in
   MINGW*)
-    docker-compose run --rm -u "$USER_UID:$GROUP_GID" node sh -c "npm install --no-bin-links && node_modules/gulp/bin/gulp.js build --module=massmailing"
+    docker-compose run --rm -u "$USER_UID:$GROUP_GID" node sh -c "npm install --no-bin-links && node_modules/gulp/bin/gulp.js build --targetModule=massmailing"
     ;;
   *)
-    docker-compose run --rm -u "$USER_UID:$GROUP_GID" node sh -c "npm install && node_modules/gulp/bin/gulp.js build --module=massmailing"
+    docker-compose run --rm -u "$USER_UID:$GROUP_GID" node sh -c "npm install && node_modules/gulp/bin/gulp.js build --targetModule=massmailing"
     ;;
   esac
   docker-compose run --rm -u "$USER_UID:$GROUP_GID" gradle gradle :massmailing:shadowJar :massmailing:install :massmailing:publishToMavenLocal
@@ -138,10 +138,10 @@ massmailing:buildGradle() {
 statistics() {
   case $(uname -s) in
   MINGW*)
-    docker-compose run --rm -u "$USER_UID:$GROUP_GID" node sh -c "npm install --no-bin-links && node_modules/gulp/bin/gulp.js build --module=statistics-presences"
+    docker-compose run --rm -u "$USER_UID:$GROUP_GID" node sh -c "npm install --no-bin-links && node_modules/gulp/bin/gulp.js build --targetModule=statistics-presences"
     ;;
   *)
-    docker-compose run --rm -u "$USER_UID:$GROUP_GID" node sh -c "npm install && node_modules/gulp/bin/gulp.js build --module=statistics-presences"
+    docker-compose run --rm -u "$USER_UID:$GROUP_GID" node sh -c "npm install && node_modules/gulp/bin/gulp.js build --targetModule=statistics-presences"
     ;;
   esac
   docker-compose run --rm -u "$USER_UID:$GROUP_GID" gradle gradle :statistics:shadowJar :statistics:install :statistics:publishToMavenLocal

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,8 +8,9 @@ var args = require('yargs').argv;
 
 var apps = ['presences', 'incidents', 'massmailing', 'statistics-presences'];
 
-if (args.module) {
-    apps = [args.module];
+if (args.targetModule) {
+    console.log("using arg:", args.targetModule);
+    apps = [args.targetModule];
 }
 
 gulp.task('drop-cache', function () {


### PR DESCRIPTION
## Describe your changes

Voici l'erreur quand on tente de faire un buildNode sur un module précis : 

```
docker-compose run --rm node sh -c "node_modules/gulp/bin/gulp.js build --module=presences"
```

```
/usr/local/bin/node: bad option: --module=presences
[21:40:26] Node flags detected: --module=presences
[21:40:26] Respawned to PID: 17
```
C'est due à la nouvelle version de l'image de node qui est en version 10, le flag `--module` est un flag de node v10 concernant  [compilerOptions](https://www.typescriptlang.org/docs/handbook/esm-node.html) qui peut également être executé en CLI ([--module](https://www.typescriptlang.org/docs/handbook/modules.html#simple-example))

Du coup le `bad option` est justifié car on l'utilise pour un autre besoin (gulpfile arguments)

On utilise un autre nommage pour éviter tout conflit.

## Checklist tests

Relancer la commande node pour faire un gulp build, ne devrait plus générer l'erreur

## Issue ticket number and link

https://github.com/OPEN-ENT-NG/presences/issues/167

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

