### PR TITLE
fix(right): #MA-1008 unrestricted right takes precedence over restricted right

### DIFF
--- a/common/src/main/java/fr/openent/presences/common/security/IWorkflowActionsCouple.java
+++ b/common/src/main/java/fr/openent/presences/common/security/IWorkflowActionsCouple.java
@@ -1,0 +1,46 @@
+package fr.openent.presences.common.security;
+
+import fr.openent.presences.common.helper.WorkflowHelper;
+import org.entcore.common.user.UserInfos;
+
+public interface IWorkflowActionsCouple {
+    String getUnrestrictedAction();
+    String getRestrictedAction();
+
+    /**
+     * @param user User info
+     * @param restrictedCondition Restriction condition
+     * @return true if user has unrestricted right or if user has restricted right AND restrictedCondition is true
+     */
+    default boolean hasRight(UserInfos user, Boolean restrictedCondition) {
+        return WorkflowHelper.hasRight(user, this.getUnrestrictedAction()) ||
+                (WorkflowHelper.hasRight(user, this.getRestrictedAction()) && Boolean.TRUE.equals(restrictedCondition));
+    }
+
+    /**
+     * @param user User info
+     * @return true if user has unrestricted right or if user has restricted right
+     */
+    default boolean hasRight(UserInfos user) {
+        return hasRight(user, true);
+    }
+
+    /**
+     * @param user User info
+     * @param restrictedCondition Restriction condition
+     * @return true if user don't have unrestricted right and user has restricted right and restrictedCondition is true
+     */
+    default boolean hasOnlyRestrictedRight(UserInfos user, Boolean restrictedCondition) {
+        return !WorkflowHelper.hasRight(user, this.getUnrestrictedAction())
+                && WorkflowHelper.hasRight(user, this.getRestrictedAction())
+                && Boolean.TRUE.equals(restrictedCondition);
+    }
+
+    /**
+     * @param user User info
+     * @return true if user don't have unrestricted right and user has restricted right
+     */
+    default boolean hasOnlyRestrictedRight(UserInfos user) {
+        return hasOnlyRestrictedRight(user, true);
+    }
+}

--- a/common/src/test/java/fr/openent/presences/common/security/IWorkflowActionsCoupleTest.java
+++ b/common/src/test/java/fr/openent/presences/common/security/IWorkflowActionsCoupleTest.java
@@ -1,0 +1,75 @@
+package fr.openent.presences.common.security;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.entcore.common.user.UserInfos;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+@RunWith(VertxUnitRunner.class)
+public class IWorkflowActionsCoupleTest {
+    enum WorkflowActionsCoupleTest implements IWorkflowActionsCouple {
+        SEARCH("unrestricted", "restricted");
+
+        private final String unrestricted;
+        private final String restricted;
+        WorkflowActionsCoupleTest(String unrestricted, String restricted) {
+            this.restricted = restricted;
+            this.unrestricted = unrestricted;
+        }
+
+        @Override
+        public String getUnrestrictedAction() {
+            return unrestricted;
+        }
+
+        @Override
+        public String getRestrictedAction() {
+            return restricted;
+        }
+    }
+
+    UserInfos userInfosUnrestricted = new UserInfos();
+    UserInfos userInfosRestricted = new UserInfos();
+    UserInfos userInfosBoth = new UserInfos();
+    UserInfos userInfosNone = new UserInfos();
+
+    @Before
+    public void setUp() {
+        UserInfos.Action searchUnrestricted = new UserInfos.Action();
+        searchUnrestricted.setDisplayName("unrestricted");
+        UserInfos.Action searchRestricted = new UserInfos.Action();
+        searchRestricted.setDisplayName("restricted");
+
+        userInfosUnrestricted.setAuthorizedActions(Collections.singletonList(searchUnrestricted));
+        userInfosRestricted.setAuthorizedActions(Collections.singletonList(searchRestricted));
+        userInfosBoth.setAuthorizedActions(Arrays.asList(searchRestricted, searchUnrestricted));
+        userInfosNone.setAuthorizedActions(Collections.emptyList());
+    }
+
+    @Test
+    public void testHasRight(TestContext ctx) {
+        ctx.assertTrue(WorkflowActionsCoupleTest.SEARCH.hasRight(userInfosUnrestricted));
+        ctx.assertTrue(WorkflowActionsCoupleTest.SEARCH.hasRight(userInfosRestricted));
+        ctx.assertTrue(WorkflowActionsCoupleTest.SEARCH.hasRight(userInfosBoth));
+        ctx.assertFalse(WorkflowActionsCoupleTest.SEARCH.hasRight(userInfosNone));
+
+        ctx.assertFalse(WorkflowActionsCoupleTest.SEARCH.hasRight(userInfosRestricted, false));
+        ctx.assertTrue(WorkflowActionsCoupleTest.SEARCH.hasRight(userInfosUnrestricted, false));
+    }
+
+    @Test
+    public void testHasOnlyRestrictedRight(TestContext ctx) {
+        ctx.assertFalse(WorkflowActionsCoupleTest.SEARCH.hasOnlyRestrictedRight(userInfosUnrestricted));
+        ctx.assertTrue(WorkflowActionsCoupleTest.SEARCH.hasOnlyRestrictedRight(userInfosRestricted));
+        ctx.assertFalse(WorkflowActionsCoupleTest.SEARCH.hasOnlyRestrictedRight(userInfosBoth));
+        ctx.assertFalse(WorkflowActionsCoupleTest.SEARCH.hasOnlyRestrictedRight(userInfosNone));
+
+        ctx.assertFalse(WorkflowActionsCoupleTest.SEARCH.hasOnlyRestrictedRight(userInfosRestricted, false));
+        ctx.assertFalse(WorkflowActionsCoupleTest.SEARCH.hasOnlyRestrictedRight(userInfosUnrestricted, false));
+    }
+}

--- a/massmailing/src/main/java/fr/openent/massmailing/actions/WorkflowActionsCouple.java
+++ b/massmailing/src/main/java/fr/openent/massmailing/actions/WorkflowActionsCouple.java
@@ -1,0 +1,27 @@
+package fr.openent.massmailing.actions;
+
+import fr.openent.presences.common.security.IWorkflowActionsCouple;
+
+public enum WorkflowActionsCouple implements IWorkflowActionsCouple {
+
+    VIEW(WorkflowActions.VIEW, WorkflowActions.VIEW_RESTRICTED),
+    MANAGE(WorkflowActions.MANAGE, WorkflowActions.MANAGE_RESTRICTED);
+
+    private final WorkflowActions unrestrictedAction;
+    private final WorkflowActions restrictedAction;
+
+    WorkflowActionsCouple(WorkflowActions unrestrictedAction, WorkflowActions restrictedAction) {
+        this.unrestrictedAction = unrestrictedAction;
+        this.restrictedAction = restrictedAction;
+    }
+
+    @Override
+    public String getUnrestrictedAction() {
+        return unrestrictedAction.name();
+    }
+
+    @Override
+    public String getRestrictedAction() {
+        return restrictedAction.name();
+    }
+}

--- a/massmailing/src/main/java/fr/openent/massmailing/controller/MailingController.java
+++ b/massmailing/src/main/java/fr/openent/massmailing/controller/MailingController.java
@@ -65,9 +65,8 @@ public class MailingController extends ControllerHelper {
 
 
         UserUtils.getUserInfos(eb, request, userInfos -> {
-
-            String teacherId = (WorkflowHelper.hasRight(userInfos, WorkflowActions.VIEW_RESTRICTED.toString())
-                    && UserType.TEACHER.equals(userInfos.getType())) ? userInfos.getUserId() : null;
+            boolean hasRestrictedRight = WorkflowActionsCouple.VIEW.hasOnlyRestrictedRight(userInfos, UserType.TEACHER.equals(userInfos.getType()));
+            String teacherId = hasRestrictedRight ? userInfos.getUserId() : null;
 
             Future<List<String>> studentsFromTeacherFuture = this.userService.getStudentsFromTeacher(teacherId, structureId);
             Future<JsonArray> groupStudentsFuture = this.groupService.getGroupStudents(groupsIds);

--- a/massmailing/src/main/java/fr/openent/massmailing/controller/MassmailingController.java
+++ b/massmailing/src/main/java/fr/openent/massmailing/controller/MassmailingController.java
@@ -235,10 +235,8 @@ public class MassmailingController extends ControllerHelper {
 
     private void processStudents(HttpServerRequest request, Handler<Either<String, List<String>>> handler) {
         UserUtils.getUserInfos(eb, request, userInfos -> {
-
-            String teacherId = (WorkflowHelper.hasRight(userInfos, WorkflowActions.MANAGE_RESTRICTED.toString())
-                    && UserType.TEACHER.equals(userInfos.getType())) ?
-                    userInfos.getUserId() : null;
+            boolean hasRestrictedRight = WorkflowActionsCouple.MANAGE.hasOnlyRestrictedRight(userInfos, UserType.TEACHER.equals(userInfos.getType()));
+            String teacherId = hasRestrictedRight ? userInfos.getUserId() : null;
 
             String structureId = request.getParam(Field.STRUCTURE);
 

--- a/massmailing/src/main/java/fr/openent/massmailing/security/BodyCanAccessMassMailing.java
+++ b/massmailing/src/main/java/fr/openent/massmailing/security/BodyCanAccessMassMailing.java
@@ -1,8 +1,7 @@
 package fr.openent.massmailing.security;
 
-import fr.openent.massmailing.actions.WorkflowActions;
-import fr.openent.presences.common.helper.WorkflowHelper;
-import fr.openent.presences.core.constants.*;
+import fr.openent.massmailing.actions.WorkflowActionsCouple;
+import fr.openent.presences.core.constants.Field;
 import fr.wseduc.webutils.http.Binding;
 import fr.wseduc.webutils.request.RequestUtils;
 import io.vertx.core.Handler;
@@ -18,9 +17,7 @@ public class BodyCanAccessMassMailing implements ResourcesProvider {
         RequestUtils.bodyToJson(request, body -> {
             String structureId = body.getString(Field.STRUCTURE);
             List<String> structures = userInfos.getStructures();
-            handler.handle(structures.contains(structureId) &&
-                    (WorkflowHelper.hasRight(userInfos, WorkflowActions.VIEW.toString())
-                    || WorkflowHelper.hasRight(userInfos, WorkflowActions.VIEW_RESTRICTED.toString())));
+            handler.handle(structures.contains(structureId) && WorkflowActionsCouple.VIEW.hasRight(userInfos));
         });
     }
 }

--- a/massmailing/src/main/java/fr/openent/massmailing/security/CanAccessMassMailing.java
+++ b/massmailing/src/main/java/fr/openent/massmailing/security/CanAccessMassMailing.java
@@ -1,8 +1,7 @@
 package fr.openent.massmailing.security;
 
-import fr.openent.massmailing.actions.WorkflowActions;
-import fr.openent.presences.common.helper.WorkflowHelper;
-import fr.openent.presences.core.constants.*;
+import fr.openent.massmailing.actions.WorkflowActionsCouple;
+import fr.openent.presences.core.constants.Field;
 import fr.wseduc.webutils.http.Binding;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
@@ -16,8 +15,6 @@ public class CanAccessMassMailing implements ResourcesProvider {
     public void authorize(HttpServerRequest request, Binding binding, UserInfos userInfos, Handler<Boolean> handler) {
         String structureId = request.getParam(Field.STRUCTURE);
         List<String> structures = userInfos.getStructures();
-        handler.handle(structures.contains(structureId)
-                && (WorkflowHelper.hasRight(userInfos, WorkflowActions.VIEW.toString())
-                    || WorkflowHelper.hasRight(userInfos, WorkflowActions.VIEW_RESTRICTED.toString())));
+        handler.handle(structures.contains(structureId) && WorkflowActionsCouple.MANAGE.hasRight(userInfos));
     }
 }

--- a/presences/src/main/java/fr/openent/presences/Presences.java
+++ b/presences/src/main/java/fr/openent/presences/Presences.java
@@ -1,6 +1,6 @@
 package fr.openent.presences;
 
-import fr.openent.presences.common.export.*;
+import fr.openent.presences.common.export.ExportData;
 import fr.openent.presences.common.incidents.Incidents;
 import fr.openent.presences.common.massmailing.Massmailing;
 import fr.openent.presences.common.statistics_presences.StatisticsPresences;
@@ -12,7 +12,10 @@ import fr.openent.presences.cron.CreateDailyRegistersTask;
 import fr.openent.presences.db.DB;
 import fr.openent.presences.event.PresencesRepositoryEvents;
 import fr.openent.presences.service.CommonPresencesServiceFactory;
-import fr.openent.presences.worker.*;
+import fr.openent.presences.worker.CreateDailyPresenceWorker;
+import fr.openent.presences.worker.EventExportWorker;
+import fr.openent.presences.worker.PresencesExportWorker;
+import fr.openent.presences.worker.ResetAlertsWorker;
 import fr.wseduc.cron.CronTrigger;
 import fr.wseduc.mongodb.MongoDb;
 import io.vertx.core.DeploymentOptions;
@@ -26,8 +29,6 @@ import org.entcore.common.storage.Storage;
 import org.entcore.common.storage.StorageFactory;
 
 import java.text.ParseException;
-
-import static fr.wseduc.webutils.Utils.handlerToAsyncHandler;
 
 public class Presences extends BaseServer {
 

--- a/presences/src/main/java/fr/openent/presences/controller/AbsenceController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/AbsenceController.java
@@ -1,12 +1,12 @@
 package fr.openent.presences.controller;
 
-import fr.openent.presences.common.helper.WorkflowHelper;
 import fr.openent.presences.common.security.UserInStructure;
 import fr.openent.presences.constants.Actions;
 import fr.openent.presences.core.constants.Field;
+import fr.openent.presences.core.constants.UserType;
 import fr.openent.presences.enums.EventType;
 import fr.openent.presences.enums.Markers;
-import fr.openent.presences.enums.WorkflowActions;
+import fr.openent.presences.enums.WorkflowActionsCouple;
 import fr.openent.presences.export.AbsencesCSVExport;
 import fr.openent.presences.security.AbsenceRight;
 import fr.openent.presences.security.CreateEventRight;
@@ -244,9 +244,8 @@ public class AbsenceController extends ControllerHelper {
         Integer page = request.getParam(Field.PAGE) != null ? Integer.parseInt(request.getParam(Field.PAGE)) : null;
 
         UserUtils.getUserInfos(eb, request, user -> {
-            String teacherId = (WorkflowHelper.hasRight(user, WorkflowActions.READ_EVENT_RESTRICTED.toString())
-                    && "Teacher".equals(user.getType())) ?
-                    user.getUserId() : null;
+            boolean hasRestrictedRight = WorkflowActionsCouple.READ_EVENT.hasOnlyRestrictedRight(user, UserType.TEACHER.equals(user.getType()));
+            String teacherId = hasRestrictedRight ? user.getUserId() : null;
 
             absenceService
                     .get(structure, teacherId, classes, students, reasons, start, end, (regularized != null ? regularized : justified),
@@ -321,9 +320,8 @@ public class AbsenceController extends ControllerHelper {
                 .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
 
         UserUtils.getUserInfos(eb, request, user -> {
-            String teacherId = (WorkflowHelper.hasRight(user, WorkflowActions.READ_EVENT_RESTRICTED.toString())
-                    && "Teacher".equals(user.getType())) ?
-                    user.getUserId() : null;
+            boolean hasRestrictedRight = WorkflowActionsCouple.READ_EVENT.hasOnlyRestrictedRight(user, UserType.TEACHER.equals(user.getType()));
+            String teacherId = hasRestrictedRight ? user.getUserId() : null;
 
             String domain = Renders.getHost(request);
             String local = I18n.acceptLanguage(request);
@@ -369,9 +367,8 @@ public class AbsenceController extends ControllerHelper {
                 .collect(ArrayList::new, ArrayList::add, ArrayList::addAll);
 
         UserUtils.getUserInfos(eb, request, user -> {
-            String teacherId = (WorkflowHelper.hasRight(user, WorkflowActions.READ_EVENT_RESTRICTED.toString())
-                    && "Teacher".equals(user.getType())) ?
-                    user.getUserId() : null;
+            boolean hasRestrictedRight = WorkflowActionsCouple.READ_EVENT.hasOnlyRestrictedRight(user, UserType.TEACHER.equals(user.getType()));
+            String teacherId = hasRestrictedRight ? user.getUserId() : null;
 
             String domain = Renders.getHost(request);
             String local = I18n.acceptLanguage(request);

--- a/presences/src/main/java/fr/openent/presences/controller/ExemptionController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/ExemptionController.java
@@ -3,7 +3,6 @@ package fr.openent.presences.controller;
 import fr.openent.presences.Presences;
 import fr.openent.presences.common.helper.*;
 import fr.openent.presences.common.service.*;
-import fr.openent.presences.common.service.impl.*;
 import fr.openent.presences.constants.Actions;
 import fr.openent.presences.core.constants.*;
 import fr.openent.presences.enums.*;
@@ -12,14 +11,11 @@ import fr.openent.presences.model.Exemption.ExemptionBody;
 import fr.openent.presences.security.ExportRight;
 import fr.openent.presences.security.ManageExemptionRight;
 import fr.openent.presences.service.*;
-import fr.openent.presences.service.impl.DefaultExemptionService;
 import fr.wseduc.rs.*;
 import fr.wseduc.security.ActionType;
 import fr.wseduc.security.SecuredAction;
-import fr.wseduc.webutils.Either;
 import fr.wseduc.webutils.request.RequestUtils;
 import io.vertx.core.*;
-import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -88,9 +84,8 @@ public class ExemptionController extends ControllerHelper {
                 ? new ArrayList<>(Arrays.asList(request.getParam(Field.AUDIENCE_ID).split("\\s*,\\s*"))) : null;
 
         UserUtils.getUserInfos(eb, request, user -> {
-            String restrictedTeacherId = (WorkflowHelper.hasRight(user,
-                    WorkflowActions.READ_EXEMPTION_RESTRICTED.toString()) && UserType.TEACHER.equals(user.getType())) ?
-                    user.getUserId() : null;
+            boolean hasRestrictedRight = WorkflowActionsCouple.READ_EXEMPTION.hasOnlyRestrictedRight(user, UserType.TEACHER.equals(user.getType()));
+            String restrictedTeacherId = hasRestrictedRight ? user.getUserId() : null;
 
             //get class's users
             this.userService.getStudentsFromTeacher(restrictedTeacherId, structureId)
@@ -225,9 +220,8 @@ public class ExemptionController extends ControllerHelper {
     public void createExemptions(final HttpServerRequest request) {
         RequestUtils.bodyToJson(request, pathPrefix + "exemption", exemptions ->
                 UserUtils.getUserInfos(eb, request, user -> {
-                    String restrictedTeacherId = (WorkflowHelper.hasRight(user,
-                            WorkflowActions.MANAGE_EXEMPTION_RESTRICTED.toString()) && UserType.TEACHER.equals(user.getType())) ?
-                            user.getUserId() : null;
+                    boolean hasRestrictedRight = WorkflowActionsCouple.MANAGE_EXEMPTION.hasOnlyRestrictedRight(user, UserType.TEACHER.equals(user.getType()));
+                    String restrictedTeacherId = hasRestrictedRight ? user.getUserId() : null;
 
                     ExemptionBody exemptionBody = new ExemptionBody(exemptions);
 
@@ -265,9 +259,8 @@ public class ExemptionController extends ControllerHelper {
         RequestUtils.bodyToJson(request, pathPrefix + "exemption", exemption -> {
 
             UserUtils.getUserInfos(eb, request, user -> {
-                String restrictedTeacherId = (WorkflowHelper.hasRight(user,
-                        WorkflowActions.MANAGE_EXEMPTION_RESTRICTED.toString()) && UserType.TEACHER.equals(user.getType())) ?
-                        user.getUserId() : null;
+                boolean hasRestrictedRight = WorkflowActionsCouple.MANAGE_EXEMPTION.hasOnlyRestrictedRight(user, UserType.TEACHER.equals(user.getType()));
+                String restrictedTeacherId = hasRestrictedRight ? user.getUserId() : null;
 
                 ExemptionBody exemptionBody = new ExemptionBody(exemption);
                 Integer id = Integer.parseInt(request.params().get(Field.ID));

--- a/presences/src/main/java/fr/openent/presences/controller/SearchController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/SearchController.java
@@ -1,7 +1,6 @@
 package fr.openent.presences.controller;
 
 import fr.openent.presences.Presences;
-import fr.openent.presences.common.helper.*;
 import fr.openent.presences.common.service.GroupService;
 import fr.openent.presences.common.service.UserService;
 import fr.openent.presences.common.service.impl.DefaultGroupService;
@@ -56,10 +55,8 @@ public class SearchController extends ControllerHelper {
                 && request.params().contains(Field.STRUCTUREID)) {
 
             UserUtils.getUserInfos(eb, request, user -> {
-
-                String restrictedTeacherId = (WorkflowHelper.hasRight(user,
-                        WorkflowActions.SEARCH_RESTRICTED.toString()) && UserType.TEACHER.equals(user.getType())) ?
-                        user.getUserId() : null;
+                boolean hasRestrictedRight = WorkflowActionsCouple.SEARCH.hasOnlyRestrictedRight(user, UserType.TEACHER.equals(user.getType()));
+                String restrictedTeacherId = hasRestrictedRight ? user.getUserId() : null;
 
                 String query = request.getParam(Field.Q);
                 List<String> fields = request.params().getAll(Field.FIELD);
@@ -89,9 +86,8 @@ public class SearchController extends ControllerHelper {
     @ResourceFilter(SearchStudents.class)
     public void searchStudents(HttpServerRequest request) {
         UserUtils.getUserInfos(eb, request, user -> {
-            String userId = (WorkflowHelper.hasRight(user, WorkflowActions.SEARCH_RESTRICTED.toString())
-                    && UserType.TEACHER.equals(user.getType())) ?
-                    user.getUserId() : null;
+            boolean hasRight = WorkflowActionsCouple.SEARCH.hasOnlyRestrictedRight(user, UserType.TEACHER.equals(user.getType()));
+            String userId = hasRight ? user.getUserId() : null;
         if (request.params().contains(Field.Q) && !"".equals(request.params().get(Field.Q).trim())
                 && request.params().contains(Field.FIELD)
                 && request.params().contains(Field.STRUCTUREID)) {
@@ -118,9 +114,8 @@ public class SearchController extends ControllerHelper {
     @ResourceFilter(SearchStudents.class)
     public void searchGroups(HttpServerRequest request) {
         UserUtils.getUserInfos(eb, request, user -> {
-            String userId = (WorkflowHelper.hasRight(user, WorkflowActions.SEARCH_RESTRICTED.toString())
-                            && UserType.TEACHER.equals(user.getType())) ?
-                    user.getUserId() : null;
+            boolean hasRestrictedRight = WorkflowActionsCouple.SEARCH.hasOnlyRestrictedRight(user, UserType.TEACHER.equals(user.getType()));
+            String userId = hasRestrictedRight ? user.getUserId() : null;
             if (request.params().contains(Field.Q)
                     && !"".equals(request.params().get(Field.Q).trim())
                     && request.params().contains(Field.FIELD)
@@ -141,9 +136,8 @@ public class SearchController extends ControllerHelper {
     @SecuredAction(Presences.SEARCH_STUDENTS)
     public void search(HttpServerRequest request) {
         UserUtils.getUserInfos(eb, request, user -> {
-            String userId = (WorkflowHelper.hasRight(user, WorkflowActions.SEARCH_RESTRICTED.toString())
-                    && UserType.TEACHER.equals(user.getType())) ?
-                    user.getUserId() : null;
+            boolean hasRestrictedRight = WorkflowActionsCouple.SEARCH_STUDENTS.hasOnlyRestrictedRight(user, UserType.TEACHER.equals(user.getType()));
+            String userId = hasRestrictedRight ? user.getUserId() : null;
 
             if (request.params().contains(Field.Q) && !"".equals(request.params().get(Field.Q).trim())
                     && request.params().contains(Field.STRUCTUREID)) {

--- a/presences/src/main/java/fr/openent/presences/controller/StatementAbsenceController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/StatementAbsenceController.java
@@ -58,12 +58,10 @@ public class StatementAbsenceController extends ControllerHelper {
     @SecuredAction(value = "", type = ActionType.RESOURCE)
     public void get(HttpServerRequest request) {
         UserUtils.getUserInfos(eb, request, user -> {
-
             String structureId = request.getParam(Field.STRUCTURE_ID);
 
-            String teacherId = (WorkflowHelper.hasRight(user, WorkflowActions.MANAGE_ABSENCE_STATEMENTS_RESTRICTED.toString())
-                    && "Teacher".equals(user.getType())) ?
-                    user.getUserId() : null;
+            boolean hasRestrictedRight = WorkflowActionsCouple.MANAGE_ABSENCE_STATEMENTS.hasOnlyRestrictedRight(user, UserType.TEACHER.equals(user.getType()));
+            String teacherId = hasRestrictedRight ? user.getUserId() : null;
 
             this.userService.getStudentsFromTeacher(teacherId, structureId)
                     .onFailure(fail -> renderError(request))
@@ -84,12 +82,10 @@ public class StatementAbsenceController extends ControllerHelper {
     @SecuredAction(value = "", type = ActionType.RESOURCE)
     public void export(HttpServerRequest request) {
         UserUtils.getUserInfos(eb, request, user -> {
-
             String structureId = request.getParam(Field.STRUCTURE_ID);
 
-            String teacherId = (WorkflowHelper.hasRight(user, WorkflowActions.MANAGE_ABSENCE_STATEMENTS_RESTRICTED.toString())
-                    && "Teacher".equals(user.getType())) ?
-                    user.getUserId() : null;
+            boolean hasRestrictedRight = WorkflowActionsCouple.MANAGE_ABSENCE_STATEMENTS.hasOnlyRestrictedRight(user, UserType.TEACHER.equals(user.getType()));
+            String teacherId = hasRestrictedRight ? user.getUserId() : null;
 
             this.userService.getStudentsFromTeacher(teacherId, structureId)
                     .onFailure(fail -> renderError(request))

--- a/presences/src/main/java/fr/openent/presences/controller/events/EventController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/events/EventController.java
@@ -94,11 +94,8 @@ public class EventController extends ControllerHelper {
 
 
         UserUtils.getUserInfos(eb, request, userInfos -> {
-
-            String teacherId = (WorkflowHelper.hasRight(userInfos, WorkflowActions.READ_EVENT_RESTRICTED.toString())
-                    && "Teacher".equals(userInfos.getType())) ?
-                    userInfos.getUserId() : null;
-
+            boolean hasRestrictedRight = WorkflowActionsCouple.READ_EVENT.hasOnlyRestrictedRight(userInfos, UserType.TEACHER.equals(userInfos.getType()));
+            String teacherId = hasRestrictedRight ? userInfos.getUserId() : null;
 
             this.groupService.getGroupsAndClassesFromTeacherId(teacherId, structureId)
                     .onFailure(fail -> renderError(request, JsonObject.mapFrom(fail.getMessage())))
@@ -172,11 +169,9 @@ public class EventController extends ControllerHelper {
 
 
         UserUtils.getUserInfos(eb, request, userInfos -> {
-
-            String teacherId = (WorkflowHelper.hasRight(userInfos, WorkflowActions.READ_EVENT_RESTRICTED.toString())
-                    && "Teacher".equals(userInfos.getType())) ?
-                    userInfos.getUserId() : null;
-            Boolean canSeeAllStudent = teacherId == null;
+            boolean hasRestrictedRight = WorkflowActionsCouple.READ_EVENT.hasOnlyRestrictedRight(userInfos, UserType.TEACHER.equals(userInfos.getType()));
+            String teacherId = hasRestrictedRight ? userInfos.getUserId() : null;
+            Boolean canSeeAllStudent = !hasRestrictedRight;
 
             this.groupService.getGroupsAndClassesFromTeacherId(teacherId, structureId)
                     .onFailure(fail -> renderError(request, JsonObject.mapFrom(fail.getMessage())))
@@ -287,10 +282,8 @@ public class EventController extends ControllerHelper {
         Boolean followed = request.params().contains(Field.FOLLOWED) ? Boolean.parseBoolean(request.getParam(Field.FOLLOWED)) : null;
 
         UserUtils.getUserInfos(eb, request, userInfos -> {
-
-            String teacherId = (WorkflowHelper.hasRight(userInfos, WorkflowActions.READ_EVENT_RESTRICTED.toString())
-                    && "Teacher".equals(userInfos.getType())) ?
-                    userInfos.getUserId() : null;
+            boolean hasRestrictedRight = WorkflowActionsCouple.READ_EVENT.hasOnlyRestrictedRight(userInfos, UserType.TEACHER.equals(userInfos.getType()));
+            String teacherId = hasRestrictedRight ? userInfos.getUserId() : null;
 
             this.groupService.getGroupsAndClassesFromTeacherId(teacherId, structureId)
                     .onFailure(fail -> renderError(request, JsonObject.mapFrom(fail.getMessage())))

--- a/presences/src/main/java/fr/openent/presences/enums/WorkflowActions.java
+++ b/presences/src/main/java/fr/openent/presences/enums/WorkflowActions.java
@@ -34,6 +34,7 @@ public enum WorkflowActions {
     REGISTRY(Presences.REGISTRY),
     INIT_SETTINGS_1D(Presences.INIT_SETTINGS_1D),
     INIT_SETTINGS_2D(Presences.INIT_SETTINGS_2D),
+    READ_EXEMPTION(Presences.READ_EXEMPTION),
     READ_EXEMPTION_RESTRICTED(Presences.READ_EXEMPTION_RESTRICTED);
 
     private final String actionName;

--- a/presences/src/main/java/fr/openent/presences/enums/WorkflowActionsCouple.java
+++ b/presences/src/main/java/fr/openent/presences/enums/WorkflowActionsCouple.java
@@ -1,0 +1,31 @@
+package fr.openent.presences.enums;
+
+import fr.openent.presences.common.security.IWorkflowActionsCouple;
+
+public enum WorkflowActionsCouple implements IWorkflowActionsCouple {
+
+    READ_EVENT(WorkflowActions.READ_EVENT, WorkflowActions.READ_EVENT_RESTRICTED),
+    MANAGE_ABSENCE_STATEMENTS(WorkflowActions.MANAGE_ABSENCE_STATEMENTS, WorkflowActions.MANAGE_ABSENCE_STATEMENTS_RESTRICTED),
+    MANAGE_EXEMPTION(WorkflowActions.MANAGE_EXEMPTION, WorkflowActions.MANAGE_EXEMPTION_RESTRICTED),
+    READ_EXEMPTION(WorkflowActions.READ_EXEMPTION, WorkflowActions.READ_EXEMPTION_RESTRICTED),
+    SEARCH_STUDENTS(WorkflowActions.SEARCH_STUDENTS, WorkflowActions.SEARCH_RESTRICTED),
+    SEARCH(WorkflowActions.SEARCH, WorkflowActions.SEARCH_RESTRICTED);
+
+    private final WorkflowActions unrestrictedAction;
+    private final WorkflowActions restrictedAction;
+
+    WorkflowActionsCouple(WorkflowActions unrestrictedAction, WorkflowActions restrictedAction) {
+        this.unrestrictedAction = unrestrictedAction;
+        this.restrictedAction = restrictedAction;
+    }
+
+    @Override
+    public String getUnrestrictedAction() {
+        return unrestrictedAction.name();
+    }
+
+    @Override
+    public String getRestrictedAction() {
+        return restrictedAction.name();
+    }
+}

--- a/presences/src/main/java/fr/openent/presences/security/AbsenceStatementsViewRight.java
+++ b/presences/src/main/java/fr/openent/presences/security/AbsenceStatementsViewRight.java
@@ -2,6 +2,7 @@ package fr.openent.presences.security;
 
 import fr.openent.presences.common.helper.WorkflowHelper;
 import fr.openent.presences.core.constants.*;
+import fr.openent.presences.enums.WorkflowActionsCouple;
 import fr.openent.presences.enums.WorkflowActions;
 import fr.wseduc.webutils.http.Binding;
 import io.vertx.core.Handler;
@@ -15,8 +16,7 @@ public class AbsenceStatementsViewRight implements ResourcesProvider {
     @Override
     public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
         List<String> studentIds = request.params().getAll(Field.STUDENT_ID);
-        boolean result = WorkflowHelper.hasRight(user, WorkflowActions.MANAGE_ABSENCE_STATEMENTS.toString()) ||
-                WorkflowHelper.hasRight(user, WorkflowActions.MANAGE_ABSENCE_STATEMENTS_RESTRICTED.toString()) ||
+        boolean result = WorkflowActionsCouple.MANAGE_ABSENCE_STATEMENTS.hasRight(user) ||
                 (WorkflowHelper.hasRight(user, WorkflowActions.ABSENCE_STATEMENTS_VIEW.toString())
                         && request.params().size() > 0 && (!studentIds.isEmpty())
                         && studentIds.stream()

--- a/presences/src/main/java/fr/openent/presences/security/Event/EventReadRight.java
+++ b/presences/src/main/java/fr/openent/presences/security/Event/EventReadRight.java
@@ -1,7 +1,6 @@
 package fr.openent.presences.security.Event;
 
-import fr.openent.presences.common.helper.WorkflowHelper;
-import fr.openent.presences.enums.WorkflowActions;
+import fr.openent.presences.enums.WorkflowActionsCouple;
 import fr.wseduc.webutils.http.Binding;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
@@ -11,8 +10,7 @@ import org.entcore.common.user.UserInfos;
 public class EventReadRight implements ResourcesProvider {
     @Override
     public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
-        handler.handle(WorkflowHelper.hasRight(user, WorkflowActions.READ_EVENT.toString()) ||
-                WorkflowHelper.hasRight(user, WorkflowActions.READ_EVENT_RESTRICTED.toString()));
+        handler.handle(WorkflowActionsCouple.READ_EVENT.hasRight(user));
     }
 }
 

--- a/presences/src/main/java/fr/openent/presences/security/ManageExemptionRight.java
+++ b/presences/src/main/java/fr/openent/presences/security/ManageExemptionRight.java
@@ -1,7 +1,6 @@
 package fr.openent.presences.security;
 
-import fr.openent.presences.common.helper.WorkflowHelper;
-import fr.openent.presences.enums.WorkflowActions;
+import fr.openent.presences.enums.WorkflowActionsCouple;
 import fr.wseduc.webutils.http.Binding;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
@@ -11,7 +10,6 @@ import org.entcore.common.user.UserInfos;
 public class ManageExemptionRight implements ResourcesProvider {
     @Override
     public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
-        handler.handle(WorkflowHelper.hasRight(user, WorkflowActions.MANAGE_EXEMPTION.toString())
-        || WorkflowHelper.hasRight(user, WorkflowActions.MANAGE_EXEMPTION_RESTRICTED.toString()));
+        handler.handle(WorkflowActionsCouple.MANAGE_EXEMPTION.hasRight(user));
     }
 }

--- a/presences/src/main/java/fr/openent/presences/security/SearchRight.java
+++ b/presences/src/main/java/fr/openent/presences/security/SearchRight.java
@@ -1,17 +1,15 @@
 package fr.openent.presences.security;
 
-import fr.openent.presences.common.helper.*;
-import fr.openent.presences.enums.*;
-import fr.wseduc.webutils.http.*;
-import io.vertx.core.*;
-import io.vertx.core.http.*;
-import org.entcore.common.http.filter.*;
-import org.entcore.common.user.*;
+import fr.openent.presences.enums.WorkflowActionsCouple;
+import fr.wseduc.webutils.http.Binding;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import org.entcore.common.http.filter.ResourcesProvider;
+import org.entcore.common.user.UserInfos;
 
 public class SearchRight implements ResourcesProvider {
     @Override
     public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
-        handler.handle(WorkflowHelper.hasRight(user, WorkflowActions.SEARCH.toString())
-                || WorkflowHelper.hasRight(user, WorkflowActions.SEARCH_RESTRICTED.toString()));
+        handler.handle(WorkflowActionsCouple.SEARCH.hasRight(user));
     }
 }

--- a/presences/src/main/java/fr/openent/presences/security/SearchStudents.java
+++ b/presences/src/main/java/fr/openent/presences/security/SearchStudents.java
@@ -1,7 +1,6 @@
 package fr.openent.presences.security;
 
-import fr.openent.presences.common.helper.WorkflowHelper;
-import fr.openent.presences.enums.WorkflowActions;
+import fr.openent.presences.enums.WorkflowActionsCouple;
 import fr.wseduc.webutils.http.Binding;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
@@ -11,7 +10,6 @@ import org.entcore.common.user.UserInfos;
 public class SearchStudents implements ResourcesProvider {
     @Override
     public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
-        handler.handle(WorkflowHelper.hasRight(user, WorkflowActions.SEARCH_STUDENTS.toString())
-                || WorkflowHelper.hasRight(user, WorkflowActions.SEARCH_RESTRICTED.toString()));
+        handler.handle(WorkflowActionsCouple.SEARCH_STUDENTS.hasRight(user));
     }
 }

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/controller/StatisticsController.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/controller/StatisticsController.java
@@ -169,10 +169,8 @@ public class StatisticsController extends ControllerHelper {
         Promise<Void> promise = Promise.promise();
 
         UserUtils.getUserInfos(eb, request, userInfos -> {
-            String restrictedTeacherId = (WorkflowHelper.hasRight(userInfos,
-                    WorkflowActions.STATISTICS_PRESENCES_VIEW_RESTRICTED.toString())
-                    && UserType.TEACHER.equals(userInfos.getType())) ?
-                    userInfos.getUserId() : null;
+            boolean hasRestrictedRight = WorkflowActionsCouple.STATISTICS_PRESENCES_VIEW.hasOnlyRestrictedRight(userInfos, UserType.TEACHER.equals(userInfos.getType()));
+            String restrictedTeacherId = hasRestrictedRight ? userInfos.getUserId() : null;
 
             Future<List<String>> restrictedClassesFuture = serviceFactory.groupService()
                     .getGroupsAndClassesFromTeacherId(restrictedTeacherId, request.getParam(Field.STRUCTURE));

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/controller/security/UserInStructure.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/controller/security/UserInStructure.java
@@ -3,6 +3,7 @@ package fr.openent.statistics_presences.controller.security;
 import fr.openent.presences.common.helper.WorkflowHelper;
 import fr.openent.presences.core.constants.*;
 import fr.openent.statistics_presences.enums.WorkflowActions;
+import fr.openent.statistics_presences.enums.WorkflowActionsCouple;
 import fr.wseduc.webutils.http.Binding;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpServerRequest;
@@ -13,8 +14,7 @@ public class UserInStructure implements ResourcesProvider {
     @Override
     public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
         String structure = request.getParam(Field.STRUCTURE);
-        handler.handle(user.getStructures().contains(structure) &&
-                (WorkflowHelper.hasRight(user, WorkflowActions.STATISTICS_PRESENCES_VIEW.toString())
-                || WorkflowHelper.hasRight(user, WorkflowActions.STATISTICS_PRESENCES_VIEW_RESTRICTED.toString())));
+        handler.handle(user.getStructures().contains(structure)
+                && WorkflowActionsCouple.STATISTICS_PRESENCES_VIEW.hasRight(user));
     }
 }

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/enums/WorkflowActionsCouple.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/enums/WorkflowActionsCouple.java
@@ -1,0 +1,25 @@
+package fr.openent.statistics_presences.enums;
+
+import fr.openent.presences.common.security.IWorkflowActionsCouple;
+
+public enum WorkflowActionsCouple implements IWorkflowActionsCouple {
+    STATISTICS_PRESENCES_VIEW(WorkflowActions.STATISTICS_PRESENCES_VIEW, WorkflowActions.STATISTICS_PRESENCES_VIEW_RESTRICTED);
+
+    private final WorkflowActions unrestrictedAction;
+    private final WorkflowActions restrictedAction;
+
+    WorkflowActionsCouple(WorkflowActions unrestrictedAction, WorkflowActions restrictedAction) {
+        this.unrestrictedAction = unrestrictedAction;
+        this.restrictedAction = restrictedAction;
+    }
+
+    @Override
+    public String getUnrestrictedAction() {
+        return unrestrictedAction.name();
+    }
+
+    @Override
+    public String getRestrictedAction() {
+        return restrictedAction.name();
+    }
+}


### PR DESCRIPTION
## Describe your changes
When a user has restricted rights and unrestricted rights, then the unrestricted rights prevail.

Ex: The teacher group has restricted rights for student research. This means that teachers can only search for students assigned to them.
We give the unrestricted right to a particular teacher. He therefore has the 2 rights but we still want him to be able to search for all the students.

Doc: 
https://confluence.support-ent.fr/display/MP/Massmailing
https://confluence.support-ent.fr/display/MP/Statistics
https://confluence.support-ent.fr/display/MP/Absence
https://confluence.support-ent.fr/display/MP/Event
https://confluence.support-ent.fr/display/MP/Declaration+Absence
https://confluence.support-ent.fr/display/MP/Exemption
https://confluence.support-ent.fr/display/MP/Search

## Checklist tests
Look for a student as a teacher with both rights.

## Issue ticket number and link
[MA-1008](https://jira.support-ent.fr/browse/MA-1008)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

