### PR TITLE
fix(right): #MA-1004 add unrestricted right for get presence

### DIFF
--- a/presences/src/main/java/fr/openent/presences/Presences.java
+++ b/presences/src/main/java/fr/openent/presences/Presences.java
@@ -34,6 +34,7 @@ public class Presences extends BaseServer {
 
     public static final String VIEW = "view";
     public static final String READ_PRESENCE = "presences.presence.read";
+    public static final String READ_PRESENCE_RESTRICTED = "presences.presence.read.restricted";
     public static final String CREATE_PRESENCE = "presences.presence.create";
     public static final String MANAGE_PRESENCE = "presences.presence.manage";
     public static final String READ_REGISTER = "presences.register.read";

--- a/presences/src/main/java/fr/openent/presences/controller/FakeRight.java
+++ b/presences/src/main/java/fr/openent/presences/controller/FakeRight.java
@@ -107,4 +107,12 @@ public class FakeRight extends ControllerHelper {
     @SecuredAction(Presences.INIT_SETTINGS_2D)
     public void initSettings2D(HttpServerRequest request) {notImplemented(request);}
 
+    @Get("/rights/read/presence")
+    @SecuredAction(Presences.READ_PRESENCE)
+    public void readPresence(HttpServerRequest request) {notImplemented(request);}
+
+    @Get("/rights/read/presence/restricted")
+    @SecuredAction(Presences.READ_PRESENCE_RESTRICTED)
+    public void readPresenceRestricted(HttpServerRequest request) {notImplemented(request);}
+
 }

--- a/presences/src/main/java/fr/openent/presences/enums/WorkflowActions.java
+++ b/presences/src/main/java/fr/openent/presences/enums/WorkflowActions.java
@@ -3,6 +3,8 @@ package fr.openent.presences.enums;
 import fr.openent.presences.Presences;
 
 public enum WorkflowActions {
+    READ_PRESENCE(Presences.READ_PRESENCE),
+    READ_PRESENCE_RESTRICTED(Presences.READ_PRESENCE_RESTRICTED),
     CREATE_REGISTER(Presences.CREATE_REGISTER),
     READ_REGISTER(Presences.READ_REGISTER),
     SEARCH(Presences.SEARCH),

--- a/presences/src/main/java/fr/openent/presences/enums/WorkflowActionsCouple.java
+++ b/presences/src/main/java/fr/openent/presences/enums/WorkflowActionsCouple.java
@@ -5,6 +5,7 @@ import fr.openent.presences.common.security.IWorkflowActionsCouple;
 public enum WorkflowActionsCouple implements IWorkflowActionsCouple {
 
     READ_EVENT(WorkflowActions.READ_EVENT, WorkflowActions.READ_EVENT_RESTRICTED),
+    READ_PRESENCE(WorkflowActions.READ_PRESENCE, WorkflowActions.READ_PRESENCE_RESTRICTED),
     MANAGE_ABSENCE_STATEMENTS(WorkflowActions.MANAGE_ABSENCE_STATEMENTS, WorkflowActions.MANAGE_ABSENCE_STATEMENTS_RESTRICTED),
     MANAGE_EXEMPTION(WorkflowActions.MANAGE_EXEMPTION, WorkflowActions.MANAGE_EXEMPTION_RESTRICTED),
     READ_EXEMPTION(WorkflowActions.READ_EXEMPTION, WorkflowActions.READ_EXEMPTION_RESTRICTED),

--- a/presences/src/main/java/fr/openent/presences/security/PresenceReadRight.java
+++ b/presences/src/main/java/fr/openent/presences/security/PresenceReadRight.java
@@ -1,0 +1,15 @@
+package fr.openent.presences.security;
+
+import fr.openent.presences.enums.WorkflowActionsCouple;
+import fr.wseduc.webutils.http.Binding;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import org.entcore.common.http.filter.ResourcesProvider;
+import org.entcore.common.user.UserInfos;
+
+public class PresenceReadRight implements ResourcesProvider {
+    @Override
+    public void authorize(HttpServerRequest httpServerRequest, Binding binding, UserInfos userInfos, Handler<Boolean> handler) {
+        handler.handle(WorkflowActionsCouple.READ_PRESENCE.hasRight(userInfos));
+    }
+}


### PR DESCRIPTION
## Describe your changes
Creation of a right to allow teachers to see all presences.

You have to redefine the rights presences.presence.read and presences.presence.read.restricted

Doc: https://confluence.support-ent.fr/pages/viewpage.action?pageId=42897049
https://confluence.support-ent.fr/display/MP/Configuration+des+droits+Workflow
## Checklist tests
Take a teacher with the right presences.presence.read.restricted. We only see the presences of the students of the teacher.
Take a teacher with the right presences.presence.read. We see the presence of the students of the structure.

## Issue ticket number and link
[MA-1004](https://jira.support-ent.fr/browse/MA-1004)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

