### PR TITLE
fix(search): #216 fix search bar when structure change

### DIFF
--- a/common/src/main/resources/ts/directives/async-autocomplete.ts
+++ b/common/src/main/resources/ts/directives/async-autocomplete.ts
@@ -61,6 +61,9 @@ export const asyncAutocomplete = ng.directive('asyncAutocomplete', ['$timeout', 
         };
 
         $scope.$watch('options', (newVal) => {
+            if ((!$scope.search || $scope.search == "") && newVal && newVal.length == 0) {
+                return;
+            }
             $scope.match = newVal;
             cancelAnimationFrame(token);
             setLoadingStatus(false);


### PR DESCRIPTION
## Describe your changes
When the structure is changed, the async autocomplete directive displays the result of the search even though there was no search.

## Checklist tests
Go to the dashboard. Change structure. Below the group search bar, there is no "No results".
Test the attendance, punishment and sanction search bar, dashboard, register, list of events, alerts, exemptions, collective absence, list of calls and statistics.

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

