### PR TITLE
fix MA-894 registry and statistics

### DIFF
--- a/common/src/main/resources/ts/utils/autocomplete/groupsSearch.ts
+++ b/common/src/main/resources/ts/utils/autocomplete/groupsSearch.ts
@@ -28,13 +28,15 @@ export class GroupsSearch extends AutoCompleteUtils {
     //Only returns group from grouping, but not the grouping itself
     public getGroups(): Array<Group> {
         let groupsResult: Array<Group> = []
-        this._groups.forEach((groupItem: Group | Grouping) => {
-            if (instanceOfGrouping(groupItem)) {
-                groupsResult = (<Grouping>groupItem).groupList.concat(groupsResult);
-            } else {
-                groupsResult.push(groupItem);
-            }
-        })
+        if (!!this._groups) {
+            this._groups.forEach((groupItem: Group | Grouping) => {
+                if (instanceOfGrouping(groupItem)) {
+                    groupsResult = (<Grouping>groupItem).groupList.concat(groupsResult);
+                } else {
+                    groupsResult.push(groupItem);
+                }
+            })
+        }
         return groupsResult;
     }
 

--- a/presences/src/main/resources/public/ts/controllers/registry.ts
+++ b/presences/src/main/resources/public/ts/controllers/registry.ts
@@ -12,6 +12,7 @@ import {
 import {DateUtils, GroupsSearch} from "@common/utils";
 import {EventType} from "../models";
 import {EVENT_TYPE} from "@common/core/enum/event-type";
+import {instanceOfGrouping} from "@common/model/grouping";
 
 declare let window: any;
 
@@ -104,7 +105,7 @@ export const registryController = ng.controller('RegistryController', ['$scope',
 
         vm.emptyState = '';
         vm.groupsSearch = new GroupsSearch(window.structure.id, searchService, groupService, groupingService);
-        vm.groupsSearch.setSelectedGroups(window.item.groupList);
+        vm.groupsSearch.setSelectedGroups(instanceOfGrouping(window.item) ? window.item.groupList : [window.item]);
 
         const getDynamicMonths = (): { name: string, value: string }[] => {
             let months = [];
@@ -245,7 +246,9 @@ export const registryController = ng.controller('RegistryController', ['$scope',
         };
 
         vm.searchGroup = async (value) => {
-            await vm.groupsSearch.searchGroups(value);
+            await vm.groupsSearch.searchGroups(value)
+                .catch(error => console.error(error));
+            $scope.safeApply();
         };
 
         vm.hasEventType = (event: RegistryEvent[], eventTypeName: string): boolean => {

--- a/statistics-presences/src/main/resources/public/template/main.html
+++ b/statistics-presences/src/main/resources/public/template/main.html
@@ -22,7 +22,7 @@
                 <span data-ng-show="vm.studentsSearch.getSelectedStudents().length === 0">&nbsp;</span>
                 <li ng-repeat="student in vm.studentsSearch.getSelectedStudents()">
                     [[student.displayName]] <i class="close"
-                                               data-ng-click="vm.removeSelection('students', student)"></i>
+                                               data-ng-click="vm.removeStudent(student)"></i>
                 </li>
             </ul>
         </div>
@@ -45,7 +45,7 @@
                 <span data-ng-show="vm.groupsSearch.getSelectedGroups().length === 0">&nbsp;</span>
                 <li ng-repeat="audience in vm.groupsSearch.getSelectedGroups()">
                     [[audience.name]] <i class="close"
-                                         data-ng-click="vm.removeSelection('audiences', audience)"></i>
+                                         data-ng-click="vm.removeGroup(audience)"></i>
                 </li>
             </ul>
         </div>

--- a/statistics-presences/src/main/resources/public/ts/controllers/main.ts
+++ b/statistics-presences/src/main/resources/public/ts/controllers/main.ts
@@ -100,7 +100,11 @@ interface ViewModel {
 
     selectAudience(model: any, audience: any): void;
 
-    removeSelection(type: any, value: any): Promise<void>;
+    removeGroup(value: Group): Promise<void>;
+
+    removeStudent(value: Student): Promise<void>;
+
+    removeSelection(): Promise<void>;
 
     refreshStudentsStatistics(arrayStudentIds: Array<string>): void;
 
@@ -326,8 +330,17 @@ export const mainController = ng.controller('MainController',
                 vm.safeApply();
             };
 
-            vm.removeSelection = async function (type, value): Promise<void> {
-                vm.filter[type] = _.without(vm.filter[type], _.findWhere(vm.filter[type], value));
+            vm.removeGroup = async function (value: Group): Promise<void> {
+                vm.groupsSearch.removeSelectedGroups(value);
+                await vm.removeSelection();
+            }
+
+            vm.removeStudent = async function (value: Student): Promise<void> {
+                vm.studentsSearch.removeSelectedStudents(value);
+                await vm.removeSelection();
+            }
+
+            vm.removeSelection = async function (): Promise<void> {
                 if (vm.isWeekly(vm.indicator)) {
                     (<Weekly>vm.indicator).setUserAndAudienceFilter(vm.studentsSearch.getSelectedStudents()
                             .map((student: Student) => student.id),


### PR DESCRIPTION
## Describe your changes
Fixed several problems on the MA-894:

- When doing a group search from the registry, this search is endless.
- When selecting a group from the dashboard, this group is not correctly transmitted to the registry.
- On the statistics we can no longer remove the filters.

## Checklist tests
Go to the dashboard, search for a class. We are redirected to the register with the selected class.
From the register the group search should no longer be infinite.
On the statistics put a filter then remove it.

## Issue ticket number and link
[MA-894](https://jira.support-ent.fr/browse/MA-894)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

