### PR TITLE
fix(search): #MA-1015 fix user class name retrieval

### DIFF
--- a/common/src/main/resources/ts/services/SearchService.ts
+++ b/common/src/main/resources/ts/services/SearchService.ts
@@ -47,8 +47,11 @@ export const SearchService: SearchService = {
             data.forEach((user) => {
                 if (user.idClasse && user.idClasse != null) {
                     let idClass = user.idClasse;
-                    user.idClasse = idClass.map(id => id.split('$')[1]);
-                    user.toString = () => user.displayName + ' - ' + user.idClasse;
+                    user.idClasse = idClass.map(id => id.split('$').length > 1 ? id.split('$')[1] : id);
+                }
+                if (!!user.classesNames && user.classesNames.length > 0) {
+                    user.classesNames.sort();
+                    user.toString = () => user.displayName + ' - ' + user.classesNames;
                 } else user.toString = () => user.displayName;
             });
 
@@ -65,8 +68,11 @@ export const SearchService: SearchService = {
             data.forEach((user) => {
                 if (user.idClasse && user.idClasse != null) {
                     let idClass = user.idClasse;
-                    user.idClasse = idClass.map(id => id.split('$')[1]);
-                    user.toString = () => user.displayName + ' - ' + user.idClasse;
+                    user.idClasse = idClass.map(id => id.split('$').length > 1 ? id.split('$')[1] : id);
+                }
+                if (!!user.classesNames && user.classesNames.length > 0) {
+                    user.classesNames.sort();
+                    user.toString = () => user.displayName + ' - ' + user.classesNames;
                 } else user.toString = () => user.displayName;
             });
 

--- a/common/src/main/resources/ts/services/__tests__/search.service.test.ts
+++ b/common/src/main/resources/ts/services/__tests__/search.service.test.ts
@@ -1,0 +1,71 @@
+// tricks to fake "mock" entcore ng class in order to use service
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import {SearchService, searchService} from "@common/services";
+
+describe('TimeslotClasseService', () => {
+    it('returns data when API request is correctly called for search method', done => {
+        var mock = new MockAdapter(axios);
+        const data = [{type: "USER", displayName: "displayName1", groupName: "groupName1"},
+            {type: "GROUP", displayName: "displayName2", groupName: "groupName2"}];
+        const structureId = "sturctureId";
+        const value = "value";
+
+        mock.onGet(`/presences/search?structureId=${structureId}&q=${value}`).reply(200, data);
+
+        SearchService.search(structureId, value).then(res => {
+            expect(res[0].toString()).toEqual("displayName1 - groupName1");
+            expect(res[1].toString()).toEqual("displayName2");
+            done();
+        });
+    });
+
+    it('returns data when API request is correctly called for searchUser method', done => {
+        var mock = new MockAdapter(axios);
+        const data = [{idClasse: ["3184$3EME1", "3487$3EME2"], classesNames: ["3EME2", "3EME1"], displayName: "displayName1"},
+            {idClasse: ["AMIENS-2588141165", "AMIENS-1689416"], classesNames: ["CP", "CM1"], displayName: "displayName2"},
+            {displayName: "displayName3"}];
+        const structureId = "sturctureId";
+        const value = "value";
+        const profile = "profile";
+
+        mock.onGet(`/presences/search/users?structureId=${structureId}&profile=${profile}&q=${value}&field=firstName&field=lastName`)
+            .reply(200, data);
+
+        SearchService.searchUser(structureId, value, profile).then((res: Array<any>) => {
+            expect(res[0].toString()).toEqual("displayName1 - 3EME1,3EME2");
+            expect(res[1].toString()).toEqual("displayName2 - CM1,CP");
+            expect(res[2].toString()).toEqual("displayName3");
+
+            expect(res[0].idClasse).toEqual(["3EME1", "3EME2"]);
+            expect(res[1].idClasse).toEqual(["AMIENS-2588141165", "AMIENS-1689416"]);
+            expect(res[0].classesNames).toEqual(["3EME1", "3EME2"]);
+            expect(res[1].classesNames).toEqual(["CM1", "CP"]);
+            done();
+        });
+    });
+
+    it('returns data when API request is correctly called for searchStudents method', done => {
+        var mock = new MockAdapter(axios);
+        const data = [{idClasse: ["3184$3EME1", "3487$3EME2"], classesNames: ["3EME2", "3EME1"], displayName: "displayName1"},
+            {idClasse: ["AMIENS-2588141165", "AMIENS-1689416"], classesNames: ["CP", "CM1"], displayName: "displayName2"},
+            {displayName: "displayName3"}];
+        const structureId = "sturctureId";
+        const value = "value";
+
+        mock.onGet(`/presences/search/students?structureId=${structureId}&q=${value}&field=firstName&field=lastName`)
+            .reply(200, data);
+
+        SearchService.searchStudents(structureId, value).then((res: Array<any>) => {
+            expect(res[0].toString()).toEqual("displayName1 - 3EME1,3EME2");
+            expect(res[1].toString()).toEqual("displayName2 - CM1,CP");
+            expect(res[2].toString()).toEqual("displayName3");
+
+            expect(res[0].idClasse).toEqual(["3EME1", "3EME2"]);
+            expect(res[1].idClasse).toEqual(["AMIENS-2588141165", "AMIENS-1689416"]);
+            expect(res[0].classesNames).toEqual(["3EME1", "3EME2"]);
+            expect(res[1].classesNames).toEqual(["CM1", "CP"]);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
## Describe your changes
When importing students with the AAF method, the student classes are in a different form (3841$3em1 in CSV import, AMIENS-174781 in AAF import). Instead of reading the classes field, we will directly look for the name of the class directly from the association.

We add a classNames field in the return of viescolaire eventbus in [MVS-79](https://jira.support-ent.fr/browse/MVS-79)

## Checklist tests
Go to the different presences search bar and search for a student. Classes appear as they should.

## Issue ticket number and link
[MA-1015](https://jira.support-ent.fr/browse/MA-1015)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

