### PR TITLE
fix(calendar): #MA-1013 fix calendar not display when api call fail

### DIFF
--- a/presences/src/main/resources/public/ts/controllers/calendar.ts
+++ b/presences/src/main/resources/public/ts/controllers/calendar.ts
@@ -179,19 +179,39 @@ export const calendarController = ng.controller('CalendarController',
             const hover = document.getElementById('exemption-hover');
 
             const loadCalendarItems = async (student: User, startWeekDate: string, structureId: string): Promise<ICalendarItems> => {
-                return Promise.all([
-                    CalendarService.loadCourses(student, startWeekDate, structureId),
-                    CalendarService.loadPresences(student, startWeekDate, structureId),
-                    CalendarService.loadAbsences(student, startWeekDate, structureId),
-                    reasonService.getReasons(structureId, REASON_TYPE_ID.ALL)]
-                ).then((values: [Array<Course>, Presences, Array<Absence>, Array<Reason>]) => {
-                    return {
-                        courses: values[0],
-                        presences: values[1],
-                        absences: values[2],
-                        reasons: values[3]
-                    };
-                });
+                let courses: Array<Course> = await (CalendarService.loadCourses(student, startWeekDate, structureId)
+                    .then((coursesResult: Array<Course>) => coursesResult)
+                    .catch(e => {
+                        console.error(e);
+                        return [];
+                    }));
+
+                let presences: Presences = await (CalendarService.loadPresences(student, startWeekDate, structureId)
+                    .then((presencesResult: Presences) => presencesResult)
+                    .catch(e => {
+                        console.error(e);
+                        return new Presences(structureId);
+                    }));
+
+                let absences: Array<Absence> = await (CalendarService.loadAbsences(student, startWeekDate, structureId)
+                    .then((absencesResult: Array<Absence>) => absencesResult)
+                    .catch(e => {
+                        console.error(e);
+                        return [];
+                    }));
+
+                let reasons: Array<Reason> = await (reasonService.getReasons(structureId, REASON_TYPE_ID.ALL)
+                    .then((reasonsResult: Array<Reason>) => reasonsResult)
+                    .catch(e => {
+                        console.error(e);
+                        return [];
+                    }));
+                return {
+                    courses: courses,
+                    presences: presences,
+                    absences: absences,
+                    reasons: reasons
+                };
             };
 
             async function initCalendar() {


### PR DESCRIPTION
## Describe your changes
When loading the calendar, 4 APIs are called (absence, lessons, attendances, reason list). If one of the APIs fails, the calendar was not displayed. Thanks to this fix, even if the API calls have failed, we will still display the calendar.

## Checklist tests
Having a user without the presences.read and presences.read.restricted right. Go to calendar view. The calendar is displayed correctly.

## Issue ticket number and link
[MA-1013](https://jira.support-ent.fr/browse/MA-1013)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

