### PR TITLE
fix(statistics): #MA-1019 delete user queue  when doing a manual calculation

### DIFF
--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/ComputeStatistics.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/ComputeStatistics.java
@@ -38,6 +38,7 @@ public class ComputeStatistics extends ProcessingScheduledManual {
         initTemplateProcessor();
         fetchUsers(structures, studentIds)
                 .compose(this::processManualIndicators)
+                .compose(res -> this.clearWaitingList(studentIds))
                 .onSuccess(promise::complete)
                 .onFailure(error -> {
                     String message = String.format("[StatisticsPresences@%s@::manualStart] An error has occurred during " +


### PR DESCRIPTION
## Describe your changes
When we recalculate the stats manually we do not delete the users who were waiting for recalculation.

## Checklist tests
Have a user in database waiting forr ecalculation. Do a manual recalculation. The user is no longer waiting for a recalculation.

## Issue ticket number and link
[MA-1019](https://jira.support-ent.fr/browse/MA-1019)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

