### PR TITLE
feat(presence): #MA-1020 fix event and absence not update when edit presence

### DIFF
--- a/presences/deployment/test-sql/alertes/MA-1020-update-event-when-presence-update.sql
+++ b/presences/deployment/test-sql/alertes/MA-1020-update-event-when-presence-update.sql
@@ -1,0 +1,125 @@
+    do $$
+    declare
+        structureId varchar = '46094e4c-a86f-4b73-812e-890e791a6900';
+        studentId1 varchar = 'ae0c59ca-10e2-433f-8bd5-e33860b17901';
+        studentId2 varchar = '07644b76-a0e6-4cbe-88ea-1f56e5973166';
+        studentId3 varchar = 'a0a336b4-7bca-47f4-8e48-eba60682cf31';
+        reasonId bigint;
+    begin
+        -- Insert and define default value
+        INSERT INTO presences.register(id, personnel_id, course_id, state_id, owner, structure_id, start_date)
+        VALUES (9100, '', '', 3, '', structureId, '2022-10-17 08:30:00.00000');
+
+        INSERT INTO presences.register(id, personnel_id, course_id, state_id, owner, structure_id, start_date)
+        VALUES (9101, '', '', 3, '', structureId, '2022-10-18 08:30:00.00000');
+
+        --Init event
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9000, '2022-10-17 08:30:00.00000', '2022-10-17 09:25:00.000000', studentId1, 9100, 2, NULL, '', false);
+
+        --Unregularized absence
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9001, '2022-10-17 08:30:00.00000', '2022-10-17 09:25:00.000000', studentId2, 9100, 2, 1, '', false);
+
+        --Regularized absence
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9002, '2022-10-17 08:30:00.00000', '2022-10-17 09:25:00.000000', studentId3, 9100, 2, 12, '', false);
+
+        --Different period
+        INSERT INTO presences.event(id, start_date, end_date, student_id, register_id, type_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9003, '2022-10-18 08:30:00.00000', '2022-10-18 09:25:00.000000', studentId1, 9100, 2, NULL, '', false);
+
+        -- Init absences
+        INSERT INTO presences.absence(id, start_date, end_date, student_id, reason_id, structure_id, counsellor_regularisation)
+        VALUES (9500, '2022-10-17 08:30:00.00000', '2022-10-17 09:25:00.000000', studentId1, NULL, structureId, false);
+
+        INSERT INTO presences.absence(id, start_date, end_date, student_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9501, '2022-10-17 08:30:00.00000', '2022-10-17 09:25:00.000000', studentId1, 1, '', false);
+
+        INSERT INTO presences.absence(id, start_date, end_date, student_id, reason_id, owner, counsellor_regularisation)
+        VALUES (9502, '2022-10-17 08:30:00.00000', '2022-10-17 09:25:00.000000', studentId1, 12, '', false);
+
+        INSERT INTO presences.absence(id, start_date, end_date, student_id, reason_id, structure_id, counsellor_regularisation)
+        VALUES (9503, '2022-10-18 08:30:00.00000', '2022-10-18 09:25:00.000000', studentId1, NULL, structureId, false);
+
+        --Test add presence
+        INSERT INTO presences.presence(id, start_date, end_date, discipline_id, structure_id, owner)
+        VALUES (9200, '2022-10-17 08:30:00.00000', '2022-10-17 09:25:00.000000', 1, structureId, '');
+
+        INSERT INTO presences.presence(id, start_date, end_date, discipline_id, structure_id, owner)
+        VALUES (9201, '2022-10-17 08:30:00.00000', '2022-10-17 19:25:00.000000', 1, structureId, '');
+
+        INSERT INTO presences.presence_student(student_id, presence_id) VALUES (studentId1, 9200), (studentId2, 9200), (studentId3, 9200);
+        SELECT reason_id FROM presences.event WHERE id = 9000 INTO reasonId;
+        assert reasonId = -2, 'update event on presence -2 != ' || reasonId;
+
+        SELECT reason_id FROM presences.event WHERE id = 9001 INTO reasonId;
+        assert reasonId = 1, 'dont update event with reason 1 != ' || reasonId;
+
+        SELECT reason_id FROM presences.event WHERE id = 9002 INTO reasonId;
+        assert reasonId = 12, 'dont update event with reason 12 != ' || reasonId;
+
+        SELECT reason_id FROM presences.event WHERE id = 9003 INTO reasonId;
+        assert reasonId IS NULL, 'dont update event on other period NULL != ' || reasonId;
+
+        SELECT reason_id FROM presences.absence WHERE id = 9500 INTO reasonId;
+        assert reasonId = -2, 'update absence on presence -2 != ' || reasonId;
+
+        SELECT reason_id FROM presences.absence WHERE id = 9501 INTO reasonId;
+        assert reasonId = 1, 'dont update absence with reason 1 != ' || reasonId;
+
+        SELECT reason_id FROM presences.absence WHERE id = 9502 INTO reasonId;
+        assert reasonId = 12, 'dont update absence with reason 12 != ' || reasonId;
+
+        SELECT reason_id FROM presences.absence WHERE id = 9503 INTO reasonId;
+        assert reasonId IS NULL, 'dont update absence on other period NULL != ' || reasonId;
+
+        --Test delete presences
+        DELETE FROM presences.presence_student WHERE student_id = studentId1 OR student_id = studentId2 OR student_id = studentId3;
+
+        SELECT reason_id FROM presences.event WHERE id = 9000 INTO reasonId;
+        assert reasonId IS NULL , 'update event on presence delete NULL != ' || reasonId;
+
+        SELECT reason_id FROM presences.event WHERE id = 9001 INTO reasonId;
+        assert reasonId = 1, 'dont update event with reason 1 != ' || reasonId;
+
+        SELECT reason_id FROM presences.event WHERE id = 9002 INTO reasonId;
+        assert reasonId = 12, 'dont update event with reason 12 != ' || reasonId;
+
+        SELECT reason_id FROM presences.absence WHERE id = 9500 INTO reasonId;
+        assert reasonId IS NULL , 'update absence on presence delete NULL != ' || reasonId;
+
+        SELECT reason_id FROM presences.absence WHERE id = 9501 INTO reasonId;
+        assert reasonId = 1, 'dont update absence with reason 1 != ' || reasonId;
+
+        SELECT reason_id FROM presences.absence WHERE id = 9502 INTO reasonId;
+        assert reasonId = 12, 'dont update absence with reason 12 != ' || reasonId;
+
+        INSERT INTO presences.presence_student(student_id, presence_id) VALUES (studentId1, 9200), (studentId1, 9201);
+        SELECT reason_id FROM presences.event WHERE id = 9000 INTO reasonId;
+        assert reasonId = -2 , 'update event on presence NULL != ' || reasonId;
+
+        SELECT reason_id FROM presences.absence WHERE id = 9500 INTO reasonId;
+        assert reasonId = -2 , 'update absence on presence NULL != ' || reasonId;
+
+        DELETE FROM presences.presence_student WHERE student_id = studentId1 AND presence_id = 9200;
+        SELECT reason_id FROM presences.event WHERE id = 9000 INTO reasonId;
+        assert reasonId = -2 , 'do not update event on presence delete when having other presence NULL != ' || reasonId;
+
+        SELECT reason_id FROM presences.absence WHERE id = 9500 INTO reasonId;
+        assert reasonId = -2 , 'do not update absence on presence delete when having other presence NULL != ' || reasonId;
+
+        DELETE FROM presences.presence WHERE id = 9201;
+
+        SELECT reason_id FROM presences.event WHERE id = 9000 INTO reasonId;
+        assert reasonId IS NULL , 'update event on presence delete NULL != ' || reasonId;
+
+        SELECT reason_id FROM presences.absence WHERE id = 9500 INTO reasonId;
+        assert reasonId IS NULL , 'update absence on presence delete NULL != ' || reasonId;
+
+        DELETE FROM presences.absence WHERE id IN (9500, 9501, 9502, 9503);
+        DELETE FROM presences.event WHERE id IN (9000, 9001, 9002, 9003);
+        DELETE FROM presences.presence_student WHERE student_id IN (studentId1, studentId2, studentId3);
+        DELETE FROM presences.presence WHERE id IN (9200, 9201);
+        DELETE FROM presences.register WHERE id = 9100 OR id = 9101;
+    end$$;

--- a/presences/src/main/java/fr/openent/presences/controller/PresencesController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/PresencesController.java
@@ -85,7 +85,7 @@ public class PresencesController extends ControllerHelper {
                 return;
             }
             UserUtils.getUserInfos(eb, request, user ->
-                    presencesService.create(user, presences, DefaultResponseHandler.defaultResponseHandler(request)));
+                    presencesService.createWithoutUpdateAbsence(user, presences, DefaultResponseHandler.defaultResponseHandler(request)));
         });
     }
 

--- a/presences/src/main/java/fr/openent/presences/service/PresenceService.java
+++ b/presences/src/main/java/fr/openent/presences/service/PresenceService.java
@@ -38,6 +38,15 @@ public interface PresenceService {
     void create(UserInfos user, JsonObject presenceBody, Handler<Either<String, JsonObject>> handler);
 
     /**
+     * Create presence
+     *
+     * @param user              user infos {@link UserInfos}
+     * @param presenceBody      list of absences identifiers
+     * @param handler           Handler sending {@link Either>} reply
+     */
+    void createWithoutUpdateAbsence(UserInfos user, JsonObject presenceBody, Handler<Either<String, JsonObject>> handler);
+
+    /**
      * Update an presence
      *
      * @param presenceBody presence object

--- a/presences/src/main/resources/sql/055-MA-1020-update-event-when-presence-update.sql
+++ b/presences/src/main/resources/sql/055-MA-1020-update-event-when-presence-update.sql
@@ -1,0 +1,87 @@
+-- Returns true if the student has another presence for the period provided in the parameter
+-- presenceId      id of the presence to ignore
+-- studentId       student id
+-- startDate       period start date
+-- endDate         period end date
+CREATE OR REPLACE FUNCTION presences.eventHasOtherPresence(presenceId bigint, studentId character varying,
+    startDate timestamp without time zone, endDate timestamp without time zone) RETURNS BOOLEAN AS
+$BODY$
+DECLARE
+    result presences.presence;
+BEGIN
+    SELECT * FROM presences.presence AS p INNER JOIN presences.presence_student ps on p.id = ps.presence_id
+    WHERE p.id != presenceId AND p.start_date <= endDate AND p.end_date >= startDate AND ps.student_id = studentId
+    LIMIT 1 INTO result;
+    RETURN result IS NOT NULL;
+END
+$BODY$
+    LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION presences.updateReasonToNoReasonWhenPresenceStudentDelete() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+    presenceResult presences.presence;
+BEGIN
+    SELECT * FROM presences.presence WHERE id = OLD.presence_id INTO presenceResult;
+    -- Update event
+    UPDATE presences.event as e SET reason_id = NULL WHERE e.id IN (SELECT id FROM presences.event WHERE student_id = OLD.student_id
+        AND start_date <= presenceResult.end_date AND end_date >= presenceResult.start_date AND reason_id = -2)
+        AND presences.studentHasOtherPresence(presenceResult.id, OLD.student_id, e.start_date,
+            e.end_date) IS FALSE;
+    -- Update absences
+    UPDATE presences.absence as a SET reason_id = NULL WHERE a.id IN (SELECT id FROM presences.absence WHERE student_id = OLD.student_id
+        AND start_date <= presenceResult.end_date AND end_date >= presenceResult.start_date AND reason_id = -2)
+        AND presences.studentHasOtherPresence(presenceResult.id, OLD.student_id, a.start_date,
+            a.end_date) IS FALSE;
+    RETURN OLD;
+END
+$BODY$
+    LANGUAGE plpgsql;
+
+CREATE TRIGGER updateReasonToNoReason BEFORE DELETE ON presences.presence_student
+    FOR EACH ROW EXECUTE PROCEDURE presences.updateReasonToNoReasonWhenPresenceStudentDelete();
+
+CREATE OR REPLACE FUNCTION presences.updateReasonToNoReasonWhenPresenceDelete() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+    presenceStudentResult presences.presence_student;
+BEGIN
+    FOR presenceStudentResult IN SELECT * FROM presences.presence_student WHERE presence_id = OLD.id LOOP
+            -- Update event
+            UPDATE presences.event as e SET reason_id = NULL WHERE e.id IN (SELECT id FROM presences.event WHERE student_id = presenceStudentResult.student_id
+                AND start_date <= OLD.end_date AND end_date >= OLD.start_date AND reason_id = -2)
+                AND presences.studentHasOtherPresence(OLD.id, presenceStudentResult.student_id, e.start_date,
+                    e.end_date) IS FALSE;
+            -- Update absences
+            UPDATE presences.absence as a SET reason_id = NULL WHERE a.id IN (SELECT id FROM presences.absence WHERE student_id = presenceStudentResult.student_id
+                AND start_date <= OLD.end_date AND end_date >= OLD.start_date AND reason_id = -2)
+                AND presences.studentHasOtherPresence(OLD.id, presenceStudentResult.student_id, a.start_date,
+                    a.end_date) IS FALSE;
+    END LOOP;
+    RETURN OLD;
+END
+$BODY$
+    LANGUAGE plpgsql;
+
+CREATE TRIGGER updateReasonToNoReason BEFORE DELETE ON presences.presence
+    FOR EACH ROW EXECUTE PROCEDURE presences.updateReasonToNoReasonWhenPresenceDelete();
+
+CREATE OR REPLACE FUNCTION presences.updateReasonToInStructureWhenPresenceStudentCreate() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+    presenceResult presences.presence;
+BEGIN
+    SELECT * FROM presences.presence WHERE id = NEW.presence_id INTO presenceResult;
+    -- Update event
+    UPDATE presences.event SET reason_id = -2 WHERE event.id IN (SELECT id FROM presences.event WHERE student_id = NEW.student_id
+        AND start_date <= presenceResult.end_date AND end_date >= presenceResult.start_date AND reason_id IS NULL);
+    -- Update absences
+    UPDATE presences.absence SET reason_id = -2 WHERE absence.id IN (SELECT id FROM presences.absence WHERE student_id = NEW.student_id
+        AND start_date <= presenceResult.end_date AND end_date >= presenceResult.start_date AND reason_id IS NULL);
+    RETURN NEW;
+END
+$BODY$
+    LANGUAGE plpgsql;
+
+CREATE TRIGGER updateReasonInStructure BEFORE INSERT ON presences.presence_student
+    FOR EACH ROW EXECUTE PROCEDURE presences.updateReasonToInStructureWhenPresenceStudentCreate();


### PR DESCRIPTION
## Describe your changes
When a presence is deleted, the events are not updated. In this patch we no longer use the back to update events and absences, we go through sql triggers.

## Checklist tests
Crée une absence sans motif sur le crénaux 1. Mettre une presence sur le crénaux 1. L'absence passe en "Présent dans l'établissement."
Supprimer la presence, l'absece est repasser en sans motif.
Recrée la presence. L'absence passe en present dans l'établissement.
Crée une deuxement presence sur tout la journée Supprimer la premiere presence. L'absence est toujour en "Présent dans l'établissement".

## Issue ticket number and link
[MA-1020](https://jira.support-ent.fr/browse/MA-1020)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

