### PR TITLE
feat(stats): #MA-1033 use only 1 worker for stats calculation

### DIFF
--- a/common/src/main/java/fr/openent/presences/common/helper/IModelHelper.java
+++ b/common/src/main/java/fr/openent/presences/common/helper/IModelHelper.java
@@ -4,7 +4,9 @@ import fr.openent.presences.model.IModel;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -15,6 +17,10 @@ import java.util.stream.Collectors;
  * ⚠ This will guarantee the correct execution of the line modelClass.getConstructor(JsonObject.class).newInstance(iModel).
  */
 public class IModelHelper {
+    private final static List<Class<?>> validJsonClasses = Arrays.asList(String.class, boolean.class, Boolean.class,
+            double.class, Double.class, float.class, Float.class, Integer.class, int.class, CharSequence.class,
+            JsonObject.class, JsonArray.class, Long.class, long.class);
+
     private IModelHelper() {
         throw new IllegalStateException("Utility class");
     }
@@ -35,5 +41,70 @@ public class IModelHelper {
 
     public static JsonArray toJsonArray(List<? extends IModel<?>> dataList) {
         return new JsonArray(dataList.stream().map(IModel::toJson).collect(Collectors.toList()));
+    }
+
+    /**
+     * Generic convert an {@link IModel} to {@link JsonObject}.
+     * Classes that do not implement any {@link #validJsonClasses} class or iModel implementation will be ignored.
+     * Except {@link List} and {@link Enum}
+     *
+     * @param ignoreNull If true ignore, fields that are null will not be put in the result
+     * @param iModel Instance of {@link IModel} to convert to {@link JsonObject}
+     * @return {@link JsonObject}
+     */
+    public static JsonObject toJson(boolean ignoreNull, IModel<?> iModel) {
+        JsonObject statisticsData = new JsonObject();
+        final Field[] declaredFields = iModel.getClass().getDeclaredFields();
+        Arrays.stream(declaredFields).forEach(field -> {
+            boolean accessibility = field.isAccessible();
+            field.setAccessible(true);
+            try {
+                Object object = field.get(iModel);
+                String fieldName = field.getName();
+                if (object == null) {
+                    if (!ignoreNull) statisticsData.putNull(fieldName);
+                }
+                else if (object instanceof IModel) {
+                    statisticsData.put(StringHelper.camelToSnake(fieldName), ((IModel<?>)object).toJson());
+                } else if (validJsonClasses.stream().anyMatch(aClass -> aClass.isInstance(object))) {
+                    statisticsData.put(StringHelper.camelToSnake(fieldName), object);
+                } else if (object instanceof Enum) {
+                    statisticsData.put(StringHelper.camelToSnake(fieldName), (Enum) object);
+                } else if (object instanceof List) {
+                    statisticsData.put(StringHelper.camelToSnake(fieldName), listToJsonArray(((List<?>)object)));
+                }
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            }
+            field.setAccessible(accessibility);
+        });
+        return statisticsData;
+    }
+
+    /**
+     * Generic convert a list of {@link Object} to {@link JsonArray}.
+     * Classes that do not implement any {@link #validJsonClasses} class or iModel implementation will be ignored.
+     * Except {@link List} and {@link Enum}
+     *
+     * @param objects List of object
+     * @return {@link JsonArray}
+     */
+    private static JsonArray listToJsonArray(List<?> objects) {
+        JsonArray res = new JsonArray();
+        objects.stream()
+                .filter(Objects::nonNull)
+                .forEach(object -> {
+                    if (object instanceof IModel) {
+                        res.add(((IModel<?>) object).toJson());
+                    }
+                    else if (validJsonClasses.stream().anyMatch(aClass -> aClass.isInstance(object))) {
+                        res.add(object);
+                    } else if (object instanceof Enum) {
+                        res.add((Enum)object);
+                    } else if (object instanceof List) {
+                        res.add(listToJsonArray(((List<?>) object)));
+                    }
+                });
+        return res;
     }
 }

--- a/common/src/main/java/fr/openent/presences/common/helper/StringHelper.java
+++ b/common/src/main/java/fr/openent/presences/common/helper/StringHelper.java
@@ -9,4 +9,42 @@ public class StringHelper {
     public static String repeat(String toRepeat, int time) {
         return new String(new char[time]).replace("\0", toRepeat);
     }
+
+    public static String camelToSnake(String str)
+    {
+        if (str == null || str.isEmpty()) {
+            return str;
+        }
+        // Empty String
+        StringBuilder result = new StringBuilder();
+
+        // Append first character(in lower case)
+        // to result string
+        char c = str.charAt(0);
+        result.append(Character.toLowerCase(c));
+
+        // Traverse the string from
+        // ist index to last index
+        for (int i = 1; i < str.length(); i++) {
+
+            char ch = str.charAt(i);
+
+            // Check if the character is upper case
+            // then append '_' and such character
+            // (in lower case) to result string
+            if (Character.isUpperCase(ch)) {
+                result.append('_');
+                result.append(Character.toLowerCase(ch));
+            }
+
+            // If the character is lower case then
+            // add such character into result string
+            else {
+                result.append(ch);
+            }
+        }
+
+        // return the result
+        return result.toString();
+    }
 }

--- a/common/src/main/java/fr/openent/presences/core/constants/Field.java
+++ b/common/src/main/java/fr/openent/presences/core/constants/Field.java
@@ -364,6 +364,7 @@ public class Field {
     public static final String STUDENT_DIVISIONS = "student_divisions";
     public static final String STUDENT_ID_LIST = "student_id_list";
     public static final String STUDENT_TIMESLOT = "student_timeslot";
+    public static final String DELAY_AT = "delay_at";
 
     private Field() {
         throw new IllegalStateException("Utility class");

--- a/common/src/test/java/fr/openent/presences/common/helper/IModelHelperTest.java
+++ b/common/src/test/java/fr/openent/presences/common/helper/IModelHelperTest.java
@@ -20,15 +20,64 @@ import static org.reflections.scanners.Scanners.SubTypes;
 
 @RunWith(VertxUnitRunner.class)
 public class IModelHelperTest {
+    enum MyEnum {
+        VALUE1,
+        VALUE2,
+        VALUE3
+    }
+
+    class MyClass {
+        public String id;
+    }
+    class MyIModel implements IModel<MyIModel> {
+        public String id;
+        public boolean isGood;
+        public MyOtherIModel otherIModel;
+        public MyClass myClass;
+        public List<Integer> typeIdList;
+        public List<MyOtherIModel> otherIModelList;
+        public List<MyClass> myClassList;
+        public List<List<JsonObject>> listList;
+        public MyEnum myEnum;
+        public List<MyEnum> myEnumList;
+
+        @Override
+        public JsonObject toJson() {
+            return IModelHelper.toJson(true, this);
+        }
+
+        @Override
+        public boolean validate() {
+            return false;
+        }
+    }
+
+    class MyOtherIModel implements IModel<MyOtherIModel> {
+        public String myName;
+
+        @Override
+        public JsonObject toJson() {
+            return IModelHelper.toJson(true, this);
+        }
+
+        @Override
+        public boolean validate() {
+            return false;
+        }
+    }
+
     private static final Logger log = LoggerFactory.getLogger(IModelHelperTest.class);
 
     @Test
     public void testSubClassIModel(TestContext ctx) {
         Reflections reflections = new Reflections("fr.openent.presences");
+        List<Class<?>> ignoredClassList = Arrays.asList(MyIModel.class, MyOtherIModel.class);
 
         Set<Class<?>> subTypes =
                 reflections.get(SubTypes.of(IModel.class).asClass());
-        List<Class<?>> invalidModel = subTypes.stream().filter(modelClass -> {
+        List<Class<?>> invalidModel = subTypes.stream()
+                .filter(modelClass -> !ignoredClassList.contains(modelClass))
+                .filter(modelClass -> {
             Constructor<?> emptyConstructor = Arrays.stream(modelClass.getConstructors())
                     .filter(constructor -> constructor.getParameterTypes().length == 1
                             && constructor.getParameterTypes()[0].equals(JsonObject.class))
@@ -44,5 +93,47 @@ public class IModelHelperTest {
         });
 
         ctx.assertTrue(invalidModel.isEmpty(), "One or more IModel don't have public constructor with JsonObject parameter declared. Check log above.");
+    }
+
+    @Test
+    public void toJson(TestContext ctx) {
+        MyOtherIModel otherIModel1 = new MyOtherIModel();
+        otherIModel1.myName = "otherIModel1";
+        MyOtherIModel otherIModel2 = new MyOtherIModel();
+        otherIModel2.myName = "otherIModel2";
+        MyOtherIModel otherIModel3 = new MyOtherIModel();
+        otherIModel3.myName = "otherIModel3";
+
+        MyClass myClass1 = new MyClass();
+        myClass1.id = "myClass1";
+        MyClass myClass2 = new MyClass();
+        myClass2.id = "myClass2";
+        MyClass myClass3 = new MyClass();
+        myClass3.id = "myClass3";
+
+        MyIModel iModel = new MyIModel();
+        iModel.id = "id";
+        iModel.isGood = true;
+        iModel.typeIdList = Arrays.asList(1,2,3);
+        iModel.otherIModel = otherIModel1;
+        iModel.myClass = myClass1;
+        iModel.otherIModelList = Arrays.asList(otherIModel2, otherIModel3);
+        iModel.myClassList = Arrays.asList(myClass2, myClass3);
+
+        iModel.listList = Arrays.asList(Arrays.asList(new JsonObject().put("uuid", "uuid1"), new JsonObject().put("uuid", "uuid2")),
+                Arrays.asList(new JsonObject().put("uuid", "uuid3"), new JsonObject().put("uuid", "uuid4")),
+                Arrays.asList(new JsonObject().put("uuid", "uuid5"), new JsonObject().put("uuid", "uuid6")));
+
+        iModel.myEnum = MyEnum.VALUE1;
+        iModel.myEnumList = Arrays.asList(MyEnum.VALUE2, MyEnum.VALUE3);
+
+        String expected = "{\"id\":\"id\",\"is_good\":true,\"other_i_model\":{\"my_name\":\"otherIModel1\"}," +
+                "\"type_id_list\":[1,2,3],\"other_i_model_list\":[{\"my_name\":\"otherIModel2\"},{\"my_name\":\"otherIModel3\"}]," +
+                "\"my_class_list\":[],\"list_list\":[[{\"uuid\":\"uuid1\"},{\"uuid\":\"uuid2\"}],[{\"uuid\":\"uuid3\"}," +
+                "{\"uuid\":\"uuid4\"}],[{\"uuid\":\"uuid5\"},{\"uuid\":\"uuid6\"}]],\"my_enum\":\"VALUE1\"," +
+                "\"my_enum_list\":[\"VALUE2\",\"VALUE3\"]}";
+        ctx.assertEquals(expected, IModelHelper.toJson(true, iModel).toString());
+
+        System.out.println();
     }
 }

--- a/common/src/test/java/fr/openent/presences/common/helper/StringHelperTest.java
+++ b/common/src/test/java/fr/openent/presences/common/helper/StringHelperTest.java
@@ -1,0 +1,19 @@
+package fr.openent.presences.common.helper;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class StringHelperTest {
+
+    @Test
+    public void camelToSnakeTest(TestContext ctx) {
+        ctx.assertEquals(StringHelper.camelToSnake(""), "");
+        ctx.assertEquals(StringHelper.camelToSnake("camelCase"), "camel_case");
+        ctx.assertEquals(StringHelper.camelToSnake("DTRE"), "d_t_r_e");
+        ctx.assertEquals(StringHelper.camelToSnake("snake_case"), "snake_case");
+        ctx.assertEquals(StringHelper.camelToSnake("D_T_R_E"), "d__t__r__e");
+    }
+}

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/Stat.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/Stat.java
@@ -4,6 +4,10 @@ import fr.openent.statistics_presences.utils.EventType;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+/**
+ * @deprecated  Replaced by {@link fr.openent.statistics_presences.bean.statistics.StatisticsData}
+ */
+@Deprecated
 public interface Stat {
     JsonObject toJSON();
 

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/StatProcessSettings.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/StatProcessSettings.java
@@ -1,6 +1,7 @@
 package fr.openent.statistics_presences.bean;
 
 import fr.openent.presences.core.constants.Field;
+import fr.openent.presences.model.TimeslotModel;
 import fr.openent.statistics_presences.bean.timeslot.Timeslot;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -14,7 +15,14 @@ public class StatProcessSettings {
     private List<String> studentClassNames;
     private List<String> studentClassIds;
     private List<String> audienceIds;
+    /**
+     * Timeslot not implement {@link fr.openent.presences.model.IModel}
+     * 
+     * @deprecated  Replaced by {@link #timeslotModel}
+     */
+    @Deprecated
     private Timeslot timeslot;
+    private TimeslotModel timeslotModel;
 
     @SuppressWarnings("unchecked")
     public void setStudentInfo(JsonObject student) {
@@ -28,6 +36,12 @@ public class StatProcessSettings {
         this.audienceIds = audienceIds != null ? audienceIds.getList() : new ArrayList<>();
     }
 
+    /**
+     * Timeslot not implement {@link fr.openent.presences.model.IModel}
+     *
+     * @deprecated  Replaced by {@link #setTimeslotModel(JsonObject)}
+     */
+    @Deprecated
     public void setTimeslot(JsonObject timeslot) {
         this.timeslot = new Timeslot(timeslot);
     }
@@ -48,9 +62,22 @@ public class StatProcessSettings {
         return audienceIds;
     }
 
+    /**
+     * Timeslot not implement {@link fr.openent.presences.model.IModel}
+     *
+     * @deprecated  Replaced by {@link #getTimeslotModel()}
+     */
+    @Deprecated
     public Timeslot getTimeslot() {
         return timeslot;
     }
 
+    public TimeslotModel getTimeslotModel() {
+        return timeslotModel;
+    }
 
+    public StatProcessSettings setTimeslotModel(JsonObject timeslotModel) {
+        this.timeslotModel = new TimeslotModel(timeslotModel);
+        return this;
+    }
 }

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/global/GlobalStat.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/global/GlobalStat.java
@@ -5,6 +5,10 @@ import fr.openent.statistics_presences.utils.EventType;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+/**
+ * @deprecated  Replaced by {@link fr.openent.statistics_presences.bean.statistics.StatisticsData}
+ */
+@Deprecated
 public class GlobalStat implements Stat {
     private String indicator;
     private EventType type;

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/monthly/MonthlyStat.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/monthly/MonthlyStat.java
@@ -5,6 +5,10 @@ import fr.openent.statistics_presences.utils.EventType;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+/**
+ * @deprecated  Replaced by {@link fr.openent.statistics_presences.bean.statistics.StatisticsData}
+ */
+@Deprecated
 public class MonthlyStat implements Stat {
     private String indicator;
     private EventType type;

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/statistics/StatisticsData.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/statistics/StatisticsData.java
@@ -1,0 +1,150 @@
+package fr.openent.statistics_presences.bean.statistics;
+
+import fr.openent.presences.common.helper.IModelHelper;
+import fr.openent.presences.model.IModel;
+import fr.openent.presences.model.SlotModel;
+import fr.openent.statistics_presences.utils.EventType;
+import io.vertx.core.json.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class StatisticsData implements IModel<StatisticsData> {
+    private EventType type;
+    private String user;
+    private String name;
+    private String className;
+    private String structure;
+    private List<String> audiences = new ArrayList<>();
+    private Long reason;
+    private Long punishmentType;
+    private String groupedPunishmentId;
+    private String startDate;
+    private String endDate;
+    private List<SlotModel> slots = new ArrayList<>();
+
+    public StatisticsData() {
+    }
+
+    public StatisticsData(JsonObject jsonObject) {
+        throw new UnsupportedOperationException("Scheduled for issue #253");
+    }
+
+    public EventType getType() {
+        return type;
+    }
+
+    public StatisticsData setType(EventType type) {
+        this.type = type;
+        return this;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public StatisticsData setUser(String user) {
+        this.user = user;
+        return this;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public StatisticsData setName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public StatisticsData setClassName(String className) {
+        this.className = className;
+        return this;
+    }
+
+    public String getStructure() {
+        return structure;
+    }
+
+    public StatisticsData setStructure(String structure) {
+        this.structure = structure;
+        return this;
+    }
+
+    public List<String> getAudiences() {
+        return audiences;
+    }
+
+    public StatisticsData setAudiences(List<String> audiences) {
+        this.audiences = audiences;
+        return this;
+    }
+
+    public Long getReason() {
+        return reason;
+    }
+
+    public StatisticsData setReason(Long reason) {
+        this.reason = reason;
+        return this;
+    }
+
+    public Long getPunishmentType() {
+        return punishmentType;
+    }
+
+    public StatisticsData setPunishmentType(Long punishmentType) {
+        this.punishmentType = punishmentType;
+        return this;
+    }
+
+    public String getGroupedPunishmentId() {
+        return groupedPunishmentId;
+    }
+
+    public StatisticsData setGroupedPunishmentId(String groupedPunishmentId) {
+        this.groupedPunishmentId = groupedPunishmentId;
+        return this;
+    }
+
+    public String getStartDate() {
+        return startDate;
+    }
+
+    public StatisticsData setStartDate(String startDate) {
+        this.startDate = startDate;
+        return this;
+    }
+
+    public String getEndDate() {
+        return endDate;
+    }
+
+    public StatisticsData setEndDate(String endDate) {
+        this.endDate = endDate;
+        return this;
+    }
+
+    public List<SlotModel> getSlots() {
+        return slots;
+    }
+
+    public StatisticsData setSlots(List<SlotModel> slots) {
+        this.slots = slots;
+        return this;
+    }
+
+    @Override
+    public JsonObject toJson() {
+        return IModelHelper.toJson(false, this);
+    }
+
+    @Override
+    public boolean validate() {
+        return false;
+    }
+}

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/timeslot/Slot.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/timeslot/Slot.java
@@ -3,6 +3,10 @@ package fr.openent.statistics_presences.bean.timeslot;
 import fr.openent.presences.core.constants.Field;
 import io.vertx.core.json.JsonObject;
 
+/**
+ * @deprecated  Replaced by {@link fr.openent.presences.model.SlotModel}
+ */
+@Deprecated
 public class Slot {
     private String id;
     private String name;

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/timeslot/Timeslot.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/timeslot/Timeslot.java
@@ -7,6 +7,10 @@ import io.vertx.core.json.JsonObject;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * @deprecated  Replaced by {@link fr.openent.presences.model.TimeslotModel}
+ */
+@Deprecated
 public class Timeslot {
     private String id;
     private String structureId;

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/weekly/WeeklyStat.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/bean/weekly/WeeklyStat.java
@@ -6,6 +6,10 @@ import fr.openent.statistics_presences.utils.EventType;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
+/**
+ * @deprecated  Replaced by {@link fr.openent.statistics_presences.bean.statistics.StatisticsData}
+ */
+@Deprecated
 public class WeeklyStat implements Stat {
     private String indicator;
     private EventType type;

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/helper/TimeslotHelper.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/helper/TimeslotHelper.java
@@ -1,6 +1,7 @@
 package fr.openent.statistics_presences.helper;
 
 import fr.openent.presences.common.helper.DateHelper;
+import fr.openent.presences.model.SlotModel;
 import fr.openent.statistics_presences.bean.timeslot.Slot;
 import fr.openent.statistics_presences.bean.timeslot.Timeslot;
 import io.vertx.core.json.JsonArray;
@@ -15,14 +16,48 @@ public class TimeslotHelper {
         throw new IllegalStateException("Utility class");
     }
 
+    /**
+     * {@link Timeslot} is deprecated
+     *
+     * @deprecated  Replaced by {@link fr.openent.presences.common.helper.IModelHelper#toList(JsonArray, Class)} by using
+     * {@link fr.openent.presences.model.TimeslotModel}
+     */
     @SuppressWarnings("unchecked")
+    @Deprecated
     public static List<Timeslot> getTimeslotsFromArray(JsonArray timeslots) {
         return ((List<JsonObject>) timeslots.getList()).stream()
                 .map(Timeslot::new)
                 .collect(Collectors.toList());
     }
 
+    /**
+     * {@link Slot} is deprecated
+     *
+     * @deprecated  Replaced by {@link #getSlotModelsFromPeriod(String, String, List)} by using
+     * {@link fr.openent.presences.model.SlotModel}
+     */
+    @Deprecated
     public static List<Slot> getSlotsFromPeriod(String startAt, String endAt, List<Slot> slots) {
+        long currentEventStartTime = DateHelper.parseDate(
+                DateHelper.fetchTimeString(startAt, DateHelper.SQL_FORMAT),
+                DateHelper.HOUR_MINUTES
+        ).getTime();
+
+        long currentEventEndTime = DateHelper.parseDate(
+                DateHelper.fetchTimeString(endAt, DateHelper.SQL_FORMAT),
+                DateHelper.HOUR_MINUTES
+        ).getTime();
+
+        return slots
+                .stream()
+                .filter(slot ->
+                        DateHelper.parseDate(slot.getEndHour(), DateHelper.HOUR_MINUTES).getTime() - currentEventStartTime > 0
+                                && currentEventEndTime - DateHelper.parseDate(slot.getStartHour(), DateHelper.HOUR_MINUTES).getTime() > 0
+                )
+                .collect(Collectors.toList());
+    }
+
+    public static List<SlotModel> getSlotModelsFromPeriod(String startAt, String endAt, List<SlotModel> slots) {
         long currentEventStartTime = DateHelper.parseDate(
                 DateHelper.fetchTimeString(startAt, DateHelper.SQL_FORMAT),
                 DateHelper.HOUR_MINUTES

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/ComputeStatistics.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/ComputeStatistics.java
@@ -1,14 +1,11 @@
 package fr.openent.statistics_presences.indicator;
 
 
-import fr.openent.presences.common.helper.FutureHelper;
-import fr.openent.statistics_presences.StatisticsPresences;
 import fr.openent.statistics_presences.service.CommonServiceFactory;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class ComputeStatistics extends ProcessingScheduledManual {
@@ -51,7 +48,7 @@ public class ComputeStatistics extends ProcessingScheduledManual {
     }
 
     /**
-     * Launch indicators manually (meaning without using Verticle context worker)
+     * Launch indicator manually (meaning without using Verticle context worker)
      *
      * @param structures structure map. Contains in key structure identifier and in value an array containing each structure
      *                   student to proceed
@@ -59,11 +56,7 @@ public class ComputeStatistics extends ProcessingScheduledManual {
      */
     private Future<Void> processManualIndicators(JsonObject structures) {
         Promise<Void> promise = Promise.promise();
-        List<Future<JsonObject>> indicatorFutures = new ArrayList<>();
-        for (Indicator indicator : StatisticsPresences.indicatorMap.values()) {
-            indicatorFutures.add(indicator.manualProcess(structures));
-        }
-        FutureHelper.join(indicatorFutures)
+        IndicatorGeneric.manualProcess(structures)
                 .onSuccess(success -> promise.complete())
                 .onFailure(error -> {
                     log.error(String.format("[StatisticsPresences@ProcessingScheduledManual::processIndicators] Some indicator failed during processing. %s", error.getMessage()));

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/Indicator.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/Indicator.java
@@ -72,7 +72,9 @@ public abstract class Indicator extends DBService {
      *
      * @param structures student list group by structure
      * @return Future ending process
+     * @deprecated Replaced by {@link IndicatorGeneric#process(Vertx, JsonObject)}
      */
+    @Deprecated
     public Future<Report> process(JsonObject structures) {
         log.info(String.format("[StatisticsPresences@Indicator::process] processing indicator %s", this.name));
         String consumerName = indicatorClassName();
@@ -90,6 +92,10 @@ public abstract class Indicator extends DBService {
         return promise.future();
     }
 
+    /**
+     * @deprecated Replaced by {@link IndicatorGeneric#process(Vertx, JsonObject)}
+     */
+    @Deprecated
     private void deployWorker(JsonObject structures) {
         JsonObject config = new JsonObject()
                 .put("structures", structures)
@@ -105,7 +111,9 @@ public abstract class Indicator extends DBService {
      *
      * @param structures student list group by structure
      * @return Future ending process
+     * @deprecated Replaced by {@link IndicatorGeneric#manualProcess(JsonObject)}
      */
+    @Deprecated
     public Future<JsonObject> manualProcess(JsonObject structures) {
         Promise<JsonObject> promise = Promise.promise();
         JsonObject config = new JsonObject()

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/ProcessingScheduledManual.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/ProcessingScheduledManual.java
@@ -1,6 +1,5 @@
 package fr.openent.statistics_presences.indicator;
 
-import fr.openent.presences.common.helper.FutureHelper;
 import fr.openent.presences.core.constants.Field;
 import fr.openent.statistics_presences.StatisticsPresences;
 import fr.openent.statistics_presences.bean.Report;
@@ -20,7 +19,7 @@ import org.entcore.common.sql.Sql;
 import org.entcore.common.sql.SqlResult;
 import org.vertx.java.busmods.BusModBase;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -118,19 +117,8 @@ public class ProcessingScheduledManual extends BusModBase implements Handler<Mes
      */
     private Future<List<Report>> processIndicators(JsonObject structures) {
         Promise<List<Report>> promise = Promise.promise();
-        List<Future<Report>> indicatorFutures = new ArrayList<>();
-        for (Indicator indicator : StatisticsPresences.indicatorMap.values()) {
-            indicatorFutures.add(indicator.process(structures));
-        }
-
-        FutureHelper.join(indicatorFutures)
-                .onSuccess(success -> {
-                    List<Report> reports = new ArrayList<>();
-                    for (Future<Report> reportFuture : indicatorFutures) {
-                        reports.add(reportFuture.result());
-                    }
-                    promise.complete(reports);
-                })
+        IndicatorGeneric.process(vertx, structures)
+                .onSuccess(report -> promise.complete(Arrays.asList(report)))
                 .onFailure(error -> {
                     log.error(String.format("[StatisticsPresences@ProcessingScheduledManual::processIndicators] Some indicator failed during processing. %s", error.getMessage()));
                     promise.fail(error.getMessage());

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/worker/Global.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/worker/Global.java
@@ -1,8 +1,10 @@
 package fr.openent.statistics_presences.indicator.worker;
 
 import fr.openent.presences.core.constants.Field;
+import fr.openent.presences.model.TimeslotModel;
 import fr.openent.statistics_presences.bean.Stat;
 import fr.openent.statistics_presences.bean.global.GlobalStat;
+import fr.openent.statistics_presences.bean.statistics.StatisticsData;
 import fr.openent.statistics_presences.bean.timeslot.Timeslot;
 import fr.openent.statistics_presences.indicator.IndicatorGeneric;
 import fr.openent.statistics_presences.indicator.IndicatorWorker;
@@ -17,6 +19,10 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+/**
+ * @deprecated  Replaced by {@link StatisticsWorker}
+ */
+@Deprecated
 public class Global extends IndicatorWorker {
 
     /**
@@ -29,8 +35,7 @@ public class Global extends IndicatorWorker {
      */
     @Override
     @SuppressWarnings("unchecked")
-    protected Future<List<Stat>> fetchEvent(EventType type, String structureId, String studentId, Timeslot timeslot,
-                                            String startDate, String endDate) {
+    protected Future<List<Stat>> fetchEvent(EventType type, String structureId, String studentId, Timeslot timeslot, String startDate, String endDate) {
         Future<List<Stat>> future;
         switch (type) {
             case INCIDENT:
@@ -61,6 +66,11 @@ public class Global extends IndicatorWorker {
         }
 
         return future;
+    }
+
+    @Override
+    protected Future<List<StatisticsData>> fetchEventData(EventType type, String structureId, String studentId, TimeslotModel timeslot, String startDate, String endDate) {
+        throw new UnsupportedOperationException("Deprecated Class");
     }
 
     private Future<List<Stat>> countHandler(Future<JsonArray> requestResult) {

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/worker/Monthly.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/worker/Monthly.java
@@ -1,8 +1,10 @@
 package fr.openent.statistics_presences.indicator.worker;
 
 import fr.openent.presences.core.constants.Field;
+import fr.openent.presences.model.TimeslotModel;
 import fr.openent.statistics_presences.bean.Stat;
 import fr.openent.statistics_presences.bean.monthly.MonthlyStat;
+import fr.openent.statistics_presences.bean.statistics.StatisticsData;
 import fr.openent.statistics_presences.bean.timeslot.Timeslot;
 import fr.openent.statistics_presences.indicator.IndicatorGeneric;
 import fr.openent.statistics_presences.indicator.IndicatorWorker;
@@ -21,8 +23,10 @@ import java.util.stream.Collectors;
 /**
  * We keep the same instruction like the Global Worker as we figured the behavior should be the same
  * We might still be able to "evolve" this behavior
+ *
+ * @deprecated  Replaced by {@link StatisticsWorker}
  */
-
+@Deprecated
 public class Monthly extends IndicatorWorker {
 
     /**
@@ -66,6 +70,11 @@ public class Monthly extends IndicatorWorker {
         }
 
         return future;
+    }
+
+    @Override
+    protected Future<List<StatisticsData>> fetchEventData(EventType type, String structureId, String studentId, TimeslotModel timeslot, String startDate, String endDate) {
+        throw new UnsupportedOperationException("Deprecated Class");
     }
 
     private Future<List<Stat>> countHandler(Future<JsonArray> requestResult) {

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/worker/StatisticsWorker.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/worker/StatisticsWorker.java
@@ -1,0 +1,193 @@
+package fr.openent.statistics_presences.indicator.worker;
+
+import fr.openent.presences.common.helper.DateHelper;
+import fr.openent.presences.core.constants.Field;
+import fr.openent.presences.model.SlotModel;
+import fr.openent.presences.model.TimeslotModel;
+import fr.openent.statistics_presences.bean.statistics.StatisticsData;
+import fr.openent.statistics_presences.helper.TimeslotHelper;
+import fr.openent.statistics_presences.indicator.IndicatorGeneric;
+import fr.openent.statistics_presences.indicator.IndicatorWorker;
+import fr.openent.statistics_presences.utils.EventType;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class StatisticsWorker extends IndicatorWorker {
+
+    @Override
+    protected Future<List<StatisticsData>> fetchEventData(EventType type, String structureId, String studentId, TimeslotModel timeslot, String startDate, String endDate) {
+        Future<List<StatisticsData>> future;
+        switch (type) {
+            case INCIDENT:
+                String select = "date as start_date, date as end_date";
+                future = countHandler(IndicatorGeneric.fetchIncidentValue(structureId, studentId, select, null, startDate, endDate), null);
+                break;
+            case DEPARTURE:
+                future = retrieveEventCount(structureId, studentId, 3, null, timeslot, startDate, endDate);
+                break;
+            case LATENESS:
+                //todo check with monthy reason param
+                future = retrieveEventCount(structureId, studentId, 2, reasonIdList(structureId), timeslot, startDate, endDate);
+                break;
+            case NO_REASON:
+                future = fetchEventCountFromPresences(structureId, studentId, new ArrayList<>(), true,
+                        null, timeslot, startDate, endDate);
+                break;
+            case UNREGULARIZED:
+                future = fetchEventCountFromPresences(structureId, studentId, reasonIdList(structureId), false,
+                        false, timeslot, startDate, endDate);
+                break;
+            case REGULARIZED:
+                future = fetchEventCountFromPresences(structureId, studentId, reasonIdList(structureId), false,
+                        true, timeslot, startDate, endDate);
+                break;
+            case PUNISHMENT:
+            case SANCTION:
+                future = retrievePunishmentCount(structureId, studentId, type.toString(), startDate, endDate);
+                break;
+            default:
+                future = Future.failedFuture(new RuntimeException("Unrecognized event type"));
+        }
+        return future;
+    }
+
+    private Future<List<StatisticsData>> countHandler(Future<JsonArray> requestResult, TimeslotModel timeslot) {
+        Promise<List<StatisticsData>> promise = Promise.promise();
+        requestResult
+                .onSuccess(result -> {
+                    List<StatisticsData> stats = result.stream()
+                            .map(JsonObject.class::cast)
+                            .map(statisticsData -> {
+                                StatisticsData stat = new StatisticsData()
+                                        .setReason(statisticsData.getLong(Field.REASON_ID, null))
+                                        .setStartDate(statisticsData.getString(Field.START_DATE))
+                                        .setEndDate(statisticsData.getString(Field.END_DATE));
+                                setStatFromStartDate(stat, timeslot);
+                                return stat;
+                            })
+                            .collect(Collectors.toList());
+                    promise.complete(stats);
+                })
+                .onFailure(promise::fail);
+        return promise.future();
+    }
+
+    private void setStatFromStartDate(StatisticsData statisticsData, TimeslotModel timeslot) {
+        if (timeslot == null) return;
+        SlotModel slot = getCurrentSlot(statisticsData.getStartDate(), timeslot.getSlots());
+        if (slot != null) {
+            statisticsData.getSlots().add(slot);
+        }
+    }
+
+    private SlotModel getCurrentSlot(String date, List<SlotModel> slots) {
+        long currentEventStartTime = DateHelper.parseDate(
+                DateHelper.fetchTimeString(date, DateHelper.SQL_FORMAT),
+                DateHelper.HOUR_MINUTES
+        ).getTime();
+
+        return slots.stream()
+                .filter(slot -> DateHelper.parseDate(slot.getStartHour(), DateHelper.HOUR_MINUTES).getTime() - currentEventStartTime >= 0)
+                .min((slotA, slotB) -> {
+                    long dateA = DateHelper.parseDate(slotA.getStartHour(), DateHelper.HOUR_MINUTES).getTime() - currentEventStartTime;
+                    long dateB = DateHelper.parseDate(slotB.getStartHour(), DateHelper.HOUR_MINUTES).getTime() - currentEventStartTime;
+                    return Long.compare(dateA, dateB);
+                })
+                .orElse(null);
+    }
+
+    private Future<List<StatisticsData>> retrieveEventCount(String structureId, String studentId, Integer eventType, List<Integer> reasonIds,
+                                                            TimeslotModel timeslot, String startDate, String endDate) {
+        String select = "event.start_date, event.end_date, event.reason_id";
+        return countHandler(IndicatorGeneric.retrieveEventCount(structureId, studentId, eventType, select, null, reasonIds, startDate, endDate), timeslot);
+    }
+
+    private Future<List<StatisticsData>> fetchEventCountFromPresences(String structureId, String studentId, List<Integer> reasonIds,
+                                                            Boolean noReasons, Boolean regularized, TimeslotModel timeslot, String startDate, String endDate) {
+        Promise<List<StatisticsData>> promise = Promise.promise();
+        IndicatorGeneric.fetchEventsFromPresences(structureId, studentId, reasonIds, noReasons, regularized, startDate, endDate)
+                .onSuccess(result -> {
+                    List<StatisticsData> stats = result.stream()
+                            .map(JsonObject.class::cast)
+                            .map(event -> {
+                                        StatisticsData statisticsData = new StatisticsData()
+                                                .setReason(event.getJsonArray(Field.EVENTS).stream()
+                                                        .map(JsonObject.class::cast)
+                                                        .map(evt -> evt.getLong(Field.REASON_ID))
+                                                        .filter(Objects::nonNull)
+                                                        .findFirst()
+                                                        .orElse(null))
+                                                .setStartDate(event.getString(Field.START_DATE))
+                                                .setEndDate(event.getString(Field.END_DATE));
+                                        this.setStatisticsDataSlot(statisticsData, timeslot);
+                                        return statisticsData;
+                                    }
+                            )
+                            .collect(Collectors.toList());
+                    promise.complete(stats);
+                })
+                .onFailure(promise::fail);
+
+        return promise.future();
+    }
+
+    private void setStatisticsDataSlot(StatisticsData statisticsData, TimeslotModel timeslot) {
+        List<SlotModel> slots = TimeslotHelper.getSlotModelsFromPeriod(statisticsData.getStartDate(), statisticsData.getEndDate(), timeslot.getSlots());
+        statisticsData.getSlots().addAll(slots);
+    }
+
+    private Future<List<StatisticsData>> retrievePunishmentCount(String structureId, String studentId, String eventType, String startDate, String endDate) {
+        Promise<List<StatisticsData>> promise = Promise.promise();
+        IndicatorGeneric.retrievePunishments(structureId, studentId, eventType, startDate, endDate)
+                .onSuccess(result -> {
+                    List<StatisticsData> stats = result.stream()
+                            .map(JsonObject.class::cast)
+                            .flatMap(punishmentsHolder -> {
+                                JsonArray punishments = punishmentsHolder.getJsonArray(Field.PUNISHMENTS);
+                                return punishments.stream()
+                                        .map(JsonObject.class::cast)
+                                        .map(punishment -> {
+                                            StatisticsData statisticsData = new StatisticsData()
+                                                    .setPunishmentType(punishment.getLong(Field.TYPEID))
+                                                    .setGroupedPunishmentId(punishment.getString(Field.GROUPED_PUNISHMENT_ID));
+                                            setDatesFromPunishments(punishment, statisticsData);
+                                            return statisticsData;
+                                        });
+                            })
+                            .collect(Collectors.toList());
+                    promise.complete(stats);
+                })
+                .onFailure(promise::fail);
+        return promise.future();
+    }
+
+    private void setDatesFromPunishments(JsonObject punishment, StatisticsData stat) {
+        JsonObject fields = punishment.getJsonObject(Field.FIELDS, new JsonObject());
+
+        String startAt = fields.getString(Field.START_AT);
+        String endAt = fields.getString(Field.END_AT);
+        if (startAt != null && endAt != null) {
+            stat.setStartDate(startAt)
+                    .setEndDate(endAt);
+            return;
+        }
+
+        String delayAt = fields.getString(Field.DELAY_AT);
+        if (delayAt != null) {
+            stat.setStartDate(delayAt)
+                    .setEndDate(delayAt);
+            return;
+        }
+
+        String createdAt = punishment.getString(Field.CREATED_AT);
+        stat.setStartDate(createdAt)
+                .setEndDate(createdAt);
+    }
+}

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/worker/Weekly.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/worker/Weekly.java
@@ -2,10 +2,12 @@ package fr.openent.statistics_presences.indicator.worker;
 
 import fr.openent.presences.common.helper.DateHelper;
 import fr.openent.presences.core.constants.Field;
+import fr.openent.presences.model.TimeslotModel;
 import fr.openent.statistics_presences.bean.Stat;
+import fr.openent.statistics_presences.bean.statistics.StatisticsData;
 import fr.openent.statistics_presences.bean.timeslot.Slot;
-import fr.openent.statistics_presences.bean.weekly.WeeklyStat;
 import fr.openent.statistics_presences.bean.timeslot.Timeslot;
+import fr.openent.statistics_presences.bean.weekly.WeeklyStat;
 import fr.openent.statistics_presences.helper.TimeslotHelper;
 import fr.openent.statistics_presences.indicator.IndicatorGeneric;
 import fr.openent.statistics_presences.indicator.IndicatorWorker;
@@ -15,9 +17,16 @@ import io.vertx.core.Promise;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
+/**
+ * @deprecated  Replaced by {@link StatisticsWorker}
+ */
+@Deprecated
 public class Weekly extends IndicatorWorker {
 
     /**
@@ -62,6 +71,11 @@ public class Weekly extends IndicatorWorker {
         }
 
         return future;
+    }
+
+    @Override
+    protected Future<List<StatisticsData>> fetchEventData(EventType type, String structureId, String studentId, TimeslotModel timeslot, String startDate, String endDate) {
+        throw new UnsupportedOperationException("Deprecated Class");
     }
 
     private Future<List<Stat>> countHandler(Future<JsonArray> requestResult, Timeslot timeslot) {

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/service/impl/DefaultStatisticsService.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/service/impl/DefaultStatisticsService.java
@@ -113,7 +113,6 @@ public class DefaultStatisticsService implements StatisticsService {
     private Future<List<JsonObject>> deleteOldValuesForStudent(String structureId, String studentId, List<JsonObject> values, String startDate, String endDate) {
         Promise<List<JsonObject>> promise = Promise.promise();
         JsonObject selector = new JsonObject()
-                .put(Field.INDICATOR, this.indicatorName)
                 .put(Field.STRUCTURE, structureId)
                 .put(Field.USER, studentId);
         if (startDate != null && endDate != null) {

--- a/statistics-presences/src/test/java/fr/openent/statistics_presences/helper/TimeslotHelperTest.java
+++ b/statistics-presences/src/test/java/fr/openent/statistics_presences/helper/TimeslotHelperTest.java
@@ -1,0 +1,42 @@
+package fr.openent.statistics_presences.helper;
+
+import fr.openent.presences.model.SlotModel;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(VertxUnitRunner.class)
+public class TimeslotHelperTest {
+
+    @Test
+    public void getSlotModelsFromPeriodTest(TestContext ctx) {
+        SlotModel slotModel1 = new SlotModel().setName("slot1").setStartHour("08:30").setEndHour("09:25");
+        SlotModel slotModel2 = new SlotModel().setName("slot2").setStartHour("09:30").setEndHour("10:25");
+        SlotModel slotModel3 = new SlotModel().setName("slot3").setStartHour("10:30").setEndHour("11:25");
+        SlotModel slotModel4 = new SlotModel().setName("slot4").setStartHour("11:30").setEndHour("12:25");
+        List<SlotModel> slotList = Arrays.asList(slotModel1, slotModel2, slotModel3, slotModel4);
+
+        List<SlotModel> actualList = TimeslotHelper.getSlotModelsFromPeriod("2000-10-20T10:00:00",
+                "2000-10-20T12:00:00", slotList);
+
+        ctx.assertEquals(actualList.size(), 3);
+        ctx.assertEquals(actualList.get(0).getName(), slotModel2.getName());
+        ctx.assertEquals(actualList.get(1).getName(), slotModel3.getName());
+        ctx.assertEquals(actualList.get(2).getName(), slotModel4.getName());
+
+        actualList = TimeslotHelper.getSlotModelsFromPeriod("2000-10-20T09:30:00",
+                "2000-10-20T10:25:00", slotList);
+
+        ctx.assertEquals(actualList.size(), 1);
+        ctx.assertEquals(actualList.get(0).getName(), slotModel2.getName());
+
+        actualList = TimeslotHelper.getSlotModelsFromPeriod("2000-10-20T19:30:00",
+                "2000-10-20T20:25:00", slotList);
+
+        ctx.assertEquals(actualList.size(), 0);
+    }
+}

--- a/statistics-presences/src/test/java/fr/openent/statistics_presences/service/impl/DefaultStatisticsServiceTest.java
+++ b/statistics-presences/src/test/java/fr/openent/statistics_presences/service/impl/DefaultStatisticsServiceTest.java
@@ -135,7 +135,7 @@ public class DefaultStatisticsServiceTest {
     public void deleteOldValuesForStudentTest(TestContext ctx) throws Exception {
         Async async = ctx.async();
         String expectedCollection = "presences.statistics";
-        String expectedMatcher = "{\"indicator\":\"indicatorName\",\"structure\":\"structureId\",\"user\":\"studentId\"," +
+        String expectedMatcher = "{\"structure\":\"structureId\",\"user\":\"studentId\"," +
                 "\"start_date\":{\"$gte\":\"startDate\"},\"end_date\":{\"$lte\":\"endDate\"}}";
 
         PowerMockito.doAnswer(invocation -> {


### PR DESCRIPTION
## Describe your changes
When the cron goes basic, we launch 1 worker per indicator which calculates 1 data per indicator. As the data uses the same fields, we decided to make a single worker with a single data to improve performance.

Documentation:  https://confluence.support-ent.fr/display/MP/Statistique+MA-1028

## Issue ticket number and link
[MA-1033](https://jira.support-ent.fr/browse/MA-1033)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

