### PR TITLE
feat(stats): #MA-1044 add start date for manual recalculation API

### DIFF
--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/controller/StatisticsController.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/controller/StatisticsController.java
@@ -224,7 +224,8 @@ public class StatisticsController extends ControllerHelper {
     public void processStatisticsPrefetch(final HttpServerRequest request) {
         RequestUtils.bodyToJson(request, pathPrefix + "processStatisticsPrefetch", body -> {
             List<String> structures = body.getJsonArray(Field.STRUCTURE).getList();
-            statisticsPresencesService.fetchUsers(structures).compose(structureStatisticsUserList ->
+            String startDate = body.getString(Field.START_DATE, null);
+            statisticsPresencesService.fetchUsers(structures, startDate).compose(structureStatisticsUserList ->
                             statisticsPresencesService.processStatisticsPrefetch(structureStatisticsUserList, false))
                     .onSuccess(res -> renderJson(request, res))
                     .onFailure(unused -> renderError(request));

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/service/StatisticsPresencesService.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/service/StatisticsPresencesService.java
@@ -58,6 +58,17 @@ public interface StatisticsPresencesService {
     /**
      * Create a Structure Statistics User from each structure id.
      * In this method we will look for all the students of the structure to create a {@link StatisticsUser}
+     * Each {@link StatisticsUser} have modified date to startDate field
+     *
+     * @param structureIdList structure identifier list
+     * @param startDate modified date for {@link StatisticsUser}
+     * @return Future of result
+     */
+    Future<List<StructureStatisticsUser>> fetchUsers(List<String> structureIdList, String startDate);
+
+    /**
+     * Create a Structure Statistics User from each structure id.
+     * In this method we will look for all the students of the structure to create a {@link StatisticsUser}
      * Each {@link StatisticsUser} have modified date to start school date
      *
      * @param structureIdList structure identifier list

--- a/statistics-presences/src/main/resources/jsonschema/processStatisticsPrefetch.json
+++ b/statistics-presences/src/main/resources/jsonschema/processStatisticsPrefetch.json
@@ -8,6 +8,12 @@
         "array",
         "string"
       ]
+    },
+    "start_date": {
+      "type": [
+        "string",
+        "null"
+      ]
     }
   },
   "required": [


### PR DESCRIPTION
## Describe your changes
Addition of a parameter in the body of the manual recalculation API route allowing you to select the date from which you want to recalculate the statistics.
Doc API: https://confluence.support-ent.fr/display/MP/Statistics

## Issue ticket number and link
[MA-1044](https://jira.support-ent.fr/browse/MA-1044)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

