### PR TITLE
fix(init): #MA-997 fix init alert rule for unregularized alert rule

### DIFF
--- a/common/src/main/java/fr/openent/presences/model/ReasonModel.java
+++ b/common/src/main/java/fr/openent/presences/model/ReasonModel.java
@@ -4,9 +4,6 @@ import fr.openent.presences.core.constants.Field;
 import fr.openent.presences.enums.ReasonType;
 import io.vertx.core.json.JsonObject;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class ReasonModel implements IModel<ReasonModel>{
     private Integer id;
     private String structureId;
@@ -19,7 +16,9 @@ public class ReasonModel implements IModel<ReasonModel>{
     private Boolean isAbsenceCompliance;
     private ReasonType reasonType;
 
-    private boolean alertExclude;
+    private boolean regularizedAlertExclude = true;
+    private boolean unregularizedAlertExclude = true;
+    private boolean latenessAlertExclude = true;
 
     public ReasonModel(JsonObject reason) {
         this.id = reason.getInteger(Field.ID, null);
@@ -127,16 +126,29 @@ public class ReasonModel implements IModel<ReasonModel>{
         return this;
     }
 
-    public boolean isAlertExclude() {
-        return alertExclude;
+    public boolean isRegularizedAlertExclude() {
+        return regularizedAlertExclude;
     }
 
-    public boolean isAlertInclude() {
-        return !alertExclude;
+    public boolean isUnregularizedAlertExclude() {
+        return unregularizedAlertExclude;
+    }
+    public boolean isLatenessAlertExclude() {
+        return latenessAlertExclude;
     }
 
-    public ReasonModel setAlertExclude(boolean alertExclude) {
-        this.alertExclude = alertExclude;
+    public ReasonModel setRegularizedAlertExclude(boolean regularizedAlertExclude) {
+        this.regularizedAlertExclude = regularizedAlertExclude;
+        return this;
+    }
+
+    public ReasonModel setUnregularizedAlertExclude(boolean unregularizedAlertExclude) {
+        this.unregularizedAlertExclude = unregularizedAlertExclude;
+        return this;
+    }
+
+    public ReasonModel setLatenessAlertExclude(boolean latenessAlertExclude) {
+        this.latenessAlertExclude = latenessAlertExclude;
         return this;
     }
 

--- a/presences/src/main/java/fr/openent/presences/helper/init/DefaultInit1DPresencesHelper.java
+++ b/presences/src/main/java/fr/openent/presences/helper/init/DefaultInit1DPresencesHelper.java
@@ -17,33 +17,33 @@ public class DefaultInit1DPresencesHelper implements IInitPresencesHelper {
         List<ReasonModel> reasons = new ArrayList<>();
 
         //Absence reason
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.0").setAlertExclude(true).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.1").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.2").setAlertExclude(true).setProving(false).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.3").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.4").setAlertExclude(true).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.5").setAlertExclude(true).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.6").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.7").setAlertExclude(true).setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.8").setAlertExclude(true).setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.9").setAlertExclude(true).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.10").setAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.11").setAlertExclude(true).setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.12").setAlertExclude(true).setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.13").setAlertExclude(true).setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.14").setAlertExclude(true).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.15").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.16").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.17").setAlertExclude(true).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.18").setAlertExclude(true).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.19").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.20").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.21").setAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.0").setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.1").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.2").setProving(false).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.3").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.4").setUnregularizedAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.5").setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.6").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.7").setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.8").setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.9").setUnregularizedAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.10").setUnregularizedAlertExclude(false).setRegularizedAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.11").setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.12").setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.13").setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.14").setUnregularizedAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.15").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.16").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.17").setUnregularizedAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.18").setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.19").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.20").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.21").setUnregularizedAlertExclude(false).setRegularizedAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
 
         //Lateness reason
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.22").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.LATENESS));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.23").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.LATENESS));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.24").setAlertExclude(false).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.LATENESS));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.22").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.LATENESS));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.23").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.LATENESS));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.1d.24").setLatenessAlertExclude(false).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.LATENESS));
 
         return reasons;
     }

--- a/presences/src/main/java/fr/openent/presences/helper/init/DefaultInit2DPresencesHelper.java
+++ b/presences/src/main/java/fr/openent/presences/helper/init/DefaultInit2DPresencesHelper.java
@@ -17,40 +17,40 @@ public class DefaultInit2DPresencesHelper implements IInitPresencesHelper {
         List<ReasonModel> reasons = new ArrayList<>();
 
         //Absence reason
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.0").setAlertExclude(true).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.1").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.2").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.3").setAlertExclude(true).setProving(false).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.4").setAlertExclude(true).setProving(false).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.5").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.6").setAlertExclude(true).setProving(false).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.7").setAlertExclude(true).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.8").setAlertExclude(true).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.9").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.10").setAlertExclude(true).setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.11").setAlertExclude(true).setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.12").setAlertExclude(true).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.13").setAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.14").setAlertExclude(true).setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.15").setAlertExclude(true).setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.16").setAlertExclude(true).setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.17").setAlertExclude(true).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.18").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.19").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.20").setAlertExclude(true).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.21").setAlertExclude(true).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.22").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.23").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.24").setAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.25").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.26").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.27").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.28").setAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.0").setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.1").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.2").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.3").setProving(false).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.4").setProving(false).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.5").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.6").setProving(false).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.7").setUnregularizedAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.8").setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.9").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.10").setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.11").setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.12").setUnregularizedAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.13").setUnregularizedAlertExclude(false).setRegularizedAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.14").setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.15").setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.16").setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.17").setUnregularizedAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.18").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.19").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.20").setUnregularizedAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.21").setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.22").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.23").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.24").setUnregularizedAlertExclude(false).setRegularizedAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.25").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.26").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.27").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.ABSENCE));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.28").setUnregularizedAlertExclude(false).setRegularizedAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
 
         //Lateness reason
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.29").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.LATENESS));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.30").setAlertExclude(true).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.LATENESS));
-        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.31").setAlertExclude(false).setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.LATENESS));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.29").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.LATENESS));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.30").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.LATENESS));
+        reasons.add(new ReasonModel().setLabel("presences.reasons.init.2d.31").setLatenessAlertExclude(false).setProving(true).setAbsenceCompliance(true).setReasonTypeId(ReasonType.LATENESS));
 
         return reasons;
     }

--- a/presences/src/main/java/fr/openent/presences/service/impl/DefaultInitService.java
+++ b/presences/src/main/java/fr/openent/presences/service/impl/DefaultInitService.java
@@ -45,16 +45,25 @@ public class DefaultInitService implements InitService {
                     .add(reasonModel.isProving())
                     .add(reasonModel.isAbsenceCompliance())
                     .add(reasonModel.getReasonTypeId().getValue());
-            if (reasonModel.isAlertExclude()) {
+            if (reasonModel.isRegularizedAlertExclude() || reasonModel.isUnregularizedAlertExclude() || reasonModel.isLatenessAlertExclude()) {
                 query.append("INSERT INTO ")
                         .append(Presences.dbSchema)
-                        .append(".reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) VALUES " +
-                        "(?, currval('presences.reason_id_seq'), 1)," +
-                        "(?, currval('presences.reason_id_seq'), 2)," +
-                        "(?, currval('presences.reason_id_seq'), 3);");
-                params.add(structure).add(structure).add(structure);
+                        .append(".reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) VALUES ");
+                if (reasonModel.isRegularizedAlertExclude()) {
+                    query.append("(?, currval('presences.reason_id_seq'), 1),");
+                    params.add(structure);
+                }
+                if (reasonModel.isUnregularizedAlertExclude()) {
+                    query.append("(?, currval('presences.reason_id_seq'), 2),");
+                    params.add(structure);
+                }
+                if (reasonModel.isLatenessAlertExclude()) {
+                    query.append("(?, currval('presences.reason_id_seq'), 3),");
+                    params.add(structure);
+                }
+                query.deleteCharAt(query.length() - 1);
+                query.append(";");
             }
-
         });
 
         promise.complete(new JsonObject()

--- a/presences/src/test/java/fr/openent/presences/service/impl/DefaultInitServiceTest.java
+++ b/presences/src/test/java/fr/openent/presences/service/impl/DefaultInitServiceTest.java
@@ -2,6 +2,12 @@ package fr.openent.presences.service.impl;
 
 import fr.openent.presences.core.constants.Field;
 import fr.openent.presences.enums.InitTypeEnum;
+import fr.openent.presences.enums.ReasonType;
+import fr.openent.presences.helper.init.IInitPresencesHelper;
+import fr.openent.presences.model.Action;
+import fr.openent.presences.model.Discipline;
+import fr.openent.presences.model.ReasonModel;
+import fr.openent.presences.model.Settings;
 import fr.wseduc.webutils.I18n;
 import fr.wseduc.webutils.http.Renders;
 import io.vertx.core.Promise;
@@ -19,10 +25,42 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @RunWith(PowerMockRunner.class) //Using the PowerMock runner
 @PowerMockRunnerDelegate(VertxUnitRunner.class) //And the Vertx runner
-@PrepareForTest({I18n.class, Renders.class}) //Prepare the static class you want to test
+@PrepareForTest({I18n.class, Renders.class, IInitPresencesHelper.class}) //Prepare the static class you want to test
 public class DefaultInitServiceTest {
+    IInitPresencesHelper iInitPresencesHelper = new IInitPresencesHelper() {
+        @Override
+        public List<ReasonModel> getReasonsInit() {
+            List<ReasonModel> list = new ArrayList<>();
+            list.add(new ReasonModel().setLabel("presences.reasons.init.1d.0").setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+            list.add(new ReasonModel().setLabel("presences.reasons.init.1d.1").setUnregularizedAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+            list.add(new ReasonModel().setLabel("presences.reasons.init.1d.2").setRegularizedAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+            list.add(new ReasonModel().setLabel("presences.reasons.init.1d.3").setUnregularizedAlertExclude(false).setRegularizedAlertExclude(false).setProving(false).setAbsenceCompliance(true).setReasonTypeId(ReasonType.ABSENCE));
+            list.add(new ReasonModel().setLabel("presences.reasons.init.1d.4").setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.LATENESS));
+            list.add(new ReasonModel().setLabel("presences.reasons.init.1d.5").setLatenessAlertExclude(false).setProving(true).setAbsenceCompliance(false).setReasonTypeId(ReasonType.LATENESS));
+            return list;
+        }
+
+        @Override
+        public List<Action> getActionsInit() {
+            return null;
+        }
+
+        @Override
+        public Settings getSettingsInit() {
+            return null;
+        }
+
+        @Override
+        public List<Discipline> getDisciplinesInit() {
+            return null;
+        }
+    };
+
     DefaultInitService defaultInitService;
     I18n i18n;
 
@@ -31,141 +69,51 @@ public class DefaultInitServiceTest {
         this.defaultInitService = new DefaultInitService();
         PowerMockito.spy(I18n.class);
         PowerMockito.spy(Renders.class);
+        PowerMockito.spy(IInitPresencesHelper.class);
         this.i18n = PowerMockito.spy(I18n.getInstance());
         PowerMockito.doAnswer(invocation -> invocation.getArgument(0)).when(i18n).translate(Mockito.anyString(), Mockito.anyString(), Mockito.anyString());
         PowerMockito.when(I18n.getInstance()).thenReturn(this.i18n);
         PowerMockito.doReturn(null).when(Renders.class, "getHost", Mockito.any());
         PowerMockito.doReturn(null).when(I18n.class, "acceptLanguage", Mockito.any());
+        PowerMockito.doReturn(iInitPresencesHelper).when(IInitPresencesHelper.class, "getDefaultInstance", Mockito.any());
     }
 
     @Test
     public void testGetReasonsStatement(TestContext ctx) {
         Async async = ctx.async();
-        PowerMockito.doAnswer(invocation -> "true")
-                .when(this.i18n).translate(Mockito.eq("incidents.init.2d.incident.seriousness.exclude.alert.2"), Mockito.anyString(), Mockito.anyString());
         JsonHttpServerRequest request = Mockito.mock(JsonHttpServerRequest.class);
         String structure = "structureId";
         InitTypeEnum initTypeEnum = InitTypeEnum.TWO_D;
-        String statement = "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) VALUES " +
-                "(nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id)" +
-                " VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id)" +
+        String statement = "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id)" +
+                " VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);" +
+                "INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id)" +
                 " VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id)" +
+                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id)" +
+                " VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);" +
+                "INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id)" +
+                " VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 3);" +
+                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id)" +
+                " VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);" +
+                "INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id)" +
+                " VALUES (?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
+                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id)" +
+                " VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);" +
+                "INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id)" +
+                " VALUES (?, currval('presences.reason_id_seq'), 3);" +
+                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id)" +
+                " VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);" +
+                "INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id)" +
                 " VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) " +
-                "VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id) " +
-                "VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2),(?, currval('presences.reason_id_seq'), 3);" +
-                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id) VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);";
-        String values = "[\"structureId\",\"presences.reasons.init.2d.0\",false,true,1,\"structureId\",\"structureId\"," +
-                "\"structureId\",\"structureId\",\"presences.reasons.init.2d.1\",true,false,1,\"structureId\",\"structureId\"," +
-                "\"structureId\",\"structureId\",\"presences.reasons.init.2d.2\",true,false,1,\"structureId\",\"structureId\"," +
-                "\"structureId\",\"structureId\",\"presences.reasons.init.2d.3\",false,false,1,\"structureId\",\"structureId\"," +
-                "\"structureId\",\"structureId\",\"presences.reasons.init.2d.4\",false,false,1,\"structureId\",\"structureId\"," +
-                "\"structureId\",\"structureId\",\"presences.reasons.init.2d.5\",true,false,1,\"structureId\",\"structureId\"," +
-                "\"structureId\",\"structureId\",\"presences.reasons.init.2d.6\",false,false,1,\"structureId\",\"structureId\"," +
-                "\"structureId\",\"structureId\",\"presences.reasons.init.2d.7\",false,true,1,\"structureId\",\"structureId\"," +
-                "\"structureId\",\"structureId\",\"presences.reasons.init.2d.8\",false,true,1,\"structureId\",\"structureId\"," +
-                "\"structureId\",\"structureId\",\"presences.reasons.init.2d.9\",true,false,1,\"structureId\",\"structureId\"," +
-                "\"structureId\",\"structureId\",\"presences.reasons.init.2d.10\",true,true,1,\"structureId\",\"structureId\"," +
-                "\"structureId\",\"structureId\",\"presences.reasons.init.2d.11\",true,true,1,\"structureId\",\"structureId\"," +
-                "\"structureId\",\"structureId\",\"presences.reasons.init.2d.12\",false,true,1,\"structureId\",\"structureId\"," +
-                "\"structureId\",\"structureId\",\"presences.reasons.init.2d.13\",false,true,1,\"structureId\"," +
-                "\"presences.reasons.init.2d.14\",true,true,1,\"structureId\",\"structureId\",\"structureId\",\"structureId\"," +
-                "\"presences.reasons.init.2d.15\",true,true,1,\"structureId\",\"structureId\",\"structureId\",\"structureId\"," +
-                "\"presences.reasons.init.2d.16\",true,true,1,\"structureId\",\"structureId\",\"structureId\",\"structureId\"," +
-                "\"presences.reasons.init.2d.17\",false,true,1,\"structureId\",\"structureId\",\"structureId\",\"structureId\"," +
-                "\"presences.reasons.init.2d.18\",true,false,1,\"structureId\",\"structureId\",\"structureId\",\"structureId\"," +
-                "\"presences.reasons.init.2d.19\",true,false,1,\"structureId\",\"structureId\",\"structureId\",\"structureId\"," +
-                "\"presences.reasons.init.2d.20\",false,true,1,\"structureId\",\"structureId\",\"structureId\",\"structureId\"," +
-                "\"presences.reasons.init.2d.21\",false,true,1,\"structureId\",\"structureId\",\"structureId\",\"structureId\"," +
-                "\"presences.reasons.init.2d.22\",true,false,1,\"structureId\",\"structureId\",\"structureId\",\"structureId\"," +
-                "\"presences.reasons.init.2d.23\",true,false,1,\"structureId\",\"structureId\",\"structureId\",\"structureId\"," +
-                "\"presences.reasons.init.2d.24\",false,true,1,\"structureId\"," +
-                "\"presences.reasons.init.2d.25\",true,false,1,\"structureId\",\"structureId\",\"structureId\",\"structureId\"," +
-                "\"presences.reasons.init.2d.26\",true,false,1,\"structureId\",\"structureId\",\"structureId\",\"structureId\"," +
-                "\"presences.reasons.init.2d.27\",true,false,1,\"structureId\",\"structureId\",\"structureId\",\"structureId\"," +
-                "\"presences.reasons.init.2d.28\",false,true,1,\"structureId\"," +
-                "\"presences.reasons.init.2d.29\",true,false,2,\"structureId\",\"structureId\",\"structureId\",\"structureId\"," +
-                "\"presences.reasons.init.2d.30\",true,false,2,\"structureId\",\"structureId\",\"structureId\",\"structureId\"," +
-                "\"presences.reasons.init.2d.31\",true,true,2]";
+                "INSERT INTO null.reason(id, structure_id, label, proving, comment, absence_compliance, reason_type_id)" +
+                " VALUES (nextval('presences.reason_id_seq'), ?,?,?,'',?,?);" +
+                "INSERT INTO null.reason_alert(structure_id, reason_id, reason_alert_exclude_rules_type_id)" +
+                " VALUES (?, currval('presences.reason_id_seq'), 1),(?, currval('presences.reason_id_seq'), 2);";
+        String values = "[\"structureId\",\"presences.reasons.init.1d.0\",false,true,1,\"structureId\",\"structureId\",\"structureId\"," +
+                "\"structureId\",\"presences.reasons.init.1d.1\",false,true,1,\"structureId\",\"structureId\"," +
+                "\"structureId\",\"presences.reasons.init.1d.2\",false,true,1,\"structureId\",\"structureId\"," +
+                "\"structureId\",\"presences.reasons.init.1d.3\",false,true,1,\"structureId\"," +
+                "\"structureId\",\"presences.reasons.init.1d.4\",true,false,2,\"structureId\",\"structureId\",\"structureId\"," +
+                "\"structureId\",\"presences.reasons.init.1d.5\",true,false,2,\"structureId\",\"structureId\"]";
         Promise<JsonObject> promise = Promise.promise();
         promise.future().onSuccess(result -> {
             ctx.assertEquals(result.getString(Field.STATEMENT), statement);


### PR DESCRIPTION
## Describe your changes
When we initialize presences, we could not have an exclusion of alerts only if the reason is not regularized.

## Checklist tests
Initialize presences. Reasons count in alerts only when the reason not regularize.

## Issue ticket number and link
[MA-997](https://jira.support-ent.fr/browse/MA-997)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

