### PR TITLE
fix(model): #MA-1050 fix error cast in IModelHelper

### DIFF
--- a/common/src/main/java/fr/openent/presences/common/helper/IModelHelper.java
+++ b/common/src/main/java/fr/openent/presences/common/helper/IModelHelper.java
@@ -1,12 +1,14 @@
 package fr.openent.presences.common.helper;
 
 import fr.openent.presences.model.IModel;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -27,7 +29,9 @@ public class IModelHelper {
 
     @SuppressWarnings("unchecked")
     public static <T extends IModel<T>> List<T> toList(JsonArray results, Class<T> modelClass) {
-        return ((List<JsonObject>) results.getList()).stream()
+        return results.stream()
+                .filter(JsonObject.class::isInstance)
+                .map(JsonObject.class::cast)
                 .map(iModel -> {
                     try {
                         return modelClass.getConstructor(JsonObject.class).newInstance(iModel);


### PR DESCRIPTION
## Describe your changes
When you create a JsonObject from a list containing LinkerHashMap, and you retrieve this list (JsonArray#getList) you cannot cast this list into a list of JsonObject. If we stream directly (JsonArray#stream) on the JsonArray, the LinkerHashMap elements of the stream are directly converted into JsonObject.

## Issue ticket number and link
[MA-1050](https://jira.support-ent.fr/browse/MA-1050)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

