### PR TITLE
fix(imodel): remove non instanciable class from test

### DIFF
--- a/common/src/main/java/fr/openent/presences/common/helper/IModelHelper.java
+++ b/common/src/main/java/fr/openent/presences/common/helper/IModelHelper.java
@@ -7,6 +7,7 @@ import io.vertx.core.json.JsonObject;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -21,7 +22,7 @@ import java.util.stream.Collectors;
 public class IModelHelper {
     private final static List<Class<?>> validJsonClasses = Arrays.asList(String.class, boolean.class, Boolean.class,
             double.class, Double.class, float.class, Float.class, Integer.class, int.class, CharSequence.class,
-            JsonObject.class, JsonArray.class, Long.class, long.class);
+            JsonObject.class, JsonArray.class, Long.class, long.class, Instant.class);
 
     private IModelHelper() {
         throw new IllegalStateException("Utility class");

--- a/common/src/test/java/fr/openent/presences/common/helper/IModelHelperTest.java
+++ b/common/src/test/java/fr/openent/presences/common/helper/IModelHelperTest.java
@@ -12,6 +12,7 @@ import org.junit.runner.RunWith;
 import org.reflections.Reflections;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -22,6 +23,13 @@ import static org.reflections.scanners.Scanners.SubTypes;
 
 @RunWith(VertxUnitRunner.class)
 public class IModelHelperTest {
+    interface MyInterface extends IModel<MyInterface> {
+        void myMethod();
+    }
+
+    static abstract class MyAbstractClass implements IModel<MyAbstractClass>{
+    }
+
     enum MyEnum {
         VALUE1,
         VALUE2,
@@ -86,6 +94,7 @@ public class IModelHelperTest {
         Set<Class<?>> subTypes =
                 reflections.get(SubTypes.of(IModel.class).asClass());
         List<Class<?>> invalidModel = subTypes.stream()
+                .filter(modelClass -> !Modifier.isAbstract(modelClass.getModifiers()) && !Modifier.isInterface(modelClass.getModifiers()))
                 .filter(modelClass -> !ignoredClassList.contains(modelClass))
                 .filter(modelClass -> {
             Constructor<?> emptyConstructor = Arrays.stream(modelClass.getConstructors())


### PR DESCRIPTION
## Describe your changes
Non-instantiable classes that implement IModel are not required to have a constructor with a jsonObject as an argument, since it will be the child classes that must have this constructor.

interface IChild extand IModel

class Child implement IChild

In this example it is Child who will have to implement the constructor.

Add also forgoten valide class Instant in IModelHelper 

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

