### PR TITLE
fix(stats): #MA-1061 fix end date filter when delete old stats

### DIFF
--- a/common/src/main/java/fr/openent/presences/common/helper/DateHelper.java
+++ b/common/src/main/java/fr/openent/presences/common/helper/DateHelper.java
@@ -18,6 +18,7 @@ public class DateHelper {
     private static final Logger LOGGER = LoggerFactory.getLogger(DateHelper.class);
     public static final Integer TOLERANCE = 3000;
     public static final String SQL_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
+    public static final String SQL_FORMAT_END_DAY = "yyyy-MM-dd'T'23:59:59";
     public static final String SQL_DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSSSSSZ";
     public static final String MONGO_FORMAT = "yyyy-MM-dd HH:mm:ss";
     public static final String MONGO_FORMAT_TO_STRING_YMD_HMINS = "%Y-%m-%d %H:%M:%S";

--- a/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/IndicatorWorker.java
+++ b/statistics-presences/src/main/java/fr/openent/statistics_presences/indicator/IndicatorWorker.java
@@ -265,7 +265,7 @@ public abstract class IndicatorWorker extends AbstractVerticle {
 
                     Promise<Void> init = Promise.promise();
                     Future<Void> current = init.future();
-                    String endDate = DateHelper.getCurrentDate(DateHelper.SQL_FORMAT);
+                    String endDate = DateHelper.getCurrentDate(DateHelper.SQL_FORMAT_END_DAY);
                     Function<Integer, Future<List<JsonObject>>> nextProcessFunction = index -> {
                         log.debug(String.format("[StatisticsPresences@IndicatorWorker::processStructure] " +
                                 "Processing student %s for structure %s", statisticsUserList.get(index).getId(), structureId));


### PR DESCRIPTION
## Describe your changes
When you delete the old stats, you only delete the stats on courses that are necessarily finished (thanks to an end_date < NOW filter). Let's take the following example: it's Thursday the 3rd at 3:30 p.m. and an ABS on the price from 3 p.m. to 4 p.m., and we update. The course end date of the stat is 4:00 p.m. (end_date), which is not less than 3:30 p.m. (NOW). So the stat does not pass through the suppression filter. Then we recreate the same stats, which increments the number.

As a course cannot be on 2 days at the same time, you just have to pass the deletion filter at end_date < 23h59:59. For the above example, 4:00 p.m. is much lower than 11:59:59 p.m., so the stats will be deleted.

## Checklist tests
Be during a course, then refresh the stats of a high that has a regularize abs for that course. The number of statistics no longer increments.

## Issue ticket number and link
[MA-1061](https://jira.support-ent.fr/browse/MA-1061)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

