### PR TITLE
fix(navigation): #MA-1063 hide incidents navigation item when current user has not any view right associated

### DIFF
--- a/presences/src/main/resources/public/template/behaviours/sniplet-navigation.html
+++ b/presences/src/main/resources/public/template/behaviours/sniplet-navigation.html
@@ -47,6 +47,7 @@
                     </span>
                 </a>
                 <div role="menuitem" class="item"
+                     ng-if="hasIncidentRight('access') || hasIncidentRight('readPunishment') || hasIncidentRight('readSanction')"
                      ng-class="{active: getCurrentState() === 'incidents'}"
                      data-ng-click="hoverIn('INCIDENTS')"
                      data-ng-mouseover="hoverIn('INCIDENTS')"


### PR DESCRIPTION
## Describe your changes
Si le compte courant n'a aucun droit de consultation liés à incident, l'item de la barre de navigation "incident" disparait.

## Checklist tests
- Alterner les droits liés à un compte personnel, en enlevant les droit read punishment/sanction/view incident
- Observer la disponibilité ou non de l'item "incident" de la barre de navigation (avec un compte personnel). 

## Issue ticket number and link

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

