### PR TITLE
fix(statistics): #MA-1056 set cells flexible, depending on row size, on global indicator table

### DIFF
--- a/statistics-presences/src/main/resources/public/template/indicator/Global.html
+++ b/statistics-presences/src/main/resources/public/template/indicator/Global.html
@@ -64,7 +64,7 @@
 
     <!-- Students statistics -->
     <div class="tbody">
-        <div class="tr" ng-repeat="student in vm.indicator.values.students">
+        <div class="cell-values tr" ng-repeat="student in vm.indicator.values.students">
             <!-- Audience name -->
             <div class="td text-center flex-row row__6">
                 <span class="flex-col col__1 justify-center">
@@ -76,11 +76,11 @@
                 </span>
             </div>
             <!-- Student name -->
-            <div class="td student ellipsis">
-                <student-name name="student.name" id="student.id"></student-name>
+            <div class="td student ellipsis flex-row text-center">
+                <student-name name="student.name" id="student.id" class="ellipsis"></student-name>
             </div>
             <!-- Total absences -->
-            <div ng-if="vm.indicator.absenceSelected()" class="td text-center indicator-value">
+            <div ng-if="vm.indicator.absenceSelected()" class="td flex-row text-center indicator-value">
                 <span ng-if="student.statistics.ABSENCE_TOTAL !== undefined">
                     [[vm.indicator.displayStudentValue(student, 'ABSENCE_TOTAL')]]
                 </span>
@@ -90,7 +90,7 @@
             </div>
             <!-- Other event types -->
             <div ng-repeat="type in vm.indicator._filterTypes" ng-if="type.selected()"
-                 class="td text-center indicator-value"
+                 class="cell-values td flex-row text-center indicator-value"
                  ng-class="{'max-value': student.statistics[type.name()].max}">
                 <span ng-if="student.statistics[type.name()] !== undefined">
                     [[vm.indicator.displayStudentValue(student, type.name())]]


### PR DESCRIPTION
## Describe your changes
Sur la vue indicateur global, les cases du tableau prennent désormais toute la hauteur quoi qu'il arrive, malgré un nom de classe potentiellement long.

## Checklist tests
- Se connecter avec un compte indé
- Aller sur la page des statistiques globales (présences)
- observer que, malgré une cellule étant composer de la classe + le nom du professeur (grandissant donc la taille de la ligne), les cases (notamment grises) s'adaptent et prennent toute la hauteur.

## Issue ticket number and link
[Jira - MA-1056](https://jira.support-ent.fr/browse/MA-1056)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

