### PR TITLE
fix(security): #MA-1080 get courses from presences module now require for current user to be is wanted structure and have register right.

### DIFF
--- a/presences/src/main/java/fr/openent/presences/controller/CourseController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/CourseController.java
@@ -7,6 +7,7 @@ import fr.openent.presences.core.constants.*;
 import fr.openent.presences.export.RegisterCSVExport;
 import fr.openent.presences.helper.CourseHelper;
 import fr.openent.presences.model.*;
+import fr.openent.presences.security.RegisterViewRight;
 import fr.openent.presences.service.*;
 import fr.openent.presences.service.impl.*;
 import fr.wseduc.rs.ApiDoc;
@@ -22,6 +23,7 @@ import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.entcore.common.controller.ControllerHelper;
+import org.entcore.common.http.filter.ResourceFilter;
 import org.entcore.common.http.filter.Trace;
 import org.entcore.common.user.UserInfos;
 import org.entcore.common.user.UserUtils;
@@ -52,7 +54,8 @@ public class CourseController extends ControllerHelper {
 
     @Get("/courses")
     @ApiDoc("Get courses")
-    @SecuredAction(value = "", type = ActionType.AUTHENTICATED)
+    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(RegisterViewRight.class)
     public void getCourses(HttpServerRequest request) {
         MultiMap params = request.params();
         if (!courseHelper.checkParams(params)) {

--- a/presences/src/main/java/fr/openent/presences/security/RegisterViewRight.java
+++ b/presences/src/main/java/fr/openent/presences/security/RegisterViewRight.java
@@ -1,0 +1,23 @@
+package fr.openent.presences.security;
+
+import fr.openent.presences.common.helper.WorkflowHelper;
+import fr.openent.presences.core.constants.Field;
+import fr.openent.presences.enums.WorkflowActions;
+import fr.wseduc.webutils.http.Binding;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import org.entcore.common.http.filter.ResourcesProvider;
+import org.entcore.common.user.UserInfos;
+
+public class RegisterViewRight implements ResourcesProvider {
+    @Override
+    public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
+        String structure = request.getParam(Field.STRUCTUREID);
+        structure = structure != null ? structure : request.getParam(Field.STRUCTURE_ID);
+        structure = structure != null ? structure : request.getParam(Field.STRUCTURE);
+        handler.handle(
+                user.getStructures().contains(structure) &&
+                        WorkflowHelper.hasRight(user, WorkflowActions.READ_REGISTER.toString())
+        );
+    }
+}


### PR DESCRIPTION
## Describe your changes
Fait parti des [fix de sécurité](https://jira.support-ent.fr/browse/MA-1057)

Désormais, la récupération des courses est désormais soumise au droit presences.register.read, et ne permet de récupérer que les cours étant de la même structure que l'utilisateur connecté.

doc modifiée
https://confluence.support-ent.fr/display/MP/Configuration+des+droits+Workflow

## Checklist tests
- Test la route suivante: /presences/courses?structure={identifiant structure choisit}&start=2023-01-30&end=2023-02-06&_t=2023-02-02%2009:53:00 (directement, en URL de navigateur)
- Tester d'ajouter ou d'enlever le droit afin de vérifier l'accès ou le non l'accès aux données
- Tester avec une autre structure que celle de l'utilisateur actuel, afin de vérifier qu'il n'a pas accès au cours des autres étab.

## Issue ticket number and link
[Jira - MA-1080](https://jira.support-ent.fr/browse/MA-1080)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

