### PR TITLE
fix(security): #MA-1074 set massmailing module accessible with classical or 1d manage rights.

### DIFF
--- a/massmailing/src/main/java/fr/openent/massmailing/Massmailing.java
+++ b/massmailing/src/main/java/fr/openent/massmailing/Massmailing.java
@@ -30,7 +30,6 @@ public class Massmailing extends BaseServer {
     public static final String MANAGE = "massmailing.manage";
     public static final String MANAGE_RESTRICTED = "massmailing.manage.restricted";
     public static final String VIEW = "massmailing.view";
-    public static final String VIEW_RESTRICTED = "massmailing.view.restricted";
 
     public static String SMS_ADDRESS = "entcore.sms";
 

--- a/massmailing/src/main/java/fr/openent/massmailing/actions/WorkflowActions.java
+++ b/massmailing/src/main/java/fr/openent/massmailing/actions/WorkflowActions.java
@@ -4,7 +4,6 @@ import fr.openent.massmailing.Massmailing;
 
 public enum WorkflowActions {
     VIEW(Massmailing.VIEW),
-    VIEW_RESTRICTED(Massmailing.VIEW_RESTRICTED),
     MANAGE(Massmailing.MANAGE),
     MANAGE_RESTRICTED(Massmailing.MANAGE_RESTRICTED);
 

--- a/massmailing/src/main/java/fr/openent/massmailing/actions/WorkflowActionsCouple.java
+++ b/massmailing/src/main/java/fr/openent/massmailing/actions/WorkflowActionsCouple.java
@@ -3,8 +3,6 @@ package fr.openent.massmailing.actions;
 import fr.openent.presences.common.security.IWorkflowActionsCouple;
 
 public enum WorkflowActionsCouple implements IWorkflowActionsCouple {
-
-    VIEW(WorkflowActions.VIEW, WorkflowActions.VIEW_RESTRICTED),
     MANAGE(WorkflowActions.MANAGE, WorkflowActions.MANAGE_RESTRICTED);
 
     private final WorkflowActions unrestrictedAction;

--- a/massmailing/src/main/java/fr/openent/massmailing/controller/FakeRight.java
+++ b/massmailing/src/main/java/fr/openent/massmailing/controller/FakeRight.java
@@ -15,12 +15,6 @@ public class FakeRight extends ControllerHelper {
         request.response().setStatusCode(501).end();
     }
 
-    @Get("/rights/view/restricted")
-    @SecuredAction(Massmailing.VIEW_RESTRICTED)
-    public void viewRestricted(HttpServerRequest request) {
-        notImplemented(request);
-    }
-
     @Get("/rights/manage/restricted")
     @SecuredAction(Massmailing.MANAGE_RESTRICTED)
     public void manageRestricted(HttpServerRequest request) {

--- a/massmailing/src/main/java/fr/openent/massmailing/controller/MailingController.java
+++ b/massmailing/src/main/java/fr/openent/massmailing/controller/MailingController.java
@@ -65,7 +65,7 @@ public class MailingController extends ControllerHelper {
 
 
         UserUtils.getUserInfos(eb, request, userInfos -> {
-            boolean hasRestrictedRight = WorkflowActionsCouple.VIEW.hasOnlyRestrictedRight(userInfos, UserType.TEACHER.equals(userInfos.getType()));
+            boolean hasRestrictedRight = WorkflowActionsCouple.MANAGE.hasOnlyRestrictedRight(userInfos, UserType.TEACHER.equals(userInfos.getType()));
             String teacherId = hasRestrictedRight ? userInfos.getUserId() : null;
 
             Future<List<String>> studentsFromTeacherFuture = this.userService.getStudentsFromTeacher(teacherId, structureId);

--- a/massmailing/src/main/java/fr/openent/massmailing/security/BodyCanAccessMassMailing.java
+++ b/massmailing/src/main/java/fr/openent/massmailing/security/BodyCanAccessMassMailing.java
@@ -17,7 +17,7 @@ public class BodyCanAccessMassMailing implements ResourcesProvider {
         RequestUtils.bodyToJson(request, body -> {
             String structureId = body.getString(Field.STRUCTURE);
             List<String> structures = userInfos.getStructures();
-            handler.handle(structures.contains(structureId) && WorkflowActionsCouple.VIEW.hasRight(userInfos));
+            handler.handle(structures.contains(structureId) && WorkflowActionsCouple.MANAGE.hasRight(userInfos));
         });
     }
 }


### PR DESCRIPTION
## Describe your changes
Suppression du droit massmailing.view.restricted afin que massmailing.view ne permette que l'accès au module, et que massmailing.manage et massmailing.manage.restricted soient utilisés pour distinguer une récupération complète ou restreinte.

[Doc - confluence](https://confluence.support-ent.fr/display/MP/Configuration+des+droits+Workflow)

A la prochaine livraison, il faudra jouer cette requête:
`MATCH (a:Action) where a.displayName = "massmailing.view.restricted" OPTIONAL MATCH (a)-[r]-() delete a, r`

## Checklist tests
- Ajouter le droit massmailing.view de manière systématique (pour les utilisateurs ayant accès à massmailing)
- Jongler entre le droit massmailing.manage et massmailing.manage.restricted et vérifier que l'utilisateur a toujours accès à massmailing

## Issue ticket number and link
[Jira - MA-1074](https://jira.support-ent.fr/browse/MA-1074)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

