### PR TITLE
fix(registry): #MA-1075 fix search students from groups remains distinct

### DIFF
--- a/common/src/main/java/fr/openent/presences/common/service/GroupService.java
+++ b/common/src/main/java/fr/openent/presences/common/service/GroupService.java
@@ -61,6 +61,7 @@ public interface GroupService {
      * @param handler FUnction handler returning data
      */
     void getGroupStudents(List<String> groups, Handler<Either<String, JsonArray>> handler);
+    Future<JsonArray> getGroupStudents(String structureId, List<String> groups);
 
     Future<JsonArray> getGroupStudents(List<String> groups);
 

--- a/common/src/main/java/fr/openent/presences/core/constants/Field.java
+++ b/common/src/main/java/fr/openent/presences/core/constants/Field.java
@@ -77,6 +77,7 @@ public class Field {
     public static final String END_AT = "end_at";
     public static final String ENDAT = "endAt";
     public static final String DATE = "date";
+    public static final String DAYS = "days";
     public static final String START_DATE = "start_date";
     public static final String STARTDATE = "startDate";
     public static final String START = "start";
@@ -200,6 +201,7 @@ public class Field {
     public static final String DEPARTURE = "departure";
     public static final String REMARK = "remark";
     public static final String FORGOTTEN_NOTEBOOK = "forgotten_notebook";
+    public static final String FORGOTTENNOTEBOOK = "forgottenNotebook";
     public static final String SANCTION = "sanction";
     public static final String FOLLOWED = "followed";
     public static final String MASSMAILED = "massmailed";
@@ -255,6 +257,7 @@ public class Field {
     public static final String HALFBOARDER = "halfBoarder";
     public static final String INTERNAL = "internal";
     public static final String ACCOMMODATION = "accommodation";
+    public static final String GROUPIDS = "groupIds";
 
 
     // UserInfos


### PR DESCRIPTION
## Describe your changes
Retour de la https://github.com/OPEN-ENT-NG/presences/pull/291

En recherchant des Etudiants, il restait des doublons dû au non regroupement par élèves.

## Checklist tests
- Rechercher plusieurs groupes en même temps avec un même élève étant dans des classes et groupes différents
- Vérifier qu'il n'apparait jamais en double.

## Issue ticket number and link
[Jira - MA-1075](https://jira.support-ent.fr/browse/MA-1075)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

