### PR TITLE
fix(security): #MA-1083 fix statistics graph when not from struct or …

### DIFF
--- a/presences/src/main/java/fr/openent/presences/controller/StatisticsController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/StatisticsController.java
@@ -4,7 +4,7 @@ import fr.openent.presences.Presences;
 import fr.openent.presences.common.security.UserInStructure;
 import fr.openent.presences.common.statistics_presences.StatisticsPresences;
 import fr.openent.presences.core.constants.Field;
-import fr.openent.presences.security.StatisticsAccessData;
+import fr.openent.presences.security.StatisticsViewRightAndStruct;
 import fr.wseduc.rs.Post;
 import fr.wseduc.security.ActionType;
 import fr.wseduc.security.SecuredAction;
@@ -21,8 +21,8 @@ import org.entcore.common.user.UserUtils;
 public class StatisticsController extends ControllerHelper {
 
     @Post("/statistics/structures/:structure/student/:student/graph")
-    @ResourceFilter(StatisticsAccessData.class)
-    @SecuredAction(value = "", type = ActionType.AUTHENTICATED)
+    @SecuredAction(value = "", type = ActionType.RESOURCE)
+    @ResourceFilter(StatisticsViewRightAndStruct.class)
     public void getStatisticsGraph(HttpServerRequest request) {
         request.pause();
         UserUtils.getUserInfos(eb, request, user ->

--- a/presences/src/main/java/fr/openent/presences/security/StatisticsViewRightAndStruct.java
+++ b/presences/src/main/java/fr/openent/presences/security/StatisticsViewRightAndStruct.java
@@ -11,9 +11,7 @@ import org.entcore.common.user.UserInfos;
 public class StatisticsViewRightAndStruct implements ResourcesProvider {
     @Override
     public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
-        String structure = request.getParam(Field.STRUCTUREID);
-        structure = structure != null ? structure : request.getParam(Field.STRUCTURE_ID);
-        structure = structure != null ? structure : request.getParam(Field.STRUCTURE);
+        String structure = request.getParam(Field.STRUCTURE);
 
         handler.handle(
                 user.getStructures().contains(structure) &&

--- a/presences/src/main/java/fr/openent/presences/security/StatisticsViewRightAndStruct.java
+++ b/presences/src/main/java/fr/openent/presences/security/StatisticsViewRightAndStruct.java
@@ -1,0 +1,23 @@
+package fr.openent.presences.security;
+
+import fr.openent.presences.core.constants.Field;
+import fr.openent.presences.enums.WorkflowActionsCouple;
+import fr.wseduc.webutils.http.Binding;
+import io.vertx.core.Handler;
+import io.vertx.core.http.HttpServerRequest;
+import org.entcore.common.http.filter.ResourcesProvider;
+import org.entcore.common.user.UserInfos;
+
+public class StatisticsViewRightAndStruct implements ResourcesProvider {
+    @Override
+    public void authorize(HttpServerRequest request, Binding binding, UserInfos user, Handler<Boolean> handler) {
+        String structure = request.getParam(Field.STRUCTUREID);
+        structure = structure != null ? structure : request.getParam(Field.STRUCTURE_ID);
+        structure = structure != null ? structure : request.getParam(Field.STRUCTURE);
+
+        handler.handle(
+                user.getStructures().contains(structure) &&
+                        WorkflowActionsCouple.VIEW_STATISTICS.hasRight(user)
+        );
+    }
+}


### PR DESCRIPTION
## Describe your changes

Added resource filter to check if user who is trying to get the statistics graph is from the right structures and has the rights to view statistics.

## Checklist tests

Fonctionnellement : Voir si le graph dans le memento d'un élève s'affiche sans erreur lorsque l'on est professeur ou CPE de la bonne structure

• Test la route suivante: /presences/statistics/structures/{idStructureAChanger}/student/{idStudentAChanger}/graph (en URL de navigateur)
• Tester d'ajouter ou d'enlever le droit afin de vérifier l'accès ou non aux données
• Tester avec une autre structure que celle de l'utilisateur actuel, afin de vérifier qu'il n'a pas accès aux appels des autres étabs.


## Issue ticket number and link
[MA-1083](https://jira.support-ent.fr/browse/MA-1083)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

