### PR TITLE
fix(statistics): #MA-1101 update stat trigger on event update for date

### DIFF
--- a/presences/src/main/resources/sql/059-MA-1101-fix-update-stats-trigger.sql
+++ b/presences/src/main/resources/sql/059-MA-1101-fix-update-stats-trigger.sql
@@ -1,0 +1,51 @@
+CREATE OR REPLACE FUNCTION presences.delete_statistics_on_event_handler() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+    stat_exists boolean;
+    structureid character varying;
+BEGIN
+    SELECT EXISTS(SELECT
+                  FROM information_schema.tables
+                  WHERE table_schema = 'presences_statistics'
+                    AND table_name = 'user')
+    INTO stat_exists;
+    IF stat_exists THEN
+        SELECT structure_id FROM presences.register WHERE id = OLD.register_id INTO structureid;
+
+        INSERT INTO presences_statistics."user"(id, structure, modified)
+        VALUES (OLD.student_id, structureid, OLD.start_date)
+        ON CONFLICT (id, structure)
+            DO UPDATE SET modified = LEAST(OLD.start_date, presences_statistics."user".modified)
+            WHERE presences_statistics."user".modified > OLD.start_date;
+    END IF;
+
+    RETURN OLD;
+END
+$BODY$
+    LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION presences.statistics_on_event_handler() RETURNS TRIGGER AS
+$BODY$
+DECLARE
+    stat_exists boolean;
+    structureid character varying;
+BEGIN
+    SELECT EXISTS(SELECT
+                  FROM information_schema.tables
+                  WHERE table_schema = 'presences_statistics'
+                    AND table_name = 'user')
+    INTO stat_exists;
+    IF stat_exists THEN
+        SELECT structure_id FROM presences.register WHERE id = NEW.register_id INTO structureid;
+
+        INSERT INTO presences_statistics."user"(id, structure, modified)
+        VALUES (NEW.student_id, structureid, NEW.start_date)
+        ON CONFLICT (id, structure)
+            DO UPDATE SET modified = LEAST(NEW.start_date, presences_statistics."user".modified)
+            WHERE presences_statistics."user".modified > NEW.start_date;
+    END IF;
+
+    RETURN NEW;
+END
+$BODY$
+    LANGUAGE plpgsql;


### PR DESCRIPTION
## Describe your changes

Updated statistics triggers for event creation/modification/deletion : 
- set modified date to the earliest date of modified/deleted events
- events are no longer ignored on CRON stat update

## Checklist tests

To reproduce the previous issue : 
- modify/delete an event on date 1 and an other on date 2 
- after stat update triggered by the cron, check that the stats number are correct

## Issue ticket number and link

https://jira.support-ent.fr/browse/MA-1101

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

