### PR TITLE
fix(multimailing) : #MA-1096 fix students filter list depleting when selecting a student when one was already selected.

### DIFF
--- a/common/src/main/resources/ts/utils/autocomplete/studentsSearch.ts
+++ b/common/src/main/resources/ts/utils/autocomplete/studentsSearch.ts
@@ -51,8 +51,7 @@ export class StudentsSearch extends AutoCompleteUtils {
     }
 
     public selectStudent(valueInput, studentItem) {
-        if (this._selectedStudents == null)
-            this._selectedStudents = [];
+        this._selectedStudents = [];
         this._selectedStudents.push(studentItem);
     }
 

--- a/common/src/main/resources/ts/utils/autocomplete/studentsSearch.ts
+++ b/common/src/main/resources/ts/utils/autocomplete/studentsSearch.ts
@@ -51,7 +51,8 @@ export class StudentsSearch extends AutoCompleteUtils {
     }
 
     public selectStudent(valueInput, studentItem) {
-        this._selectedStudents = [];
+        if (this._selectedStudents == null)
+            this._selectedStudents = [];
         this._selectedStudents.push(studentItem);
     }
 

--- a/massmailing/src/main/resources/public/ts/controllers/home.ts
+++ b/massmailing/src/main/resources/public/ts/controllers/home.ts
@@ -487,7 +487,7 @@ export const homeController = ng.controller('HomeController', ['$scope', 'route'
             if (vm.filter.studentsSearch.getSelectedStudents().find((student: Student) => student.id == studentSelected.id)) {
                 return;
             }
-            vm.formFilter.studentsSearch.selectStudent(model, studentSelected);
+            vm.formFilter.studentsSearch.selectStudents(model, studentSelected);
             vm.formFilter.studentsSearch.student = '';
             vm.formFilter.studentsSearch.resetStudents();
             $scope.safeApply();

--- a/presences/src/main/resources/public/template/alerts/table.html
+++ b/presences/src/main/resources/public/template/alerts/table.html
@@ -4,7 +4,8 @@
              ng-repeat="alert in vm.listAlert"
              ng-model="selected"
              ng-class="{selected: alert.selected}"
-             ng-click="vm.toggleAlert(alert)">
+             ng-click="vm.toggleAlert(alert)"
+             ng-if="alert.name">
             <div class="twelve flex space-between">
                 <div class="bold">[[alert.name]]</div>
                 <div>[[alert.audience]]</div>

--- a/presences/src/main/resources/public/ts/controllers/registers.ts
+++ b/presences/src/main/resources/public/ts/controllers/registers.ts
@@ -282,6 +282,7 @@ export const registersController = ng.controller('RegistersController',
                     getReasons();
                     if (vm.register !== undefined && vm.register.id !== undefined) {
                         await vm.register.sync();
+                        vm.filter.date = moment(vm.register.start_date).toDate();
                         await initCourses();
                         if (vm.register.teachers.length > 0) vm.filter.selected.registerTeacher = vm.register.teachers[0];
                         $scope.safeApply();
@@ -291,6 +292,7 @@ export const registersController = ng.controller('RegistersController',
                         vm.register.eventer.once('loading::true', () => $scope.safeApply());
                         vm.register.eventer.once('loading::false', () => $scope.safeApply());
                         await vm.register.sync();
+                        vm.filter.date = moment(vm.register.start_date).toDate();
                         await initCourses();
                     }
                 },


### PR DESCRIPTION
## Describe your changes
fix students filter list depleting when selecting a student when one was already selected because of emptying too much the selectedStudent tab.

## Checklist tests
Publipostage -> Bouton des filtres (à gauche de Absences sans motif) -> Sélectionner plusieurs élèves via la liste, ils sont sensés s'afficher ensemble.

## Issue ticket number and link
[MA-1096](https://jira.support-ent.fr/browse/MA-1096)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

