### PR TITLE
fix(i18n): #MA-983 move presences related i18n

### DIFF
--- a/presences/src/main/resources/i18n/en.json
+++ b/presences/src/main/resources/i18n/en.json
@@ -571,5 +571,21 @@
   "presences.export.lightbox.warning.6": "Dans le cas d'un petit export (<1000 lignes),",
   "presences.export.lightbox.warning.7": "le fichier sera directement téléchargeable après validation,",
   "presences.export.lightbox.warning.8": "une copie sera tout de même à disposition dans l'espace documentaire.",
-  "presences.do.not.show.this.message.again": "Ne plus afficher ce message"
+  "presences.do.not.show.this.message.again": "Ne plus afficher ce message",
+  "presences.absence.edit.warning": "Attention, la modification du motif entraînera une modification sur toutes les absences déjà saisies avec ce motif.",
+  "presences.absence.reason.edit": "Modifier le motif",
+  "presences.absence.reason.form.input": "Saisissez ici un motif d'absence individuelle que vous pourrez utiliser dans l'application Présences",
+  "presences.absence.reason.form.input.edit": "Modifier le motif",
+  "presences.absence.reason.form.input.edit.warning": "Attention, la modification du motif entraînera une modification sur toutes les absences déjà saisies avec ce motif. ",
+  "presences.data.init": "Initialisation des données",
+  "presences.data.init.are": "Les données suivantes seront initialisées",
+  "presences.data.init.success": "Les données ont été correctement initialisées",
+  "presences.data.init.error": "Une erreur est survenue lors de l'initialisation des données",
+  "presence.existed.reasons": "Motifs existants",
+  "presences.motifs": "Motifs",
+  "presences.state.call": "Etat de l'appel",
+  "presences.setting.data.init": "Initialisation des données de l'application",
+  "presences.start.init": "Lancer l'initialisation",
+  "presences.compliance.absence": "Ce motif doit-il être pris en compte dans la comptatibilité des absences pour le bulletin de l'élève ?",
+  "presences.regularisable": "Ce motif nécessite-t-il une régularisation pour être justifié ?"
 }

--- a/presences/src/main/resources/i18n/fr.json
+++ b/presences/src/main/resources/i18n/fr.json
@@ -673,5 +673,21 @@
   "presences.absence.reason.lateness": "Alerte pour ce motif",
   "presences.alerts.exclude.absence.no.reason": "Les absences sans motif comptent dans les alertes",
   "presences.alerts.exclude.lateness.no.reason": "Les retards sans motif comptent dans les alertes",
-  "presences.alerts.exclude.foregotten.notebook": "Les carnets oubliés comptent dans les alertes"
+  "presences.alerts.exclude.foregotten.notebook": "Les carnets oubliés comptent dans les alertes",
+  "presences.absence.edit.warning": "Attention, la modification du motif entraînera une modification sur toutes les absences déjà saisies avec ce motif.",
+  "presences.absence.reason.edit": "Modifier le motif",
+  "presences.absence.reason.form.input": "Saisissez ici un motif d'absence individuelle que vous pourrez utiliser dans l'application Présences",
+  "presences.absence.reason.form.input.edit": "Modifier le motif",
+  "presences.absence.reason.form.input.edit.warning": "Attention, la modification du motif entraînera une modification sur toutes les absences déjà saisies avec ce motif. ",
+  "presences.data.init": "Initialisation des données",
+  "presences.data.init.are": "Les données suivantes seront initialisées",
+  "presences.data.init.success": "Les données ont été correctement initialisées",
+  "presences.data.init.error": "Une erreur est survenue lors de l'initialisation des données",
+  "presence.existed.reasons": "Motifs existants",
+  "presences.motifs": "Motifs",
+  "presences.state.call": "Etat de l'appel",
+  "presences.setting.data.init": "Initialisation des données de l'application",
+  "presences.start.init": "Lancer l'initialisation",
+  "presences.compliance.absence": "Ce motif doit-il être pris en compte dans la comptatibilité des absences pour le bulletin de l'élève ?",
+  "presences.regularisable": "Ce motif nécessite-t-il une régularisation pour être justifié ?"
 }

--- a/presences/src/main/resources/public/template/behaviours/sniplet-presences-manage/reason-manage/sniplet-presences-reason-manage-absence.html
+++ b/presences/src/main/resources/public/template/behaviours/sniplet-presences-manage/reason-manage/sniplet-presences-reason-manage-absence.html
@@ -23,7 +23,7 @@
         <!-- Regularisable form -->
         <div class="sniplet-input">
             <label class="sniplet-input-title">
-                <i18n>regularisable</i18n>
+                <i18n>presences.regularisable</i18n>
             </label>
             <div class="sniplet-input-flex">
                 <div class="md-radio md-radio-inline">
@@ -53,7 +53,7 @@
         <!-- Compliance form -->
         <div class="sniplet-input">
             <label class="sniplet-input-title">
-                <i18n>compliance.absence</i18n>
+                <i18n>presences.compliance.absence</i18n>
             </label>
             <div>
                 <div class="md-radio md-radio-inline">

--- a/presences/src/main/resources/public/template/behaviours/sniplet-presences-manage/reason-manage/sniplet-presences-reason-manage-lightbox.html
+++ b/presences/src/main/resources/public/template/behaviours/sniplet-presences-manage/reason-manage/sniplet-presences-reason-manage-lightbox.html
@@ -23,7 +23,7 @@
 
         <!-- Regularisable form -->
         <label ng-if="vm.reasonTypeId == 1">
-            <i18n>regularisable</i18n>
+            <i18n>presences.regularisable</i18n>
         </label>
         <div ng-if="vm.reasonTypeId == 1" class="sniplet-form-lightbox-body-regularisable">
             <div class="md-radio md-radio-inline">
@@ -51,7 +51,7 @@
 
         <!-- Compliance -->
         <label>
-            <i18n>compliance.absence</i18n>
+            <i18n>presences.compliance.absence</i18n>
         </label>
         <div class="sniplet-form-lightbox-body-compliance">
             <div class="md-radio md-radio-inline">


### PR DESCRIPTION
## Describe your changes
Move presences related i18n from vie-sco to presences modules.
## Checklist tests
In Vie-scolaire params > presences check if the text does not contain any i18n key but only text
In presences check in all pages if the textes does not contains any i18n key but only text

## Issue ticket number and link
[MA-983](https://jira.support-ent.fr/browse/MA-983)
[Vie-sco PR](https://github.com/OPEN-ENT-NG/vie-scolaire/pull/125)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

