### PR TITLE
fix(i18n): #MA-1100 fix i18n key displayed rather than the value

### DIFF
--- a/statistics-presences/src/main/resources/public/template/filter.html
+++ b/statistics-presences/src/main/resources/public/template/filter.html
@@ -23,7 +23,7 @@
                      ng-repeat="reason in vm.getAbsenceReasons() | orderBy:'label' track by $index"
                      ng-class="{ selected: vm.indicator._factoryFilter.reasonsMap[reason.id] }"
                      data-ng-click="vm.toggleReason(reason)">
-                    <span class="no-style">[[reason.label]]</span>
+                    <span class="no-style">[[vm.translate(reason.label)]]</span>
                 </div>
             </div>
         </div>

--- a/statistics-presences/src/main/resources/public/ts/controllers/main.ts
+++ b/statistics-presences/src/main/resources/public/ts/controllers/main.ts
@@ -111,6 +111,8 @@ interface ViewModel {
     getAbsenceReasons(): Array<Reason>;
 
     getLatenessReasons(): Array<Reason>;
+
+    translate(key: string): string;
 }
 
 export const mainController = ng.controller('MainController',
@@ -204,6 +206,9 @@ export const mainController = ng.controller('MainController',
                 proceedOnChangeFilterMonth();
                 await vm.resetIndicator();
             };
+
+            vm.translate = (key: string): string => idiom.translate(key);
+
 
             const proceedOnChangeFilterMonth = (): void => {
 


### PR DESCRIPTION
## Describe your changes
fixed i18n key displayed rather than the value in statistics-presences filters

## Checklist tests
Go to Présences > Statistiques > click on the filter icon 
![image](https://github.com/OPEN-ENT-NG/presences/assets/57497688/76a60015-c0d1-42c7-a422-4189e21050f7)
And check if there is a i18n key or not
## Issue ticket number and link
[MA-1100](https://jira.support-ent.fr/browse/MA-1100)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

