### PR TITLE
fix(pagination): #MA-1141 fix pagination showing when not necessary

### DIFF
--- a/incidents/src/main/java/fr/openent/incidents/service/impl/DefaultIncidentsService.java
+++ b/incidents/src/main/java/fr/openent/incidents/service/impl/DefaultIncidentsService.java
@@ -258,7 +258,7 @@ public class DefaultIncidentsService extends SqlCrudService implements Incidents
 
         // Retrieve number of incidents if in pagination mode
         if (paginationMode) {
-            query += "SELECT COUNT(*) ";
+            query += "SELECT COUNT(DISTINCT i.id) ";
         }
         // Retrieve incidents
         else {


### PR DESCRIPTION
## Describe your changes
Fix the issue where incidents with 2 or more protagonists were incorrectly counted as more than 1 incident in pagination computation.
## Checklist tests
You need to have a number of incidents that is a multiple of 19. Then add another incident with 2 protagonists. It should not create a new page.
## Issue ticket number and link
[MA-1141](https://jira.support-ent.fr/browse/MA-1141)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

