### PR TITLE
fix(forgotten-notebooks): #MA-1159 display only w/ manageForgottenNotebook right

### DIFF
--- a/presences/src/main/resources/public/template/dashboard/dashboard-student/content.html
+++ b/presences/src/main/resources/public/template/dashboard/dashboard-student/content.html
@@ -98,7 +98,7 @@
         </events-card>
 
         <!-- forgotten notebook -->
-        <events-card ng-if="!hasRight('presences1D')"
+        <events-card ng-if="hasRight('manageForgottenNotebook')"
                      event-title="vm.eventsTitle.forgottenNotebook"
                      student="vm.filter.selectedChildren"
                      period="vm.filter.selectedPeriod"

--- a/presences/src/main/resources/public/template/register/register.html
+++ b/presences/src/main/resources/public/template/register/register.html
@@ -65,7 +65,7 @@
         </div>
         <!-- EVENT LEGENDS -->
         <events-legend absence="true" lateness="true" departure="true" remark="true" previously-absent="true"
-                       widget-forgotten-notebook="!hasRight('presences1D')">
+                       widget-forgotten-notebook="hasRight('manageForgottenNotebook')">
         </events-legend>
 
         <div ng-show="vm.register && !vm.register.loading" class="valid-content flex-column flex-one right-magnet">

--- a/presences/src/main/resources/public/template/registry/header.html
+++ b/presences/src/main/resources/public/template/registry/header.html
@@ -72,7 +72,7 @@
     </div>
     <!-- EVENT LEGENDS -->
     <events-legend absence-no-reason="true" absence-not-regularized="true" absence-regularized="true"
-                   absence-followed="true" lateness="true" departure="true" forgotten-notebook="!hasRight('presences1D')"
+                   absence-followed="true" lateness="true" departure="true" forgotten-notebook="hasRight('manageForgottenNotebook')"
                    incident="!hasRight('presences1D')">
     </events-legend>
     </div>

--- a/presences/src/main/resources/public/template/widgets/alerts.html
+++ b/presences/src/main/resources/public/template/widgets/alerts.html
@@ -18,7 +18,7 @@
                 <i18n>presences.widgets.alerts.incidents</i18n>
             </div>
         </div>
-        <div ng-if="!hasRight('presences1D')" workflow="presences.manageForgottenNotebook"
+        <div workflow="presences.manageForgottenNotebook"
              class="widget-alert textbooks" ng-click="vm.goToAlerts('FORGOTTEN_NOTEBOOK')">
             <div class="value">[[vm.alert.FORGOTTEN_NOTEBOOK]]</div>
             <div class="subtitle">


### PR DESCRIPTION
## Describe your changes

- add requirement of manageForgottenNotebook for forgotten notebooks panels
- remove useless requirement of presences1D right for forgotten notebooks panels

## Checklist tests

Check if activating manageForgottenNotebook  right allows displaying of : 
- Forgotten notebook card in student dashboard
- Forgotten notebook item in legend for register page
- Forgotten notebook item in legend for registry page
- Forgotten notebook card alert in dashboard

## Issue ticket number and link

https://jira.support-ent.fr/browse/MA-1159

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

