### PR TITLE
fix(registry): #MA-1168 display incident/forgotten notebook elements from 1D rights

### DIFF
--- a/presences/src/main/resources/public/template/registry/header.html
+++ b/presences/src/main/resources/public/template/registry/header.html
@@ -58,11 +58,11 @@
             <i18n>presences.register.event_type.lateness</i18n>
         </label>
         <label class="chip" ng-class="{selected: vm.params.forgottenNotebook}"
-               data-ng-click="vm.toggleForgottenNotebookFilter()">
+               data-ng-click="vm.toggleForgottenNotebookFilter()" ng-if="hasRight('manageForgottenNotebook')">
             <i18n>presences.register.event_type.forgotten.notebook</i18n>
         </label>
         <label class="chip" ng-class="{selected: vm.isFilterActive(vm.eventType[2])}"
-               data-ng-click="vm.toggleFilter(vm.eventType[2])">
+               data-ng-click="vm.toggleFilter(vm.eventType[2])" ng-if="!hasRight('presences1D')">
             <i18n>incidents.incident</i18n>
         </label>
         <label class="chip" ng-class="{selected: vm.isFilterActive(vm.eventType[3])}"


### PR DESCRIPTION
## Describe your changes

- hide incidents chip in register view if user has presences.1d right
- hide forgotten notebook chip in register view if user has not forgotten_notebook.manage right

## Checklist tests

- set the previously mentioned rights to the user and check if these elements are hidden

## Issue ticket number and link

https://jira.support-ent.fr/browse/MA-1168

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

