### PR TITLE
fix(filter): #MA-1145 fix filter absences

### DIFF
--- a/presences/src/main/resources/public/ts/directives/events-filter-form/events-filter-form.ts
+++ b/presences/src/main/resources/public/ts/directives/events-filter-form/events-filter-form.ts
@@ -329,6 +329,12 @@ class Controller implements ng.IController, IViewModel {
     switchReason(reason: Reason): void {
         if (this.formFilter.notRegularized || this.formFilter.regularized || reason.reason_type_id === REASON_TYPE_ID.LATENESS)
             reason.isSelected = !reason.isSelected;
+
+        if (!this.formFilter.notRegularized && !this.formFilter.regularized && reason.reason_type_id !== REASON_TYPE_ID.LATENESS) {
+            reason.isSelected = !reason.isSelected;
+            this.formFilter.regularized = true;
+            this.formFilter.notRegularized = true;
+        }
         if (this.formFilter.late && reason.id === this.noReason.id && reason.reason_type_id === REASON_TYPE_ID.LATENESS)
             this.formFilter.noReasonsLateness = reason.isSelected;
     }


### PR DESCRIPTION
## Describe your changes
Fixed an issue where the absence reasons filters couldn't be activated if both "Absences non régularisées" and "Absences régularisées" were turned off.

Now, if both of these filters are off and an absence reason filter is toggled on, they will automatically be activated.

## Checklist tests
In the event list, turn off both the "Absences non régularisées" and "Absences régularisées" filters, then try to turn on an absence reason filter.

Verify in the event list if the events correspond with the selected filter.
## Issue ticket number and link
[MA-1145](https://jira.support-ent.fr/browse/MA-1145)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

