### PR TITLE
fix(filter): #MA-1145 fix filter absences

### DIFF
--- a/presences/src/main/resources/public/ts/directives/events-filter-form/events-filter-form.ts
+++ b/presences/src/main/resources/public/ts/directives/events-filter-form/events-filter-form.ts
@@ -335,8 +335,15 @@ class Controller implements ng.IController, IViewModel {
             this.formFilter.regularized = true;
             this.formFilter.notRegularized = true;
         }
+
         if (this.formFilter.late && reason.id === this.noReason.id && reason.reason_type_id === REASON_TYPE_ID.LATENESS)
             this.formFilter.noReasonsLateness = reason.isSelected;
+
+        //If all reasons with reason_type_id = absences are unselected then formFilter.regularized get false and formFilter.notRegularized get false
+        if (!this.reasons.some((reason: Reason) => reason.reason_type_id === REASON_TYPE_ID.ABSENCE && reason.isSelected)) {
+            this.formFilter.regularized = false;
+            this.formFilter.notRegularized = false;
+        }
     }
 
     switchAllAbsenceReasons(isAllAbsenceReason?: boolean): void {


### PR DESCRIPTION
## Describe your changes
Fixed an issue from MA-1145. Now, if we deselect an absence reason and no other absence reasons are selected, both "regularized" and "not regularized" filters will be deselected.
## Checklist tests
In "Liste des evenements" open the filter popup, and then try to unselect all absences reasons except one. Now if you unselect the last absence reason it should unselect both regularized and not regularized filters in "Etat de l'absences"
## Issue ticket number and link
[MA-1145](https://jira.support-ent.fr/browse/MA-1145)
## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

