### PR TITLE
fix(init-popup): #MA-1189 change label for init button on second initialization

### DIFF
--- a/presences/src/main/resources/i18n/en.json
+++ b/presences/src/main/resources/i18n/en.json
@@ -546,6 +546,7 @@
   "presences.init.1d.form.holidays.detected.zone.C": "Zone C",
   "presences.init.1d.form.holidays.other.system": "Other system",
   "presences.init.1d.form.init": "Initialize",
+  "presences.init.1d.form.init.2": "Reinitialize",
   "presences.init.1d.form.confirm": "The initialization has been successfully launched. You will be notified in the notification feed when it is completed.",
   "presences.init.check.teachers.header": "Verification - Teacher Assignment",
   "presences.init.check.teachers.warning": "Warning! There are teachers who are not assigned to any class. By starting the initialization, classes for these teachers will not be generated.",

--- a/presences/src/main/resources/i18n/fr.json
+++ b/presences/src/main/resources/i18n/fr.json
@@ -648,6 +648,7 @@
   "presences.init.1d.form.holidays.detected.zone.C": "Zone C",
   "presences.init.1d.form.holidays.other.system": "Autre système",
   "presences.init.1d.form.init": "Initialiser",
+  "presences.init.1d.form.init.2": "Réinitialiser",
   "presences.init.1d.form.confirm": "L'initialisation a bien été lancée. Vous serez informé sur le fil de nouveautés lorsqu'elle sera terminée.",
   "presences.init.check.teachers.header": "Vérification - Rattachement des enseignants",
   "presences.init.check.teachers.warning": "Attention ! Il existe des enseignants qui ne sont rattachés à aucune classe. En lançant l'initialisation, les cours pour ces enseignants ne seront pas générés.",

--- a/presences/src/main/resources/public/ts/directives/init-lightbox/init-lightbox.html
+++ b/presences/src/main/resources/public/ts/directives/init-lightbox/init-lightbox.html
@@ -177,7 +177,12 @@
             <div class="twelve cell">
                 <button class="right-magnet" data-ng-click="vm.submitInit()"
                         ng-disabled="!vm.form.isValid()">
-                    <i18n>presences.init.1d.form.init</i18n>
+                    <i18n ng-if="vm.display === null">
+                        presences.init.1d.form.init
+                    </i18n>
+                    <i18n ng-if="vm.display !== null">
+                        presences.init.1d.form.init.2
+                    </i18n>
                 </button>
                 <button class="right-magnet cancel"
                         data-ng-click="vm.closeForm()">


### PR DESCRIPTION
## Describe your changes

- in the initialization popup, change the label of the button to "Reinitialize" when the structure has already been initialized once

## Checklist tests

- reset initialization and check if the button label has changed
- check if on first initialization, the label is still "Initialize"

## Issue ticket number and link

https://jira.support-ent.fr/browse/MA-1189

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

