### PR TITLE
fix(dashboard): #MA-1184 add empty screen for users when module not activated

### DIFF
--- a/presences/src/main/java/fr/openent/presences/controller/InitController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/InitController.java
@@ -7,7 +7,7 @@ import fr.openent.presences.common.massmailing.Massmailing;
 import fr.openent.presences.core.constants.Field;
 import fr.openent.presences.enums.InitTypeEnum;
 import fr.openent.presences.enums.WorkflowActions;
-import fr.openent.presences.security.Manage;
+import fr.openent.presences.security.*;
 import fr.openent.presences.service.InitService;
 import fr.openent.presences.service.impl.DefaultAbsenceService;
 import fr.openent.presences.service.impl.DefaultInitService;
@@ -53,7 +53,7 @@ public class InitController extends ControllerHelper {
 
     @Get("/initialization/structures/:id")
     @SecuredAction(value = "", type = ActionType.RESOURCE)
-    @ResourceFilter(Manage.class)
+    @ResourceFilter(ViewRight.class)
     @ApiDoc("Retrieve structure initialization status")
     public void getInitializationStatus(HttpServerRequest request) {
         String structure = request.getParam("id");

--- a/presences/src/main/resources/public/template/containers/dashboard.html
+++ b/presences/src/main/resources/public/template/containers/dashboard.html
@@ -1,95 +1,108 @@
 <div class="dashboard" ng-controller="DashboardController as vm" ng-style="{width: vm.getSubSize()}">
-    <div class="row presences-title">
-        <div>
-            <img src="/presences/public/img/uni-presence.svg" alt="Présences">
-        </div>
-        <h1 class="horizontal-spacing-twice">
-            <i18n>presences.title</i18n>
-        </h1>
-        <div class="structure">
-            [[structure.name]]
-        </div>
-    </div>
-    <div class="dashboard-search-row">
-        <div class="dashboard-search-row-searchs">
-            <!-- Search to access calendar -->
-            <async-autocomplete workflow="presences.viewCalendar"
-                                ng-disabled="false"
-                                ng-model="vm.filter.search.item"
-                                ng-change="vm.selectItem"
-                                on-search="vm.searchItem"
-                                options="vm.filter.search.items"
-                                placeholder="presences.dashboard.search.placeholder"
-                                search="vm.filter.search.item"></async-autocomplete>
 
-            <!-- Search to access registry -->
-            <async-autocomplete workflow="presences.readRegistry"
-                                class="search-registry"
-                                data-ng-disabled="false"
-                                data-ng-model="vm.groupsSearch.group"
-                                data-ng-change="vm.selectItemToRegistry"
-                                data-on-search="vm.searchItemToRegistry"
-                                data-options="vm.groupsSearch.groups"
-                                data-placeholder="presences.dashboard.search.registry.placeholder"
-                                data-search="vm.groupsSearch.group">
-            </async-autocomplete>
+    <div class="empty-state flex-inline twelve top-spacing-25vh justify-center"
+         ng-if="!vm.hasInitializedStructure() && !vm.hasRight('initPopup') && !vm.hasRight('initSettings1D')">
+        <div class="tick-color red">&nbsp;</div>
+        <div class="empty-title">
+            <i18n>presences.init.state.warning</i18n>
         </div>
+        <div class="tick-color purple">&nbsp;</div>
     </div>
 
-    <!--Date-->
-    <h2 class="current-date" ng-bind="::vm.date"></h2>
+    <div class="dashboard-content" ng-if="vm.hasInitializedStructure() || (vm.hasRight('initPopup') && vm.hasRight('initSettings1D'))">
+        <div class="row presences-title">
+            <div>
+                <img src="/presences/public/img/uni-presence.svg" alt="Présences">
+            </div>
+            <h1 class="horizontal-spacing-twice">
+                <i18n>presences.title</i18n>
+            </h1>
+            <div class="structure">
+                [[structure.name]]
+            </div>
+        </div>
+        <div class="dashboard-search-row">
+            <div class="dashboard-search-row-searchs">
+                <!-- Search to access calendar -->
+                <async-autocomplete workflow="presences.viewCalendar"
+                                    ng-disabled="false"
+                                    ng-model="vm.filter.search.item"
+                                    ng-change="vm.selectItem"
+                                    on-search="vm.searchItem"
+                                    options="vm.filter.search.items"
+                                    placeholder="presences.dashboard.search.placeholder"
+                                    search="vm.filter.search.item"></async-autocomplete>
 
-    <!--COUNTS OF CURRENT PRESENCES IN STRUCTURE-->
-    <div workflow="presences.readAbsentsCounts" class="dashboard-absences-counts">
-        <div class="card">
-            <i18n>presences.absence.number.total</i18n> &#58; <b>[[vm.absencesSummary.nb_absents]]</b>
+                <!-- Search to access registry -->
+                <async-autocomplete workflow="presences.readRegistry"
+                                    class="search-registry"
+                                    data-ng-disabled="false"
+                                    data-ng-model="vm.groupsSearch.group"
+                                    data-ng-change="vm.selectItemToRegistry"
+                                    data-on-search="vm.searchItemToRegistry"
+                                    data-options="vm.groupsSearch.groups"
+                                    data-placeholder="presences.dashboard.search.registry.placeholder"
+                                    data-search="vm.groupsSearch.group">
+                </async-autocomplete>
+            </div>
         </div>
-        <div class="card" ng-if="!hasRight('presences1D')">
-            <i18n>presences.absence.number.day.student</i18n> &#58; <b>[[vm.absencesSummary.nb_day_students]]</b>
+
+        <!--Date-->
+        <h2 class="current-date" ng-bind="::vm.date"></h2>
+
+        <!--COUNTS OF CURRENT PRESENCES IN STRUCTURE-->
+        <div workflow="presences.readAbsentsCounts" class="dashboard-absences-counts">
+            <div class="card">
+                <i18n>presences.absence.number.total</i18n> &#58; <b>[[vm.absencesSummary.nb_absents]]</b>
+            </div>
+            <div class="card" ng-if="!hasRight('presences1D')">
+                <i18n>presences.absence.number.day.student</i18n> &#58; <b>[[vm.absencesSummary.nb_day_students]]</b>
+            </div>
+            <div class="card">
+                <i18n>presences.absence.number.presents</i18n> &#58; <b>[[vm.absencesSummary.nb_presents]]</b>
+            </div>
         </div>
-        <div class="card">
-            <i18n>presences.absence.number.presents</i18n> &#58; <b>[[vm.absencesSummary.nb_presents]]</b>
+
+        <!-- Alerts -->
+        <div ng-include="'/presences/public/template/widgets/alerts.html'" class="vertical-spacing-six"
+             ng-if="::hasRight('widget_alerts')" workflow="presences.widget_alerts"></div>
+
+        <!-- forgotten register -->
+        <div ng-include="'/presences/public/template/widgets/forgotten_registers.html'" class="vertical-spacing-six"
+             ng-if="::hasRight('widget_forgotten_registers')" workflow="presences.widget_forgotten_registers"></div>
+
+        <!-- widget statements absences -->
+        <widget-statements-absences data-workflow="presences.widget_statements"
+                                    data-ng-if="::hasRight('widget_statements')">
+        </widget-statements-absences>
+
+        <!-- widget remarks -->
+        <!--    <div ng-include="'/presences/public/template/widgets/remarks.html'" class="vertical-spacing-six"-->
+        <!--         ng-if="::hasRight('widget_remarks')" workflow="presences.widget_remarks"></div>-->
+
+        <!-- day course as a teacher -->
+        <div ng-include="'/presences/public/template/widgets/day_courses.html'" class="vertical-spacing-six"
+             ng-if="::hasRight('widget_day_courses')"></div>
+
+        <!-- presence area -->
+        <div ng-include="'/presences/public/template/widgets/day_presences.html'" class="vertical-spacing-six"
+             ng-if="::hasRight('widget_day_presences')"></div>
+
+        <!-- Side bar widgets -->
+        <div class="sidebar-widgets">
+            <side-widget name="'presences.widgets.absences'"
+                         ng-if="::hasRight('widget_absences')" workflow="presences.widget_absences">
+                <div ng-include="'/presences/public/template/widgets/absences.html'" class="height-100"></div>
+            </side-widget>
+            <side-widget name="'presences.widgets.register'" course="vm.course"
+                         ng-if="::hasRight('widget_current_course')">
+                <div ng-include="'/presences/public/template/widgets/register.html'" class="height-100"></div>
+            </side-widget>
         </div>
+        <init-lightbox
+                ng-if="vm.hasRight('initPopup') && vm.hasRight('initSettings1D')"
+                display="vm.isInit">
+        </init-lightbox>
     </div>
 
-    <!-- Alerts -->
-    <div ng-include="'/presences/public/template/widgets/alerts.html'" class="vertical-spacing-six"
-         ng-if="::hasRight('widget_alerts')" workflow="presences.widget_alerts"></div>
-
-    <!-- forgotten register -->
-    <div ng-include="'/presences/public/template/widgets/forgotten_registers.html'" class="vertical-spacing-six"
-         ng-if="::hasRight('widget_forgotten_registers')" workflow="presences.widget_forgotten_registers"></div>
-
-    <!-- widget statements absences -->
-    <widget-statements-absences data-workflow="presences.widget_statements"
-                                data-ng-if="::hasRight('widget_statements')">
-    </widget-statements-absences>
-
-    <!-- widget remarks -->
-    <!--    <div ng-include="'/presences/public/template/widgets/remarks.html'" class="vertical-spacing-six"-->
-    <!--         ng-if="::hasRight('widget_remarks')" workflow="presences.widget_remarks"></div>-->
-
-    <!-- day course as a teacher -->
-    <div ng-include="'/presences/public/template/widgets/day_courses.html'" class="vertical-spacing-six"
-         ng-if="::hasRight('widget_day_courses')"></div>
-
-    <!-- presence area -->
-    <div ng-include="'/presences/public/template/widgets/day_presences.html'" class="vertical-spacing-six"
-         ng-if="::hasRight('widget_day_presences')"></div>
-
-    <!-- Side bar widgets -->
-    <div class="sidebar-widgets">
-        <side-widget name="'presences.widgets.absences'"
-                     ng-if="::hasRight('widget_absences')" workflow="presences.widget_absences">
-            <div ng-include="'/presences/public/template/widgets/absences.html'" class="height-100"></div>
-        </side-widget>
-        <side-widget name="'presences.widgets.register'" course="vm.course"
-                     ng-if="::hasRight('widget_current_course')">
-            <div ng-include="'/presences/public/template/widgets/register.html'" class="height-100"></div>
-        </side-widget>
-    </div>
-    <init-lightbox
-            ng-if="vm.hasRight('initPopup') && vm.hasRight('initSettings1D')"
-            display="vm.isInit">
-    </init-lightbox>
 </div>

--- a/presences/src/main/resources/public/ts/controllers/presences.ts
+++ b/presences/src/main/resources/public/ts/controllers/presences.ts
@@ -254,7 +254,7 @@ export const presencesController = ng.controller('PresencesController',
 
             /* on  (watch) */
             $scope.$watch(() => window.structure, () => {
-                if ('structure' in window) {
+                if ('structure' in window && window.structure !== undefined) {
                     startAction();
                 }
             });

--- a/presences/src/main/resources/public/ts/services/initialization.service.ts
+++ b/presences/src/main/resources/public/ts/services/initialization.service.ts
@@ -13,7 +13,7 @@ export interface IInitTeachersResponse {
 
 
 export interface IInitService {
-    getPresencesInitStatus(structureId: string): Promise<IInitStatusResponse>;
+    getPresencesInitStatus(structureId: string): Promise<boolean>;
     getViescoInitStatus(structureId: string): Promise<IInitStatusResponse>;
 
     initPresences(structureId: string, initType: INIT_TYPE): Promise<AxiosResponse>;
@@ -25,9 +25,9 @@ export interface IInitService {
 
 export const initService: IInitService = {
 
-    getPresencesInitStatus: async (structureId: string): Promise<IInitStatusResponse> => {
+    getPresencesInitStatus: async (structureId: string): Promise<boolean> => {
         return http.get(`/presences/initialization/structures/${structureId}`)
-            .then((res: AxiosResponse) => res.data);
+            .then((res: AxiosResponse) => res.data.initialized);
     },
 
     getViescoInitStatus: async (structureId: string): Promise<IInitStatusResponse> => {

--- a/presences/src/main/resources/public/ts/sniplets/presence-form.ts
+++ b/presences/src/main/resources/public/ts/sniplets/presence-form.ts
@@ -335,8 +335,11 @@ export const presenceForm = {
         setHandler: async function () {
             this.$on(SNIPLET_FORM_EVENTS.SET_PARAMS, (event: IAngularEvent, presence: Presence) => vm.openEditPresence(presence));
             this.$watch(() => window.structure, async () => {
-                this.getDisciplines();
-                this.getStructureTimeSlot();
+                if (window.structure !== undefined) {
+                    this.getDisciplines();
+                    this.getStructureTimeSlot();
+                }
+
                 vm.safeApply();
             });
         },

--- a/presences/src/main/resources/public/ts/sniplets/presences-manage.ts
+++ b/presences/src/main/resources/public/ts/sniplets/presences-manage.ts
@@ -47,8 +47,8 @@ function safeApply() {
 }
 
 function fetchInitializationStatus(): void {
-    initService.getPresencesInitStatus(window.model.vieScolaire.structure.id).then((status: IInitStatusResponse) => {
-        if (status.initialized !== undefined) vm.initialized = status.initialized;
+    initService.getPresencesInitStatus(window.model.vieScolaire.structure.id).then((status: boolean) => {
+        if (status !== undefined) vm.initialized = status;
         else vm.initialized = false;
         vm.safeApply();
     })


### PR DESCRIPTION
## Describe your changes

- added empty screen for children/relatives when presences is not activated and/or not initialized
- added empty screen for teachers when presences is not initialized

## Checklist tests

- check if users are loading presences normally when the module is activated and initialized
- check if users are having an empty screen in the dashboard when presences is not active and/or not initialized

## Issue ticket number and link

https://jira.support-ent.fr/browse/MA-1184

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

