### PR TITLE
fix(navigation): #MA-1193 display event menu even w/ asynchronous issues

### DIFF
--- a/presences/src/main/resources/public/ts/sniplets/navigation.ts
+++ b/presences/src/main/resources/public/ts/sniplets/navigation.ts
@@ -4,6 +4,7 @@ import incidentsRights from '@incidents/rights'
 import massmailingRights from '@massmailing/rights';
 import statisticsRights from '@statistics/rights';
 import {PreferencesUtils} from "@common/utils";
+import {IStructure} from "@common/model";
 
 declare let window: any;
 
@@ -36,16 +37,20 @@ export const navigation = {
     controller: {
         init: async function () {
             this.structures = initStructures();
-            let preferenceStructure = await Me.preference(PreferencesUtils.PREFERENCE_KEYS.PRESENCE_STRUCTURE);
-            let preferenceStructureId = preferenceStructure ? preferenceStructure['id'] : null;
-            let structure = this.structures.length > 1 && preferenceStructureId ? this.structures.find((s) => s.id === preferenceStructureId) : this.structures[0];
             this.menu = {
-                structure: structure,
+                structure: null,
                 hovered: '',
                 active: '',
                 timeout: null
             };
+
+            let preferenceStructure: Structure = await Me.preference(PreferencesUtils.PREFERENCE_KEYS.PRESENCE_STRUCTURE);
+            let preferenceStructureId: string = preferenceStructure ? preferenceStructure.id : null;
+            let structure: IStructure = this.structures.length > 1 && preferenceStructureId ?
+                this.structures.find((s: IStructure) => s.id === preferenceStructureId) : this.structures[0];
+            this.menu.structure = structure;
             await this.setStructure(structure);
+
             this.$apply();
         },
         setStructure: async function (structure: Structure) {


### PR DESCRIPTION
## Describe your changes

- allow display of event side sub-menu when structure preference has not finished loading

## Checklist tests

- on a slow computer/connexion, check if the sub-menu is opening at all times

## Issue ticket number and link

https://jira.support-ent.fr/browse/MA-1193

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

