### PR TITLE
fix(events) : #MA-1212 fixed 1D teachers who could see all students events even in restricted mode.

### DIFF
--- a/presences/src/main/java/fr/openent/presences/controller/events/EventController.java
+++ b/presences/src/main/java/fr/openent/presences/controller/events/EventController.java
@@ -93,8 +93,9 @@ public class EventController extends ControllerHelper {
 
 
         UserUtils.getUserInfos(eb, request, userInfos -> {
-            boolean hasRestrictedRight = WorkflowActionsCouple.READ_EVENT.hasOnlyRestrictedRight(userInfos, UserType.TEACHER.equals(userInfos.getType()));
-            String teacherId = hasRestrictedRight ? userInfos.getUserId() : null;
+            boolean hasRestrictedRightRead = WorkflowActionsCouple.READ_EVENT.hasOnlyRestrictedRight(userInfos, UserType.TEACHER.equals(userInfos.getType()));
+            boolean hasRestrictedRightAbsenceManage = WorkflowActionsCouple.MANAGE_ABSENCE_STATEMENTS.hasOnlyRestrictedRight(userInfos, UserType.TEACHER.equals(userInfos.getType()));
+            String teacherId = hasRestrictedRightRead || hasRestrictedRightAbsenceManage ? userInfos.getUserId() : null;
 
             this.groupService.getGroupsAndClassesFromTeacherId(teacherId, structureId)
                     .onFailure(fail -> renderError(request, JsonObject.mapFrom(fail.getMessage())))


### PR DESCRIPTION
## Describe your changes
Fixed 1D teachers who could see all students events even in restricted mode.

## Checklist tests
How its supposed to work : 
NO "presences.manage.absence.statements.restricted" and NO "presences.manage.absence.statements" : no events
"presences.manage.absence.statements.restricted" and NO "presences.manage.absence.statements" : only linked classes events
NO "presences.manage.absence.statements.restricted" and "presences.manage.absence.statements" : all classes
"presences.manage.absence.statements.restricted" and "presences.manage.absence.statements" : all classes

## Issue ticket number and link
[MA-1212](https://jira.support-ent.fr/browse/MA-1212)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

