### PR TITLE
fix(statistics-presences): #ENABLING-764 fix du watcher vite (indicateurs absents et instanciation ES5)

### DIFF
--- a/statistics-presences/src/main/resources/public/index.html
+++ b/statistics-presences/src/main/resources/public/index.html
@@ -13,7 +13,9 @@
 		<script type="text/ng-template" id="empty"></script>
 		<script>
 			var structures = [];
-			var indicators = [];
+			// En prod, la vue Mustache injecte les indicateurs selon la config du module
+			// (StatisticsController#view). En dev on expose les trois indicateurs standards.
+			var indicators = ["Global", "Monthly", "Weekly"];
 		</script>
 	</head>
 

--- a/statistics-presences/src/main/resources/public/ts/indicator/IndicatorFactory.ts
+++ b/statistics-presences/src/main/resources/public/ts/indicator/IndicatorFactory.ts
@@ -3,9 +3,9 @@ import {Indicator} from "./Indicator";
 export class IndicatorFactory {
 
     static create(name: string, ...args: any[]): Indicator {
-        const instance: Indicator = Object.create(window[name].prototype);
-        instance.constructor.apply(instance, args);
-        return instance;
+        // Reflect.construct : compatible avec les classes ES2015 natives servies par Vite,
+        // que l'on ne peut pas instancier via constructor.apply() (ancien pattern ES5/webpack).
+        return Reflect.construct(window[name], args) as Indicator;
     }
 
     static register(clazz: Function) {


### PR DESCRIPTION
## Describe your changes

Le module `statistics-presences` plantait au chargement avec le watcher Vite (`pnpm run dev:statistics-presences`) : `TypeError: Cannot read properties of undefined (reading 'cloneFilterTypes')` dans `main.ts#init`. Deux causes en cascade :

1. **`window.indicators` vide en dev** — en prod, la vue Mustache (`view/statistics-presences.html`) est rendue par le serveur qui injecte la liste des indicateurs selon la config du module (`StatisticsController#view`). Le `index.html` de dev la laissait vide, donc `buildIndicators()` ne créait aucun indicateur et `vm.indicator` restait `undefined`. → le `index.html` de dev expose désormais les trois indicateurs standards `["Global", "Monthly", "Weekly"]`.

2. **Pattern d'instanciation ES5 incompatible Vite** — `IndicatorFactory.create` utilisait `Object.create(...)` + `constructor.apply()`, qui ne fonctionnait que parce que webpack/Babel transpilait les classes en fonctions. Vite (dev comme build) produit des classes ES2015 natives, non invocables sans `new` (`Class constructor Global cannot be invoked without 'new'`). → remplacement par `Reflect.construct`, compatible avec les deux formes.

Aucun impact fonctionnel attendu en prod : `Reflect.construct` est équivalent à `new` sur une classe native comme sur une fonction constructeur, et le `index.html` de dev n'est pas servi en prod (la vue Mustache fait foi).

## Checklist tests

- [ ] Lancer `pnpm run dev:statistics-presences` avec un `.env` valide, ouvrir `http://localhost:4200/statistics-presences` : la page charge sans erreur console.
- [ ] Vérifier que le sélecteur d'indicateurs propose Globales / Mensuelles / Hebdomadaire et que la requête `POST /statistics-presences/structures/:id/indicators/Global?page=0` répond 200.
- [ ] Basculer entre les trois indicateurs et vérifier l'affichage des données.
- [ ] Non-régression build : `pnpm run build` (ou build CI) et vérification du module en recette.

## Issue ticket number and link

Ticket : [ENABLING-764](https://edifice-community.atlassian.net/browse/ENABLING-764)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)

- [x] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)

[ENABLING-764]: https://edifice-community.atlassian.net/browse/ENABLING-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ